### PR TITLE
Constrain MCP rule workflow lifecycle boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,19 @@ This guide is written **for AI coding agents only**. Follow it literally; improv
 - **Architecture**: follow SOLID, DRY, separation of concerns, and YAGNI (build only what you need).
 - **Code Quality**:
     - Use clear naming and reasonable abstractions.
+    - **Meaningful Code Gate**:
+        - **Purpose traceability**: every added line, identifier, literal, YAML anchor, helper, abstraction, and configuration entry must have a traceable purpose.
+          Before keeping AI-generated code, trace it back to one concrete need: production behavior, public contract, regression protection, user-facing diagnostics,
+          security or safety, readability, or removal of real duplication.
+          If the purpose cannot be explained in one specific sentence, remove it.
+        - **Meaningless code definition**: meaningless code is code that does not change or protect behavior, clarify a real contract,
+          reduce real duplication or complexity, improve diagnostics or safety, or make the code easier to read.
+          Code is also meaningless when it exists only for formal symmetry, complete-looking groups, tidy-looking structure, coverage appearance,
+          or possible future flexibility.
+          Do not keep code merely because it was generated, looks tidy, might be useful later, or makes a diff look more complete.
+        - **YAML anchor rule**: do not add YAML anchors unless they are actually reused in the same file and reduce meaningful duplication.
+          A YAML anchor with no aliases, an anticipatory anchor for possible future reuse, or an anchor that makes nearby YAML harder to read is forbidden.
+          Prefer repeating a small YAML block when repetition is clearer than indirection.
     - Do not introduce package-private top-level helper types by default.
       Keep very small, single-owner state or continuation helpers as private nested types, but avoid accumulating multiple nested collaborators inside one class.
       When a helper has cohesive behavior, multiple callers, direct test value, or enough logic to distract from the owner class, split it into a public top-level type with a clear contract and direct tests.
@@ -117,6 +130,24 @@ This guide is written **for AI coding agents only**. Follow it literally; improv
 
 ### Testing Requirements
 - **Test-Driven**: design for testability, ensure unit-test coverage, and keep background unit tests under 60s to avoid job stalls.
+- **Meaningful Unit Tests**:
+    - Meaningless unit tests are tests that do not protect behavior owned by the class under test.
+      A unit test must cover computation, decision-making, validation, transformation, state transition, error handling,
+      protocol or payload contract generation, or another non-trivial behavior owned by the target class.
+      If a method only passes data through, delegates directly, returns a constant, exposes a getter or setter, or wires an object without adding logic,
+      do not add a dedicated unit test for that method unless the pass-through itself is a documented public contract or part of an externally visible protocol boundary.
+    - A unit test is meaningful only if it would fail for a realistic bug that matters to users, callers, protocol clients, or maintainers of the class contract.
+      If a test only proves that implementation structure remains the same, rather than proving behavior is correct, remove it.
+    - Do not add unit tests that only assert constant literal values, enum names, field names, method names, YAML anchor names,
+      or configuration structure created only for internal reuse.
+      Literal-value tests are allowed only when the literal is an external protocol value, documented compatibility contract, SQL keyword, configuration key, YAML key,
+      error code, resource URI, or model-visible schema value, and no broader behavior or contract test already protects it.
+      Prefer protecting such literals through the behavior that emits or consumes them; add a dedicated literal-only test only when no behavior path can cover the contract.
+    - Do not add tests that only verify Java, Lombok, Mockito, YAML parser, collection library, or framework behavior.
+      Do not add tests that duplicate an existing scenario without covering a new branch, input class, edge case, contract, calculation path, or failure mode.
+      Do not add tests that only increase coverage numbers but would not catch a real behavioral regression.
+    - Do not add tests that mirror private implementation details, helper call order, local variable structure,
+      or current refactoring shape unless that interaction is the explicit public contract of the class under test.
 - **Quality Assurance**: run static checks, formatting, and code reviews.
 - **Checkstyle Gate**: do not hand off code with Checkstyle/Spotless failures—run the relevant module check locally and fix before completion.
 - **Formatting Gate**: after code or documentation changes, format only with `./mvnw spotless:apply -Pcheck -T1C`, then check style with `./mvnw checkstyle:check -Pcheck -T1C`; do not use any other formatting method.
@@ -125,7 +156,10 @@ This guide is written **for AI coding agents only**. Follow it literally; improv
 - **Continuous Verification**: rely on automated tests and integration validation.
 - **Test Naming Simplicity**: keep test names concise and scenario-focused (avoid “ReturnsXXX”/overly wordy or AI-like phrasing); describe the scenario directly.
 - **Coverage Discipline**: follow the dedicated coverage & branch checklist before coding when coverage targets are stated.
-- **Dedicated and scoped tests**: each public production method must be covered by dedicated test methods; each test method covers only one scenario and invokes the target public method at most once (repeat only when the same scenario needs extra assertions), and different branches/inputs belong in separate test methods.
+- **Dedicated and scoped tests**: each behavior-owning public production method must be covered by dedicated test methods.
+  Pure pass-through, constant-returning, accessor, or wiring-only methods follow the Meaningful Unit Tests gate instead of forcing dedicated tests.
+  Each test method covers only one scenario and invokes the target public method at most once (repeat only when the same scenario needs extra assertions),
+  and different branches/inputs belong in separate test methods.
 - **No testing through layers**: a unit test must not appear to test the current class under test while its inputs, branch triggers, or assertions encode collaborator implementation rules such as SPI, registry, factory, parser, loader, metadata option, driver option, dialect defaults, exception classification, or message/SQLState parsing.
   Unit tests must distinguish behavior owned by the class under test from behavior owned by collaborators.
   If a collaborator implementation can change while the class under test contract stays unchanged, the current class test must not fail; mock the nearest stable collaborator boundary and cover the collaborator rule in that collaborator's own focused tests.

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleDistSQLPlanningService.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleDistSQLPlanningService.java
@@ -19,12 +19,9 @@ package org.apache.shardingsphere.mcp.feature.encrypt.tool.service;
 
 import org.apache.shardingsphere.mcp.feature.encrypt.tool.model.EncryptWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.workflow.model.RuleArtifact;
-import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowRuleValueUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Encrypt rule DistSQL planning service.
@@ -35,45 +32,30 @@ public final class EncryptRuleDistSQLPlanningService {
      * Plan encrypt rule artifact.
      *
      * @param request workflow request
-     * @param existingRules existing table rule rows
-     * @param databaseType database type
      * @return rule artifacts
      */
-    public List<RuleArtifact> planEncryptRule(final EncryptWorkflowRequest request, final List<Map<String, Object>> existingRules, final String databaseType) {
+    public List<RuleArtifact> planEncryptRule(final EncryptWorkflowRequest request) {
         validateEncryptIdentifiers(request);
-        String prefix = "alter".equalsIgnoreCase(request.getOperationType()) || !existingRules.isEmpty() ? "ALTER ENCRYPT RULE" : "CREATE ENCRYPT RULE";
-        return List.of(new RuleArtifact(request.getOperationType(),
-                createEncryptRuleSql(prefix, request.getTable(), buildEncryptColumnSegments(request, existingRules, databaseType))));
+        return List.of(new RuleArtifact("create", createEncryptRuleSql(request.getTable(), List.of(createTargetEncryptColumnSegment(request)))));
     }
     
     /**
      * Plan encrypt drop artifact.
      *
      * @param request workflow request
-     * @param existingRules existing table rule rows
-     * @param databaseType database type
      * @return rule artifacts
      */
-    public List<RuleArtifact> planEncryptDropRule(final EncryptWorkflowRequest request, final List<Map<String, Object>> existingRules, final String databaseType) {
+    public List<RuleArtifact> planEncryptDropRule(final EncryptWorkflowRequest request) {
         validateEncryptDropIdentifiers(request);
-        List<String> remainingColumnSegments = new LinkedList<>();
-        for (Map<String, Object> each : existingRules) {
-            if (!WorkflowSQLUtils.isSameIdentifier(databaseType, request.getColumn(), WorkflowRuleValueUtils.getRuleValue(each, "logic_column"))) {
-                remainingColumnSegments.add(createExistingEncryptColumnSegment(each));
-            }
-        }
-        if (remainingColumnSegments.isEmpty()) {
-            return List.of(new RuleArtifact("drop", createDropRuleSql(request.getTable())));
-        }
-        return List.of(new RuleArtifact("drop", createEncryptRuleSql("ALTER ENCRYPT RULE", request.getTable(), remainingColumnSegments)));
+        return List.of(new RuleArtifact("drop", createDropRuleSql(request.getTable())));
     }
     
     private String createDropRuleSql(final String tableName) {
         return String.format("DROP ENCRYPT RULE %s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(tableName));
     }
     
-    private String createEncryptRuleSql(final String prefix, final String tableName, final List<String> columnSegments) {
-        return String.format("%s %s (%sCOLUMNS(%s%s%s))", prefix, WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(tableName), System.lineSeparator(), System.lineSeparator(),
+    private String createEncryptRuleSql(final String tableName, final List<String> columnSegments) {
+        return String.format("CREATE ENCRYPT RULE %s (%sCOLUMNS(%s%s%s))", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(tableName), System.lineSeparator(), System.lineSeparator(),
                 String.join(", " + System.lineSeparator(), columnSegments), System.lineSeparator());
     }
     
@@ -94,23 +76,6 @@ public final class EncryptRuleDistSQLPlanningService {
         WorkflowSQLUtils.checkSupportedIdentifier("column", request.getColumn());
     }
     
-    private List<String> buildEncryptColumnSegments(final EncryptWorkflowRequest request, final List<Map<String, Object>> existingRules, final String databaseType) {
-        List<String> result = new LinkedList<>();
-        boolean targetColumnHandled = false;
-        for (Map<String, Object> each : existingRules) {
-            if (WorkflowSQLUtils.isSameIdentifier(databaseType, request.getColumn(), WorkflowRuleValueUtils.getRuleValue(each, "logic_column"))) {
-                result.add(createTargetEncryptColumnSegment(request));
-                targetColumnHandled = true;
-                continue;
-            }
-            result.add(createExistingEncryptColumnSegment(each));
-        }
-        if (!targetColumnHandled) {
-            result.add(createTargetEncryptColumnSegment(request));
-        }
-        return result;
-    }
-    
     private String createTargetEncryptColumnSegment(final EncryptWorkflowRequest request) {
         StringBuilder result = new StringBuilder();
         result.append(String.format("(NAME=%s, CIPHER=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getColumn()),
@@ -129,39 +94,6 @@ public final class EncryptRuleDistSQLPlanningService {
         if (Boolean.TRUE.equals(request.getOptions().getRequiresLikeQuery())) {
             result.append(String.format(", LIKE_QUERY_ALGORITHM(%s)",
                     WorkflowSQLUtils.createAlgorithmFragment(request.getOptions().getLikeQueryAlgorithmType(), request.getOptions().getLikeQueryAlgorithmProperties())));
-        }
-        result.append(")");
-        return result.toString();
-    }
-    
-    private String createExistingEncryptColumnSegment(final Map<String, Object> rule) {
-        String logicColumn = WorkflowRuleValueUtils.getRuleValue(rule, "logic_column");
-        String cipherColumn = WorkflowRuleValueUtils.getRuleValue(rule, "cipher_column");
-        String assistedQueryColumn = WorkflowRuleValueUtils.getRuleValue(rule, "assisted_query_column");
-        String likeQueryColumn = WorkflowRuleValueUtils.getRuleValue(rule, "like_query_column");
-        WorkflowSQLUtils.checkSupportedIdentifier("column", logicColumn);
-        WorkflowSQLUtils.checkSupportedIdentifier("cipher_column", cipherColumn);
-        WorkflowSQLUtils.checkSupportedIdentifier("assisted_query_column", assistedQueryColumn);
-        WorkflowSQLUtils.checkSupportedIdentifier("like_query_column", likeQueryColumn);
-        StringBuilder result = new StringBuilder(String.format("(NAME=%s, CIPHER=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(logicColumn),
-                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(cipherColumn)));
-        if (!assistedQueryColumn.isEmpty()) {
-            result.append(String.format(", ASSISTED_QUERY_COLUMN=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(assistedQueryColumn)));
-        }
-        if (!likeQueryColumn.isEmpty()) {
-            result.append(String.format(", LIKE_QUERY_COLUMN=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(likeQueryColumn)));
-        }
-        result.append(String.format(", ENCRYPT_ALGORITHM(%s)",
-                WorkflowSQLUtils.createAlgorithmFragment(WorkflowRuleValueUtils.getRuleValue(rule, "encryptor_type"), WorkflowSQLUtils.createPropertyMap(rule.get("encryptor_props")))));
-        String assistedQueryType = WorkflowRuleValueUtils.getRuleValue(rule, "assisted_query_type");
-        if (!assistedQueryType.isEmpty()) {
-            result.append(String.format(", ASSISTED_QUERY_ALGORITHM(%s)",
-                    WorkflowSQLUtils.createAlgorithmFragment(assistedQueryType, WorkflowSQLUtils.createPropertyMap(rule.get("assisted_query_props")))));
-        }
-        String likeQueryType = WorkflowRuleValueUtils.getRuleValue(rule, "like_query_type");
-        if (!likeQueryType.isEmpty()) {
-            result.append(String.format(", LIKE_QUERY_ALGORITHM(%s)",
-                    WorkflowSQLUtils.createAlgorithmFragment(likeQueryType, WorkflowSQLUtils.createPropertyMap(rule.get("like_query_props")))));
         }
         result.append(")");
         return result.toString();

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowPlanningService.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowPlanningService.java
@@ -40,15 +40,13 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Consumer;
 
 /**
  * Encrypt workflow planning service.
  */
 public final class EncryptWorkflowPlanningService {
     
-    private static final String OPERATION_ALTER = "alter";
+    private static final List<String> SUPPORTED_OPERATION_TYPES = List.of("create", WorkflowLifecycle.OPERATION_DROP);
     
     private static final List<String> INTERACTION_STEPS = List.of(
             "Confirm database, table, column and target operation",
@@ -99,6 +97,9 @@ public final class EncryptWorkflowPlanningService {
         EncryptWorkflowRequest mergedRequest = prepareSnapshot(result, request);
         ClarifiedIntent clarifiedIntent = result.getClarifiedIntent();
         planningSupport.applyResolvedIntent(mergedRequest, clarifiedIntent);
+        if (!planningSupport.ensureSupportedOperationType(clarifiedIntent, SUPPORTED_OPERATION_TYPES, result)) {
+            return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
+        }
         if (!planningSupport.ensurePlanningContext(metadataQueryFacade, mergedRequest, clarifiedIntent, result)) {
             String currentStep = WorkflowLifecycle.STATUS_FAILED.equals(result.getStatus()) ? WorkflowLifecycle.STEP_FAILED : WorkflowLifecycle.STEP_CLARIFYING;
             return workflowSessionContext.persist(result, currentStep, result.getStatus());
@@ -109,7 +110,10 @@ public final class EncryptWorkflowPlanningService {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
         }
         if (isDropWorkflow(clarifiedIntent)) {
-            planDrop(mergedRequest, existingRules, result, databaseType);
+            if (!ensureSupportedRuleRewrite(mergedRequest, existingRules, result, databaseType)) {
+                return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_CLARIFYING, WorkflowLifecycle.STATUS_CLARIFYING);
+            }
+            planDrop(mergedRequest, existingRules, result);
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_REVIEW, WorkflowLifecycle.STATUS_PLANNED);
         }
         if (!planNonDrop(queryFacade, clarifiedIntent, mergedRequest, existingRules, result, databaseType)) {
@@ -139,11 +143,10 @@ public final class EncryptWorkflowPlanningService {
         return WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(clarifiedIntent.getOperationType());
     }
     
-    private void planDrop(final EncryptWorkflowRequest request, final List<Map<String, Object>> existingRules,
-                          final WorkflowContextSnapshot snapshot, final String databaseType) {
+    private void planDrop(final EncryptWorkflowRequest request, final List<Map<String, Object>> existingRules, final WorkflowContextSnapshot snapshot) {
         addDropLifecycleWarnings(snapshot);
-        snapshot.getRuleArtifacts().addAll(ruleDistSQLPlanningService.planEncryptDropRule(request, existingRules, databaseType));
-        snapshot.setFeatureData(new EncryptWorkflowState(existingRules, createExpectedDropRules(request, existingRules, databaseType)));
+        snapshot.getRuleArtifacts().addAll(ruleDistSQLPlanningService.planEncryptDropRule(request));
+        snapshot.setFeatureData(new EncryptWorkflowState(existingRules, List.of()));
     }
     
     private boolean planNonDrop(final MCPFeatureQueryFacade queryFacade, final ClarifiedIntent clarifiedIntent, final EncryptWorkflowRequest request,
@@ -153,111 +156,40 @@ public final class EncryptWorkflowPlanningService {
                 "Please use an encrypt algorithm that is visible in the current Proxy and satisfies the requirements.")) {
             return false;
         }
-        if (!ensureSupportedAlterExpansion(clarifiedIntent, request, existingRules, snapshot, databaseType)) {
+        if (!ensureSupportedRuleRewrite(request, existingRules, snapshot, databaseType)) {
             return false;
         }
-        applyExistingRuleColumnNames(clarifiedIntent, request, existingRules, databaseType);
         if (!ensureRequiredRuleInputs(request, clarifiedIntent, snapshot)) {
             return false;
         }
-        planEncryptArtifacts(request, existingRules, snapshot, databaseType);
-        snapshot.setFeatureData(new EncryptWorkflowState(existingRules, createExpectedEncryptRules(request, existingRules, databaseType)));
+        planEncryptArtifacts(request, snapshot);
+        snapshot.setFeatureData(new EncryptWorkflowState(existingRules, List.of(createExpectedTargetRule(request))));
         return true;
     }
     
-    private boolean ensureSupportedAlterExpansion(final ClarifiedIntent clarifiedIntent, final EncryptWorkflowRequest request,
-                                                  final List<Map<String, Object>> encryptRules, final WorkflowContextSnapshot snapshot, final String databaseType) {
-        Optional<Map<String, Object>> existingRule = findEncryptRule(encryptRules, request.getColumn(), databaseType);
-        boolean addsLogicColumn = existingRule.isEmpty() && !encryptRules.isEmpty();
-        if (!addsLogicColumn && !OPERATION_ALTER.equalsIgnoreCase(clarifiedIntent.getOperationType())) {
-            return true;
-        }
-        if (!addsLogicColumn && existingRule.isEmpty()) {
-            return true;
-        }
-        boolean addsAssistedQuery = existingRule.isPresent() && Boolean.TRUE.equals(request.getOptions().getRequiresEqualityFilter())
-                && WorkflowRuleValueUtils.getRuleValue(existingRule.get(), "assisted_query_column").isEmpty();
-        boolean addsLikeQuery = existingRule.isPresent() && Boolean.TRUE.equals(request.getOptions().getRequiresLikeQuery())
-                && WorkflowRuleValueUtils.getRuleValue(existingRule.get(), "like_query_column").isEmpty();
-        if (!addsLogicColumn && !addsAssistedQuery && !addsLikeQuery) {
+    private boolean ensureSupportedRuleRewrite(final EncryptWorkflowRequest request, final List<Map<String, Object>> encryptRules,
+                                               final WorkflowContextSnapshot snapshot, final String databaseType) {
+        long remainingRuleCount = encryptRules.stream()
+                .filter(each -> !WorkflowSQLUtils.isSameIdentifier(databaseType, request.getColumn(), WorkflowRuleValueUtils.getRuleValue(each, "logic_column"))).count();
+        if (0L == remainingRuleCount) {
             return true;
         }
         snapshot.getClarifiedIntent().getClarificationMessages().add(
-                "Current Proxy DistSQL cannot automatically expand an existing encrypt table rule with new logic columns, assisted-query bindings, or LIKE-query bindings. "
+                "Current Proxy DistSQL cannot automatically rewrite an existing encrypt table rule with a partial column set. "
                         + "Recreate the rule manually during a maintenance window.");
-        snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.ENCRYPT_ALTER_SCOPE_LIMITED, "error", "planning-artifacts",
-                "Encrypt planning cannot expand an existing table rule with new logic columns, assisted-query bindings, or LIKE-query bindings.",
-                "Manually recreate the encrypt rule with the complete column set after reviewing data impact.", true,
-                Map.of("adds_logic_column", addsLogicColumn, "adds_assisted_query", addsAssistedQuery, "adds_like_query", addsLikeQuery)));
+        snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.ENCRYPT_RULE_REWRITE_LIMITED, "error", "planning-artifacts",
+                "Encrypt planning cannot automatically rewrite an existing table rule while preserving other columns.",
+                "Manually recreate the encrypt rule with the complete column set after reviewing data impact.", true, Map.of("requires_table_rule_rewrite", true)));
         return false;
     }
     
-    private void applyExistingRuleColumnNames(final ClarifiedIntent clarifiedIntent, final EncryptWorkflowRequest request,
-                                              final List<Map<String, Object>> encryptRules, final String databaseType) {
-        if (!OPERATION_ALTER.equalsIgnoreCase(clarifiedIntent.getOperationType())) {
-            return;
-        }
-        Optional<Map<String, Object>> existingRule = findEncryptRule(encryptRules, request.getColumn(), databaseType);
-        if (existingRule.isEmpty()) {
-            return;
-        }
-        applyExistingRuleColumnName(request.getOptions()::setCipherColumnName, request.getOptions().getCipherColumnName(),
-                WorkflowRuleValueUtils.getRuleValue(existingRule.get(), "cipher_column"));
-        if (Boolean.TRUE.equals(request.getOptions().getRequiresEqualityFilter())) {
-            applyExistingRuleColumnName(request.getOptions()::setAssistedQueryColumnName, request.getOptions().getAssistedQueryColumnName(),
-                    WorkflowRuleValueUtils.getRuleValue(existingRule.get(), "assisted_query_column"));
-        }
-        if (Boolean.TRUE.equals(request.getOptions().getRequiresLikeQuery())) {
-            applyExistingRuleColumnName(request.getOptions()::setLikeQueryColumnName, request.getOptions().getLikeQueryColumnName(),
-                    WorkflowRuleValueUtils.getRuleValue(existingRule.get(), "like_query_column"));
-        }
-    }
-    
-    private void applyExistingRuleColumnName(final Consumer<String> target, final String requestedValue, final String existingValue) {
-        if (requestedValue.isEmpty() && !existingValue.isEmpty()) {
-            target.accept(existingValue);
-        }
-    }
-    
-    private void planEncryptArtifacts(final EncryptWorkflowRequest request, final List<Map<String, Object>> encryptRules,
-                                      final WorkflowContextSnapshot snapshot, final String databaseType) {
-        snapshot.getRuleArtifacts().addAll(ruleDistSQLPlanningService.planEncryptRule(request, encryptRules, databaseType));
+    private void planEncryptArtifacts(final EncryptWorkflowRequest request, final WorkflowContextSnapshot snapshot) {
+        snapshot.getRuleArtifacts().addAll(ruleDistSQLPlanningService.planEncryptRule(request));
     }
     
     private void addDropLifecycleWarnings(final WorkflowContextSnapshot snapshot) {
         snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.ENCRYPT_DROP_SCOPE_LIMITED, "warning", "planning-artifacts",
                 "Encrypt drop only removes the rule. MCP will not restore historical plaintext data.", "Review business impact before execution.", true, Map.of()));
-    }
-    
-    private Optional<Map<String, Object>> findEncryptRule(final List<Map<String, Object>> encryptRules, final String columnName, final String databaseType) {
-        return encryptRules.stream().filter(each -> WorkflowSQLUtils.isSameIdentifier(databaseType, columnName, WorkflowRuleValueUtils.getRuleValue(each, "logic_column"))).findFirst();
-    }
-    
-    private List<Map<String, Object>> createExpectedDropRules(final EncryptWorkflowRequest request, final List<Map<String, Object>> existingRules, final String databaseType) {
-        List<Map<String, Object>> result = new LinkedList<>();
-        for (Map<String, Object> each : existingRules) {
-            if (!WorkflowSQLUtils.isSameIdentifier(databaseType, request.getColumn(), WorkflowRuleValueUtils.getRuleValue(each, "logic_column"))) {
-                result.add(new LinkedHashMap<>(each));
-            }
-        }
-        return result;
-    }
-    
-    private List<Map<String, Object>> createExpectedEncryptRules(final EncryptWorkflowRequest request, final List<Map<String, Object>> existingRules, final String databaseType) {
-        List<Map<String, Object>> result = new LinkedList<>();
-        boolean targetRuleHandled = false;
-        for (Map<String, Object> each : existingRules) {
-            if (WorkflowSQLUtils.isSameIdentifier(databaseType, request.getColumn(), WorkflowRuleValueUtils.getRuleValue(each, "logic_column"))) {
-                result.add(createExpectedTargetRule(request));
-                targetRuleHandled = true;
-            } else {
-                result.add(new LinkedHashMap<>(each));
-            }
-        }
-        if (!targetRuleHandled) {
-            result.add(createExpectedTargetRule(request));
-        }
-        return result;
     }
     
     private Map<String, Object> createExpectedTargetRule(final EncryptWorkflowRequest request) {

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowValidationService.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowValidationService.java
@@ -131,7 +131,7 @@ public final class EncryptWorkflowValidationService implements MCPWorkflowRuntim
     
     private boolean isEncryptRuleDistSQL(final String sql) {
         String actualSQL = sql.trim().toUpperCase(Locale.ENGLISH);
-        return actualSQL.startsWith("CREATE ENCRYPT RULE") || actualSQL.startsWith("ALTER ENCRYPT RULE");
+        return actualSQL.startsWith("CREATE ENCRYPT RULE");
     }
     
     private Map<String, Object> createValidationIssue(final String message, final String sql) {
@@ -176,7 +176,7 @@ public final class EncryptWorkflowValidationService implements MCPWorkflowRuntim
         }
         if (actualRule.isEmpty()) {
             validationReport.getMismatches().add(validationSupport.createMismatch(WorkflowIssueCode.RULE_STATE_MISMATCH, "rule", snapshot.getRequest().getColumn(), "",
-                    "Encrypt rule is missing.", "Create or alter the encrypt rule again."));
+                    "Encrypt rule is missing.", "Generate the encrypt rule artifact again and re-run validation."));
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, List.of(), "Encrypt rule is missing.");
         }
         Map<String, Object> actualRuleValue = actualRule.get();

--- a/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-encrypt.yaml
+++ b/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-encrypt.yaml
@@ -33,7 +33,7 @@ resourceTemplates:
   - uriTemplate: shardingsphere://features/encrypt/databases/{database}/rules
     name: encrypt-rules
     title: Encrypt Rules
-    description: "List encrypt table rules for one ShardingSphere logical database. Read this before altering or validating encrypt configuration."
+    description: "List encrypt table rules for one ShardingSphere logical database. Read this before planning or validating encrypt configuration."
     mimeType: application/json
     shardingSphereMetadata:
       uriVariables:
@@ -203,7 +203,6 @@ tools:
           description: "Encrypt rule lifecycle operation requested by the user."
           enum:
             - create
-            - alter
             - drop
         natural_language_intent:
           type: string
@@ -249,13 +248,13 @@ tools:
           description: "LIKE-query algorithm type override used when LIKE predicates must remain usable."
         cipher_column_name:
           type: string
-          description: "Cipher column name to put into CREATE or ALTER ENCRYPT RULE."
+          description: "Cipher column name to put into encrypt rule DistSQL."
         assisted_query_column_name:
           type: string
-          description: "Assisted-query column name to put into CREATE or ALTER ENCRYPT RULE when equality filtering is required."
+          description: "Assisted-query column name to put into encrypt rule DistSQL when equality filtering is required."
         like_query_column_name:
           type: string
-          description: "LIKE-query column name to put into CREATE or ALTER ENCRYPT RULE when LIKE query support is required."
+          description: "LIKE-query column name to put into encrypt rule DistSQL when LIKE query support is required."
         primary_algorithm_properties:
           type: object
           description: "Plugin-defined primary encrypt algorithm properties. Values may be strings or protected placeholder objects with secret_ref and optional label; placeholders require manual execution outside MCP."

--- a/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/prompts/plan-encrypt-rule.md
+++ b/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/prompts/plan-encrypt-rule.md
@@ -19,7 +19,7 @@ Plan a ShardingSphere encrypt rule workflow.
 
 Scope:
 - This prompt plans supported encrypt rule DistSQL only.
-- Do not ask MCP to generate physical DDL, derived-column DDL, index DDL, data migration, backfill, repair, cleansing, plaintext restore, or physical cleanup tasks.
+- Do not ask MCP to generate physical DDL, derived-column DDL, index DDL, physical data-change tasks, plaintext restore, or physical cleanup tasks.
 - Treat cipher, assisted-query, and LIKE-query column names as rule DistSQL inputs.
   Use names explicitly provided by the user or already present in existing encrypt rules; do not invent names from physical table structure.
 

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptDescriptorContractTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptDescriptorContractTest.java
@@ -64,6 +64,12 @@ class EncryptDescriptorContractTest {
         assertTrue(actualDescription.contains("never use placeholder values"));
     }
     
+    @Test
+    void assertPlanToolOperationTypesExposeOnlySupportedLifecycleActions() {
+        Map<?, ?> actualOperationType = MCPToolDescriptorValidationUtils.findToolInputProperty(findToolDescriptor(), "operation_type").orElseThrow();
+        assertThat(actualOperationType.get("enum"), is(List.of("create", "drop")));
+    }
+    
     private MCPToolDescriptor findToolDescriptor() {
         MCPDescriptorCatalog catalog = MCPDescriptorCatalogLoader.load();
         return catalog.getProtocolDescriptors().getToolDescriptors().stream()
@@ -98,7 +104,7 @@ class EncryptDescriptorContractTest {
     
     private boolean isEncryptRuleDistSQL(final String sql) {
         String actualSQL = sql.toUpperCase(Locale.ENGLISH);
-        return actualSQL.contains("CREATE ENCRYPT RULE") || actualSQL.contains("ALTER ENCRYPT RULE");
+        return actualSQL.contains("CREATE ENCRYPT RULE");
     }
     
     private void assertEncryptRuleDistSQL(final String sql) {

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/model/EncryptWorkflowRequestTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/model/EncryptWorkflowRequestTest.java
@@ -53,7 +53,7 @@ class EncryptWorkflowRequestTest {
         previousRequest.getOptions().setAssistedQueryAlgorithmType("MD5");
         previousRequest.getOptions().getAssistedQueryAlgorithmProperties().put("digest-algorithm-name", "SHA-256");
         EncryptWorkflowRequest currentRequest = new EncryptWorkflowRequest();
-        currentRequest.setOperationType("alter");
+        currentRequest.setOperationType("drop");
         currentRequest.getOptions().setRequiresLikeQuery(true);
         currentRequest.getOptions().setLikeQueryAlgorithmType("CHAR_DIGEST_LIKE");
         currentRequest.getPrimaryAlgorithmProperties().put("aes-key-value", "current-key");
@@ -62,7 +62,7 @@ class EncryptWorkflowRequestTest {
         assertThat(actualRequest.getDatabase(), is("logic_db"));
         assertThat(actualRequest.getTable(), is("orders"));
         assertThat(actualRequest.getColumn(), is("phone"));
-        assertThat(actualRequest.getOperationType(), is("alter"));
+        assertThat(actualRequest.getOperationType(), is("drop"));
         assertTrue(actualRequest.getOptions().getRequiresDecrypt());
         assertTrue(actualRequest.getOptions().getRequiresLikeQuery());
         assertThat(actualRequest.getOptions().getAssistedQueryAlgorithmType(), is("MD5"));

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleDistSQLPlanningServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleDistSQLPlanningServiceTest.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.mcp.support.workflow.model.RuleArtifact;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -37,7 +36,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
     @Test
     void assertPlanEncryptRuleWithCreate() {
         EncryptWorkflowRequest request = createRequest("create", true, true);
-        List<RuleArtifact> actual = service.planEncryptRule(request, List.of(), "MySQL");
+        List<RuleArtifact> actual = service.planEncryptRule(request);
         assertThat(actual.size(), is(1));
         assertThat(actual.getFirst().getOperationType(), is("create"));
         assertTrue(actual.getFirst().getSql().startsWith("CREATE ENCRYPT RULE `orders`"));
@@ -48,25 +47,11 @@ class EncryptRuleDistSQLPlanningServiceTest {
     }
     
     @Test
-    void assertPlanEncryptRuleWithExistingRules() {
-        EncryptWorkflowRequest request = createRequest("alter", true, false);
-        List<RuleArtifact> actual = service.planEncryptRule(request, List.of(
-                Map.of("logic_column", "phone", "cipher_column", "old_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old"),
-                Map.of("logic_column", "email", "cipher_column", "email_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old")), "MySQL");
-        assertThat(actual.size(), is(1));
-        assertThat(actual.getFirst().getOperationType(), is("alter"));
-        assertTrue(actual.getFirst().getSql().startsWith("ALTER ENCRYPT RULE `orders`"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=`email`"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=`phone`"));
-        assertTrue(actual.getFirst().getSql().contains("CIPHER=`phone_cipher`"));
-    }
-    
-    @Test
     void assertPlanEncryptRuleEscapesAlgorithmLiterals() {
         EncryptWorkflowRequest request = createRequest("create", false, false);
         request.setAlgorithmType("AES'X");
         request.getPrimaryAlgorithmProperties().put("aes-key-value", "s'1");
-        List<RuleArtifact> actual = service.planEncryptRule(request, List.of(), "MySQL");
+        List<RuleArtifact> actual = service.planEncryptRule(request);
         assertTrue(actual.getFirst().getSql().contains("TYPE(NAME='aes''x', PROPERTIES('aes-key-value'='s''1'))"));
     }
     
@@ -76,7 +61,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
         request.setTable("order detail");
         request.setColumn("Phone Number");
         request.getOptions().setCipherColumnName("Phone Number Cipher");
-        List<RuleArtifact> actual = service.planEncryptRule(request, List.of(), "MySQL");
+        List<RuleArtifact> actual = service.planEncryptRule(request);
         assertTrue(actual.getFirst().getSql().startsWith("CREATE ENCRYPT RULE `order detail`"));
         assertTrue(actual.getFirst().getSql().contains("NAME=`Phone Number`"));
         assertTrue(actual.getFirst().getSql().contains("CIPHER=`Phone Number Cipher`"));
@@ -86,7 +71,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
     void assertPlanEncryptRuleFormatsReservedIdentifiers() {
         EncryptWorkflowRequest request = createRequest("create", false, false);
         request.setTable("key");
-        List<RuleArtifact> actual = service.planEncryptRule(request, List.of(), "MySQL");
+        List<RuleArtifact> actual = service.planEncryptRule(request);
         assertTrue(actual.getFirst().getSql().startsWith("CREATE ENCRYPT RULE `key`"));
         assertTrue(actual.getFirst().getSql().contains("NAME=`phone`"));
     }
@@ -97,7 +82,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
         request.setTable("t_user");
         request.setColumn("name");
         request.getOptions().setCipherColumnName("name_cipher");
-        List<RuleArtifact> actual = service.planEncryptRule(request, List.of(), "MySQL");
+        List<RuleArtifact> actual = service.planEncryptRule(request);
         assertTrue(actual.getFirst().getSql().startsWith("CREATE ENCRYPT RULE `t_user`"));
         assertTrue(actual.getFirst().getSql().contains("NAME=`name`"));
         assertTrue(actual.getFirst().getSql().contains("CIPHER=`name_cipher`"));
@@ -110,7 +95,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
         request.getOptions().setCipherColumnName("cipher");
         request.getOptions().setAssistedQueryColumnName("order");
         request.getOptions().setLikeQueryColumnName("type");
-        List<RuleArtifact> actual = service.planEncryptRule(request, List.of(), "MySQL");
+        List<RuleArtifact> actual = service.planEncryptRule(request);
         assertTrue(actual.getFirst().getSql().contains("CIPHER=`cipher`"));
         assertTrue(actual.getFirst().getSql().contains("ASSISTED_QUERY_COLUMN=`order`"));
         assertTrue(actual.getFirst().getSql().contains("LIKE_QUERY_COLUMN=`type`"));
@@ -120,7 +105,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
     void assertPlanEncryptRuleRejectsLineTerminatorColumn() {
         EncryptWorkflowRequest request = createRequest("create", false, false);
         request.setColumn("phone\ndrop");
-        MCPInvalidRequestException actualException = assertThrows(MCPInvalidRequestException.class, () -> service.planEncryptRule(request, List.of(), "MySQL"));
+        MCPInvalidRequestException actualException = assertThrows(MCPInvalidRequestException.class, () -> service.planEncryptRule(request));
         assertThat(actualException.getMessage(), is("column `phone\ndrop` contains unsupported characters that cannot be rendered as a reviewable SQL identifier."));
     }
     
@@ -128,54 +113,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
     void assertPlanEncryptDropRuleWithoutRemainingColumns() {
         EncryptWorkflowRequest request = createRequest("drop", false, false);
         request.getOptions().setCipherColumnName("");
-        List<RuleArtifact> actual = service.planEncryptDropRule(request, List.of(Map.of("logic_column", "phone", "cipher_column", "phone_cipher")), "MySQL");
-        assertThat(actual.size(), is(1));
-        assertThat(actual.getFirst().getOperationType(), is("drop"));
-        assertThat(actual.getFirst().getSql(), is("DROP ENCRYPT RULE `orders`"));
-    }
-    
-    @Test
-    void assertPlanEncryptDropRuleWithRemainingColumns() {
-        EncryptWorkflowRequest request = createRequest("drop", false, false);
-        request.getOptions().setCipherColumnName("");
-        List<RuleArtifact> actual = service.planEncryptDropRule(request, List.of(
-                Map.of("logic_column", "phone", "cipher_column", "phone_cipher"),
-                Map.of("logic_column", "email", "cipher_column", "email_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old")), "MySQL");
-        assertThat(actual.size(), is(1));
-        assertThat(actual.getFirst().getOperationType(), is("drop"));
-        assertTrue(actual.getFirst().getSql().startsWith("ALTER ENCRYPT RULE `orders`"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=`email`"));
-        assertTrue(actual.getFirst().getSql().contains("CIPHER=`email_cipher`"));
-    }
-    
-    @Test
-    void assertPlanEncryptDropRulePreservesCaseSensitiveSiblingColumn() {
-        EncryptWorkflowRequest request = createRequest("drop", false, false);
-        request.setColumn("\"Phone\"");
-        List<RuleArtifact> actual = service.planEncryptDropRule(request, List.of(
-                Map.of("logic_column", "Phone", "cipher_column", "Phone_cipher"),
-                Map.of("logic_column", "phone", "cipher_column", "phone_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old")), "PostgreSQL");
-        assertThat(actual.size(), is(1));
-        assertTrue(actual.getFirst().getSql().startsWith("ALTER ENCRYPT RULE `orders`"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=`phone`"));
-        assertTrue(actual.getFirst().getSql().contains("CIPHER=`phone_cipher`"));
-    }
-    
-    @Test
-    void assertPlanEncryptDropRuleMatchesPostgreSQLUnquotedColumn() {
-        EncryptWorkflowRequest request = createRequest("drop", false, false);
-        request.setColumn("Phone");
-        List<RuleArtifact> actual = service.planEncryptDropRule(request, List.of(Map.of("logic_column", "phone", "cipher_column", "phone_cipher")), "PostgreSQL");
-        assertThat(actual.size(), is(1));
-        assertThat(actual.getFirst().getOperationType(), is("drop"));
-        assertThat(actual.getFirst().getSql(), is("DROP ENCRYPT RULE `orders`"));
-    }
-    
-    @Test
-    void assertPlanEncryptDropRuleMatchesCaseInsensitiveColumn() {
-        EncryptWorkflowRequest request = createRequest("drop", false, false);
-        request.setColumn("Phone");
-        List<RuleArtifact> actual = service.planEncryptDropRule(request, List.of(Map.of("logic_column", "phone", "cipher_column", "phone_cipher")), "MySQL");
+        List<RuleArtifact> actual = service.planEncryptDropRule(request);
         assertThat(actual.size(), is(1));
         assertThat(actual.getFirst().getOperationType(), is("drop"));
         assertThat(actual.getFirst().getSql(), is("DROP ENCRYPT RULE `orders`"));

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowIntentResolverTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowIntentResolverTest.java
@@ -33,13 +33,13 @@ class EncryptWorkflowIntentResolverTest {
     @Test
     void assertResolveUsesExplicitArgumentsWithoutInference() {
         EncryptWorkflowRequest request = new EncryptWorkflowRequest();
-        request.setOperationType("alter");
+        request.setOperationType("create");
         request.setFieldSemantics("email");
         request.getOptions().setRequiresDecrypt(true);
         request.getOptions().setRequiresEqualityFilter(false);
         request.getOptions().setRequiresLikeQuery(false);
         ClarifiedIntent actual = new EncryptWorkflowIntentResolver().resolve(request);
-        assertThat(actual.getOperationType(), is("alter"));
+        assertThat(actual.getOperationType(), is("create"));
         assertThat(actual.getFieldSemantics(), is("email"));
         assertThat(actual.getInferredValues(), is(Map.of()));
         assertThat(actual.getUnresolvedFields(), is(List.of()));

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowPlanningServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowPlanningServiceTest.java
@@ -29,8 +29,10 @@ import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmCandidate;
 import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyRequirement;
 import org.apache.shardingsphere.mcp.support.workflow.model.RuleArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowPlanPayloadBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -39,12 +41,14 @@ import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -104,7 +108,7 @@ class EncryptWorkflowPlanningServiceTest {
         EncryptRuleInspectionService ruleInspectionService = mock(EncryptRuleInspectionService.class);
         when(ruleInspectionService.queryEncryptRules(any(), any(), any())).thenReturn(List.of(Map.of("logic_column", "phone")));
         EncryptRuleDistSQLPlanningService ruleDistSQLPlanningService = mock(EncryptRuleDistSQLPlanningService.class);
-        when(ruleDistSQLPlanningService.planEncryptDropRule(any(), any(), any())).thenReturn(List.of(new RuleArtifact("drop", "DROP ENCRYPT RULE `orders`")));
+        when(ruleDistSQLPlanningService.planEncryptDropRule(any())).thenReturn(List.of(new RuleArtifact("drop", "DROP ENCRYPT RULE `orders`")));
         WorkflowContextSnapshot actual = createService(ruleInspectionService, mock(EncryptAlgorithmRecommendationService.class),
                 mock(EncryptAlgorithmPropertyTemplateService.class), ruleDistSQLPlanningService)
                 .plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", createRequest("drop"));
@@ -131,6 +135,9 @@ class EncryptWorkflowPlanningServiceTest {
         assertThat(actual.getClarifiedIntent().getOperationType(), is(expectedOperationType));
         assertThat(actual.getClarifiedIntent().getFieldSemantics(), is(expectedFieldSemantics));
         assertThat(actual.getStatus(), is(expectedStatus));
+        if ("failed".equals(expectedStatus)) {
+            assertRuleDistSQLOnlyPayloadClearsOperationType(actual);
+        }
     }
     
     @Test
@@ -230,41 +237,34 @@ class EncryptWorkflowPlanningServiceTest {
         WorkflowContextSnapshot actual = createService(ruleInspectionService, createPrimaryCandidateRecommendation(), createEmptyPropertyTemplateService(), new EncryptRuleDistSQLPlanningService())
                 .plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", request);
         assertThat(actual.getStatus(), is("clarifying"));
-        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.ENCRYPT_ALTER_SCOPE_LIMITED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.ENCRYPT_RULE_REWRITE_LIMITED));
         assertTrue(actual.getRuleArtifacts().isEmpty());
     }
     
     @Test
-    void assertPlanRejectsAddingAssistedQueryBindingToExistingColumn() throws ReflectiveOperationException {
+    void assertPlanRejectsDroppingColumnFromExistingTableRule() throws ReflectiveOperationException {
         EncryptRuleInspectionService ruleInspectionService = mock(EncryptRuleInspectionService.class);
         when(ruleInspectionService.queryEncryptRules(any(), any(), any())).thenReturn(List.of(
-                Map.of("logic_column", "phone", "cipher_column", "phone_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old")));
-        EncryptWorkflowRequest request = createRequest("alter");
-        request.getOptions().setRequiresEqualityFilter(true);
-        request.getOptions().setAssistedQueryColumnName("phone_assisted");
-        request.getOptions().setAssistedQueryAlgorithmType("MD5");
-        WorkflowContextSnapshot actual = createService(ruleInspectionService, createPrimaryCandidateRecommendation(), createEmptyPropertyTemplateService(), new EncryptRuleDistSQLPlanningService())
-                .plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", request);
+                Map.of("logic_column", "phone", "cipher_column", "phone_cipher"),
+                Map.of("logic_column", "email", "cipher_column", "email_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old")));
+        WorkflowContextSnapshot actual = createService(ruleInspectionService, mock(EncryptAlgorithmRecommendationService.class),
+                mock(EncryptAlgorithmPropertyTemplateService.class), new EncryptRuleDistSQLPlanningService())
+                .plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", createRequest("drop"));
         assertThat(actual.getStatus(), is("clarifying"));
-        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.ENCRYPT_ALTER_SCOPE_LIMITED));
-        assertTrue((Boolean) actual.getIssues().getFirst().getDetails().get("adds_assisted_query"));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.ENCRYPT_RULE_REWRITE_LIMITED));
         assertTrue(actual.getRuleArtifacts().isEmpty());
     }
     
     @Test
-    void assertPlanRejectsAddingLikeQueryBindingToExistingColumn() throws ReflectiveOperationException {
-        EncryptRuleInspectionService ruleInspectionService = mock(EncryptRuleInspectionService.class);
-        when(ruleInspectionService.queryEncryptRules(any(), any(), any())).thenReturn(List.of(
-                Map.of("logic_column", "phone", "cipher_column", "phone_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old")));
-        EncryptWorkflowRequest request = createRequest("alter");
-        request.getOptions().setRequiresLikeQuery(true);
-        request.getOptions().setLikeQueryColumnName("phone_like");
-        request.getOptions().setLikeQueryAlgorithmType("FPE");
-        WorkflowContextSnapshot actual = createService(ruleInspectionService, createPrimaryCandidateRecommendation(), createEmptyPropertyTemplateService(), new EncryptRuleDistSQLPlanningService())
+    void assertPlanRejectsUnsupportedOperationType() throws ReflectiveOperationException {
+        EncryptWorkflowRequest request = createRequest("replace");
+        WorkflowContextSnapshot actual = createService(mock(EncryptRuleInspectionService.class), mock(EncryptAlgorithmRecommendationService.class),
+                mock(EncryptAlgorithmPropertyTemplateService.class), mock(EncryptRuleDistSQLPlanningService.class))
                 .plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", request);
-        assertThat(actual.getStatus(), is("clarifying"));
-        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.ENCRYPT_ALTER_SCOPE_LIMITED));
-        assertTrue((Boolean) actual.getIssues().getFirst().getDetails().get("adds_like_query"));
+        assertThat(actual.getStatus(), is("failed"));
+        assertThat(actual.getClarifiedIntent().getOperationType(), is(""));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
+        assertRuleDistSQLOnlyPayloadDoesNotExpose(actual, "replace");
         assertTrue(actual.getRuleArtifacts().isEmpty());
     }
     
@@ -363,10 +363,23 @@ class EncryptWorkflowPlanningServiceTest {
         Plugins.getMemberAccessor().set(field, target, value);
     }
     
+    private void assertRuleDistSQLOnlyPayloadDoesNotExpose(final WorkflowContextSnapshot snapshot, final String term) {
+        Map<String, Object> actualPayload = WorkflowPlanPayloadBuilder.buildRuleDistSQLOnly(snapshot, snapshot.getRequest());
+        assertFalse(String.valueOf(actualPayload).toLowerCase(Locale.ENGLISH).contains(term));
+    }
+    
+    private void assertRuleDistSQLOnlyPayloadClearsOperationType(final WorkflowContextSnapshot snapshot) {
+        Map<String, Object> actualPayload = WorkflowPlanPayloadBuilder.buildRuleDistSQLOnly(snapshot, snapshot.getRequest());
+        Map<?, ?> actualIntentInference = (Map<?, ?>) actualPayload.get("intent_inference");
+        assertThat(actualIntentInference.get(WorkflowFieldNames.OPERATION_TYPE), is(""));
+        assertFalse(((Map<?, ?>) actualIntentInference.get("inferred_values")).containsKey(WorkflowFieldNames.OPERATION_TYPE));
+        assertFalse(((Map<?, ?>) actualPayload.get("argument_provenance")).containsKey(WorkflowFieldNames.OPERATION_TYPE));
+    }
+    
     private static Stream<Arguments> assertPlanWithNaturalLanguageInferenceArguments() {
         return Stream.of(
                 Arguments.of("create from default verb", "encrypt phone column", false, "create", "phone", "planned"),
-                Arguments.of("alter from english verb", "update phone number encrypt rule", true, "alter", "phone", "planned"),
+                Arguments.of("unsupported update verb", "update phone number encrypt rule", true, "", "phone", "failed"),
                 Arguments.of("drop from english verb", "delete phone number encrypt rule", true, "drop", "phone", "planned"));
     }
 }

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowPlanningService.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowPlanningService.java
@@ -44,6 +44,8 @@ import java.util.Map;
  */
 public final class MaskWorkflowPlanningService {
     
+    private static final List<String> SUPPORTED_OPERATION_TYPES = List.of("create", WorkflowLifecycle.OPERATION_DROP);
+    
     private static final List<String> INTERACTION_STEPS = List.of(
             "Confirm database, table, column and target lifecycle",
             "Inspect mask algorithm plugins and DistSQL-visible rules",
@@ -93,6 +95,9 @@ public final class MaskWorkflowPlanningService {
         WorkflowRequest mergedRequest = prepareSnapshot(result, request);
         ClarifiedIntent clarifiedIntent = result.getClarifiedIntent();
         planningSupport.applyResolvedIntent(mergedRequest, clarifiedIntent);
+        if (!planningSupport.ensureSupportedOperationType(clarifiedIntent, SUPPORTED_OPERATION_TYPES, result)) {
+            return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
+        }
         if (!planningSupport.ensurePlanningContext(metadataQueryFacade, mergedRequest, clarifiedIntent, result)) {
             String currentStep = WorkflowLifecycle.STATUS_FAILED.equals(result.getStatus()) ? WorkflowLifecycle.STEP_FAILED : WorkflowLifecycle.STEP_CLARIFYING;
             return workflowSessionContext.persist(result, currentStep, result.getStatus());
@@ -143,8 +148,8 @@ public final class MaskWorkflowPlanningService {
                                                     final List<Map<String, Object>> maskRules, final WorkflowContextSnapshot snapshot) {
         snapshot.getClarifiedIntent().getClarificationMessages().add(
                 "Current Proxy DistSQL cannot automatically mutate an existing mask table rule. Recreate the mask rule manually with the complete column set during a maintenance window.");
-        snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.MASK_ALTER_SCOPE_LIMITED, "error", "planning-artifacts",
-                "Mask planning cannot automatically alter an existing table rule or shrink it while preserving remaining columns in V1.",
+        snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.MASK_RULE_REWRITE_LIMITED, "error", "planning-artifacts",
+                "Mask planning cannot automatically rewrite an existing table rule or shrink it while preserving remaining columns.",
                 "Manually recreate the mask rule with the complete column set after reviewing data impact.", true,
                 Map.of("operation_type", clarifiedIntent.getOperationType(), "target_column", request.getColumn(), "existing_columns", createExistingRuleColumns(maskRules))));
         return false;

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationService.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationService.java
@@ -106,7 +106,7 @@ public final class MaskWorkflowValidationService implements MCPWorkflowRuntimeHa
     
     private boolean isMaskRuleDistSQL(final String sql) {
         String actualSQL = sql.trim().toUpperCase(Locale.ENGLISH);
-        return actualSQL.startsWith("CREATE MASK RULE") || actualSQL.startsWith("ALTER MASK RULE");
+        return actualSQL.startsWith("CREATE MASK RULE");
     }
     
     private Map<String, Object> createValidationIssue(final String message, final String sql) {
@@ -143,7 +143,7 @@ public final class MaskWorkflowValidationService implements MCPWorkflowRuntimeHa
         }
         if (actualRule.isEmpty()) {
             validationReport.getMismatches().add(validationSupport.createMismatch(WorkflowIssueCode.RULE_STATE_MISMATCH, "rule", snapshot.getRequest().getColumn(), "",
-                    "Mask rule is missing.", "Create or alter the mask rule again."));
+                    "Mask rule is missing.", "Generate the mask rule artifact again and re-run validation."));
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, List.of(), "Mask rule is missing.");
         }
         Map<String, Object> actualRuleValue = actualRule.get();

--- a/mcp/features/mask/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-mask.yaml
+++ b/mcp/features/mask/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-mask.yaml
@@ -33,7 +33,7 @@ resourceTemplates:
   - uriTemplate: shardingsphere://features/mask/databases/{database}/rules
     name: mask-rules
     title: Mask Rules
-    description: "List mask table rules for one ShardingSphere logical database. Read this before altering or validating mask configuration."
+    description: "List mask table rules for one ShardingSphere logical database. Read this before planning or validating mask configuration."
     mimeType: application/json
     shardingSphereMetadata:
       uriVariables:
@@ -193,7 +193,6 @@ tools:
           description: "Mask rule lifecycle operation requested by the user."
           enum:
             - create
-            - alter
             - drop
         natural_language_intent:
           type: string

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/MaskDescriptorContractTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/MaskDescriptorContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.mask;
+
+import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalog;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogLoader;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidationUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MaskDescriptorContractTest {
+    
+    @Test
+    void assertPlanToolOperationTypesExposeOnlySupportedLifecycleActions() {
+        Map<?, ?> actualOperationType = MCPToolDescriptorValidationUtils.findToolInputProperty(findToolDescriptor(), "operation_type").orElseThrow();
+        assertThat(actualOperationType.get("enum"), is(List.of("create", "drop")));
+    }
+    
+    private MCPToolDescriptor findToolDescriptor() {
+        MCPDescriptorCatalog catalog = MCPDescriptorCatalogLoader.load();
+        return catalog.getProtocolDescriptors().getToolDescriptors().stream()
+                .filter(each -> MaskFeatureDefinition.PLAN_TOOL_NAME.equals(each.getName())).findFirst().orElseThrow();
+    }
+}

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowPlanningServiceTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowPlanningServiceTest.java
@@ -29,9 +29,11 @@ import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmCandidate;
 import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyRequirement;
 import org.apache.shardingsphere.mcp.support.workflow.model.RuleArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowPlanPayloadBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -40,12 +42,14 @@ import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -114,21 +118,20 @@ class MaskWorkflowPlanningServiceTest {
         request.getPrimaryAlgorithmProperties().put("from-x", "1");
         WorkflowContextSnapshot actual = service.plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", request);
         assertThat(actual.getStatus(), is("clarifying"));
-        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.MASK_ALTER_SCOPE_LIMITED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.MASK_RULE_REWRITE_LIMITED));
         assertThat(actual.getRuleArtifacts().size(), is(0));
     }
     
     @Test
-    void assertPlanRejectsAlterWhenExistingColumnsMustBePreserved() {
-        MaskRuleInspectionService ruleInspectionService = mock(MaskRuleInspectionService.class);
-        when(ruleInspectionService.queryMaskRules(any(), any(), any())).thenReturn(List.of(Map.of("column", "phone", "algorithm_type", "MD5"), Map.of("column", "email", "algorithm_type", "MD5")));
-        MaskWorkflowPlanningService service = createService(ruleInspectionService, createPrimaryCandidateRecommendation(), createEmptyPropertyTemplateService(),
-                new MaskRuleDistSQLPlanningService());
-        WorkflowRequest request = createRequest("alter");
-        request.getPrimaryAlgorithmProperties().put("from-x", "1");
-        WorkflowContextSnapshot actual = service.plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", request);
-        assertThat(actual.getStatus(), is("clarifying"));
-        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.MASK_ALTER_SCOPE_LIMITED));
+    void assertPlanRejectsUnsupportedOperationType() {
+        WorkflowRequest request = createRequest("replace");
+        WorkflowContextSnapshot actual = createService(mock(MaskRuleInspectionService.class), mock(MaskAlgorithmRecommendationService.class),
+                mock(MaskAlgorithmPropertyTemplateService.class), mock(MaskRuleDistSQLPlanningService.class))
+                .plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", request);
+        assertThat(actual.getStatus(), is("failed"));
+        assertThat(actual.getClarifiedIntent().getOperationType(), is(""));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
+        assertRuleDistSQLOnlyPayloadDoesNotExpose(actual, "replace");
         assertTrue(actual.getRuleArtifacts().isEmpty());
     }
     
@@ -155,7 +158,7 @@ class MaskWorkflowPlanningServiceTest {
                 mock(MaskAlgorithmPropertyTemplateService.class), mock(MaskRuleDistSQLPlanningService.class))
                 .plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), queryFacade, "session-1", createRequest("drop"));
         assertThat(actual.getStatus(), is("clarifying"));
-        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.MASK_ALTER_SCOPE_LIMITED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.MASK_RULE_REWRITE_LIMITED));
         assertThat(actual.getRuleArtifacts().size(), is(0));
     }
     
@@ -173,6 +176,9 @@ class MaskWorkflowPlanningServiceTest {
         assertThat(actual.getClarifiedIntent().getOperationType(), is(expectedOperationType));
         assertThat(actual.getClarifiedIntent().getFieldSemantics(), is(expectedFieldSemantics));
         assertThat(actual.getStatus(), is(expectedStatus));
+        if ("failed".equals(expectedStatus)) {
+            assertRuleDistSQLOnlyPayloadClearsOperationType(actual);
+        }
     }
     
     @Test
@@ -291,10 +297,23 @@ class MaskWorkflowPlanningServiceTest {
         Plugins.getMemberAccessor().set(field, target, value);
     }
     
+    private void assertRuleDistSQLOnlyPayloadDoesNotExpose(final WorkflowContextSnapshot snapshot, final String term) {
+        Map<String, Object> actualPayload = WorkflowPlanPayloadBuilder.buildRuleDistSQLOnly(snapshot, snapshot.getRequest());
+        assertFalse(String.valueOf(actualPayload).toLowerCase(Locale.ENGLISH).contains(term));
+    }
+    
+    private void assertRuleDistSQLOnlyPayloadClearsOperationType(final WorkflowContextSnapshot snapshot) {
+        Map<String, Object> actualPayload = WorkflowPlanPayloadBuilder.buildRuleDistSQLOnly(snapshot, snapshot.getRequest());
+        Map<?, ?> actualIntentInference = (Map<?, ?>) actualPayload.get("intent_inference");
+        assertThat(actualIntentInference.get(WorkflowFieldNames.OPERATION_TYPE), is(""));
+        assertFalse(((Map<?, ?>) actualIntentInference.get("inferred_values")).containsKey(WorkflowFieldNames.OPERATION_TYPE));
+        assertFalse(((Map<?, ?>) actualPayload.get("argument_provenance")).containsKey(WorkflowFieldNames.OPERATION_TYPE));
+    }
+    
     private static Stream<Arguments> assertPlanWithNaturalLanguageInferenceArguments() {
         return Stream.of(
                 Arguments.of("create from default verb", "mask phone column", false, "create", "phone", "planned"),
-                Arguments.of("alter from english verb", "update phone number mask rule", true, "alter", "phone", "clarifying"),
+                Arguments.of("unsupported update verb", "update phone number mask rule", true, "", "phone", "failed"),
                 Arguments.of("drop from english verb", "delete phone number mask rule", true, "drop", "phone", "planned"));
     }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDistSQLPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDistSQLPlanningService.java
@@ -44,9 +44,7 @@ public final class ShardingDistSQLPlanningService {
         if (WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(operationType)) {
             return new RuleArtifact("drop", String.format("DROP SHARDING TABLE RULE %s", format(request.getTable())));
         }
-        String command = "alter".equalsIgnoreCase(operationType) ? "ALTER" : "CREATE";
-        return new RuleArtifact(command.toLowerCase(Locale.ENGLISH), String.format("%s SHARDING TABLE RULE %s(%s)",
-                command, format(request.getTable()), createTableRuleBody(request)));
+        return new RuleArtifact("create", String.format("CREATE SHARDING TABLE RULE %s(%s)", format(request.getTable()), createTableRuleBody(request)));
     }
     
     /**
@@ -60,9 +58,7 @@ public final class ShardingDistSQLPlanningService {
         if (WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(operationType)) {
             return new RuleArtifact("drop", String.format("DROP SHARDING TABLE REFERENCE RULE %s", format(request.getRuleName())));
         }
-        String command = "alter".equalsIgnoreCase(operationType) ? "ALTER" : "CREATE";
-        return new RuleArtifact(command.toLowerCase(Locale.ENGLISH), String.format("%s SHARDING TABLE REFERENCE RULE %s(%s)",
-                command, format(request.getRuleName()), joinIdentifiers(request.getReferenceTables())));
+        return new RuleArtifact("create", String.format("CREATE SHARDING TABLE REFERENCE RULE %s(%s)", format(request.getRuleName()), joinIdentifiers(request.getReferenceTables())));
     }
     
     /**
@@ -76,9 +72,8 @@ public final class ShardingDistSQLPlanningService {
         if (WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(operationType)) {
             return new RuleArtifact("drop", String.format("DROP DEFAULT SHARDING %s STRATEGY", request.getDefaultStrategyType().toUpperCase(Locale.ENGLISH)));
         }
-        String command = "alter".equalsIgnoreCase(operationType) ? "ALTER" : "CREATE";
-        return new RuleArtifact(command.toLowerCase(Locale.ENGLISH), String.format("%s DEFAULT SHARDING %s STRATEGY (%s)",
-                command, request.getDefaultStrategyType().toUpperCase(Locale.ENGLISH), createShardingStrategy(request)));
+        return new RuleArtifact("create", String.format("CREATE DEFAULT SHARDING %s STRATEGY (%s)",
+                request.getDefaultStrategyType().toUpperCase(Locale.ENGLISH), createShardingStrategy(request)));
     }
     
     /**
@@ -92,9 +87,7 @@ public final class ShardingDistSQLPlanningService {
         if (WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(operationType)) {
             return new RuleArtifact("drop", String.format("DROP SHARDING KEY GENERATOR %s", format(request.getKeyGeneratorName())));
         }
-        String command = "alter".equalsIgnoreCase(operationType) ? "ALTER" : "CREATE";
-        return new RuleArtifact(command.toLowerCase(Locale.ENGLISH), String.format("%s SHARDING KEY GENERATOR %s(%s)",
-                command, format(request.getKeyGeneratorName()), createKeyGeneratorFragment(request)));
+        return new RuleArtifact("create", String.format("CREATE SHARDING KEY GENERATOR %s(%s)", format(request.getKeyGeneratorName()), createKeyGeneratorFragment(request)));
     }
     
     /**
@@ -108,9 +101,8 @@ public final class ShardingDistSQLPlanningService {
         if (WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(operationType)) {
             return new RuleArtifact("drop", String.format("DROP SHARDING KEY GENERATE STRATEGY %s", format(request.getKeyGenerateStrategyName())));
         }
-        String command = "alter".equalsIgnoreCase(operationType) ? "ALTER" : "CREATE";
-        return new RuleArtifact(command.toLowerCase(Locale.ENGLISH), String.format("%s SHARDING KEY GENERATE STRATEGY %s(%s)",
-                command, format(request.getKeyGenerateStrategyName()), createKeyGenerateStrategyBody(request)));
+        return new RuleArtifact("create", String.format("CREATE SHARDING KEY GENERATE STRATEGY %s(%s)",
+                format(request.getKeyGenerateStrategyName()), createKeyGenerateStrategyBody(request)));
     }
     
     /**

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningKernel.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningKernel.java
@@ -44,6 +44,8 @@ import java.util.Map;
  */
 final class ShardingWorkflowPlanningKernel {
     
+    private static final List<String> SUPPORTED_LIFECYCLE_OPERATION_TYPES = List.of("create", WorkflowLifecycle.OPERATION_DROP);
+    
     private static final List<String> INTERACTION_STEPS = List.of(
             "Confirm logical database and sharding intent",
             "Inspect DistSQL-visible sharding state",
@@ -211,6 +213,9 @@ final class ShardingWorkflowPlanningKernel {
                                                           final ShardingWorkflowLifecycleSpec spec) {
         WorkflowContextSnapshot result = prepareSnapshot(workflowSessionContext, sessionId, request, spec.getWorkflowKind(), spec.getDefaultOperationType(), spec.getSummary());
         ShardingWorkflowRequest mergedRequest = (ShardingWorkflowRequest) result.getRequest();
+        if (!planningSupport.ensureSupportedOperationType(result.getClarifiedIntent(), SUPPORTED_LIFECYCLE_OPERATION_TYPES, result)) {
+            return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
+        }
         if (!inputValidator.hasDatabase(mergedRequest, result)) {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_CLARIFYING, result.getStatus());
         }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationService.java
@@ -89,7 +89,7 @@ public final class ShardingWorkflowValidationService implements MCPWorkflowRunti
     }
     
     private void addRuleDistSQLIssues(final List<Map<String, Object>> issues, final WorkflowContextSnapshot snapshot, final String sql, final String displaySql) {
-        if (!isCreateOrAlterShardingDistSQL(sql) || !(snapshot.getRequest() instanceof ShardingWorkflowRequest)) {
+        if (!isRuleDefinitionDistSQL(sql) || !(snapshot.getRequest() instanceof ShardingWorkflowRequest)) {
             return;
         }
         ShardingWorkflowRequest request = (ShardingWorkflowRequest) snapshot.getRequest();
@@ -110,10 +110,9 @@ public final class ShardingWorkflowValidationService implements MCPWorkflowRunti
         }
     }
     
-    private boolean isCreateOrAlterShardingDistSQL(final String sql) {
+    private boolean isRuleDefinitionDistSQL(final String sql) {
         String actualSQL = sql.trim().toUpperCase(Locale.ENGLISH);
-        return actualSQL.startsWith("CREATE SHARDING ") || actualSQL.startsWith("ALTER SHARDING ")
-                || actualSQL.startsWith("CREATE DEFAULT SHARDING ") || actualSQL.startsWith("ALTER DEFAULT SHARDING ");
+        return actualSQL.startsWith("CREATE SHARDING ") || actualSQL.startsWith("CREATE DEFAULT SHARDING ");
     }
     
     private void addTableRuleAlgorithmIssues(final List<Map<String, Object>> issues, final ShardingWorkflowRequest request, final String displaySql) {

--- a/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
+++ b/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
@@ -329,7 +329,7 @@ prompts:
         required: false
       - name: operation_type
         title: Operation Type
-        description: "create, alter, or drop."
+        description: "create or drop."
         required: false
       - name: algorithm_type
         title: Sharding Algorithm
@@ -361,14 +361,14 @@ prompts:
     description: "Guide the model to plan sharding table reference rule DistSQL."
     binding:
       templateResource: META-INF/shardingsphere-mcp/prompts/plan-sharding-table-reference-rule.md
-    arguments: &commonPromptArguments
+    arguments:
       - name: database
         title: Logical Database
         description: "ShardingSphere logical database."
         required: false
       - name: operation_type
         title: Operation Type
-        description: "create, alter, or drop."
+        description: "create or drop."
         required: false
       - name: plan_id
         title: Workflow Plan ID
@@ -400,7 +400,7 @@ prompts:
         required: false
       - name: operation_type
         title: Operation Type
-        description: "create, alter, or drop."
+        description: "create or drop."
         required: false
       - name: algorithm_type
         title: Sharding Algorithm
@@ -437,7 +437,7 @@ prompts:
         required: false
       - name: operation_type
         title: Operation Type
-        description: "create, alter, or drop."
+        description: "create or drop."
         required: false
       - name: key_generator_type
         title: Key Generator Algorithm
@@ -474,7 +474,7 @@ prompts:
         required: false
       - name: operation_type
         title: Operation Type
-        description: "create, alter, or drop."
+        description: "create or drop."
         required: false
       - name: key_generator_type
         title: Key Generator Algorithm
@@ -505,7 +505,19 @@ prompts:
     description: "Guide the model to clean up unused sharding algorithms, key generators, or auditors."
     binding:
       templateResource: META-INF/shardingsphere-mcp/prompts/plan-sharding-rule-component-cleanup.md
-    arguments: *commonPromptArguments
+    arguments:
+      - name: database
+        title: Logical Database
+        description: "ShardingSphere logical database."
+        required: false
+      - name: operation_type
+        title: Operation Type
+        description: "drop."
+        required: false
+      - name: plan_id
+        title: Workflow Plan ID
+        description: "Existing current-session workflow plan identifier used only to continue this cleanup plan. Omit when starting a new plan; never use placeholder values such as `plan_id`."
+        required: false
     meta:
       org.apache.shardingsphere/related-tools:
         - database_gateway_plan_sharding_rule_component_cleanup
@@ -605,7 +617,7 @@ resourceNavigation:
     carriedArguments:
       - database
       - table
-    description: "Use current table rule state before planning create, alter, or drop."
+    description: "Use current table rule state before planning create or drop."
   - from: shardingsphere://features/sharding/databases/{database}/tables/{table}/nodes
     to: database_gateway_plan_sharding_table_rule
     requiredArguments:
@@ -630,7 +642,7 @@ resourceNavigation:
     carriedArguments:
       - database
       - rule
-    description: "Use one table reference rule before planning alter or drop."
+    description: "Use one table reference rule before planning drop."
   - from: shardingsphere://features/sharding/databases/{database}/default-strategy
     to: database_gateway_plan_sharding_default_strategy
     requiredArguments:
@@ -653,7 +665,7 @@ resourceNavigation:
     carriedArguments:
       - database
       - keyGenerator
-    description: "Use one key generator before planning alter or drop."
+    description: "Use one key generator before planning drop."
   - from: shardingsphere://features/sharding/databases/{database}/key-generate-strategies
     to: database_gateway_plan_sharding_key_generate_strategy
     requiredArguments:
@@ -669,7 +681,7 @@ resourceNavigation:
     carriedArguments:
       - database
       - strategy
-    description: "Use one key generate strategy before planning alter or drop."
+    description: "Use one key generate strategy before planning drop."
   - from: shardingsphere://features/sharding/databases/{database}/unused-algorithms
     to: database_gateway_plan_sharding_rule_component_cleanup
     requiredArguments:
@@ -778,7 +790,7 @@ resourceNavigation:
 tools:
   - name: database_gateway_plan_sharding_table_rule
     title: Plan Sharding Table Rule
-    description: "Plan reviewable sharding table rule DistSQL without executing it. Use this before raw SQL for natural-language requests to create, alter, or drop database/table sharding rules."
+    description: "Plan reviewable sharding table rule DistSQL without executing it. Use this before raw SQL for natural-language requests to create or drop database/table sharding rules."
     inputSchema:
       type: object
       properties:
@@ -786,7 +798,7 @@ tools:
         database: {type: string, description: "Logical database."}
         table: {type: string, description: "Logical table."}
         column: {type: string, description: "Standard or auto-table sharding column."}
-        operation_type: {type: string, description: "create, alter, or drop.", enum: [create, alter, drop]}
+        operation_type: {type: string, description: "create or drop.", enum: [create, drop]}
         data_nodes: {type: string, description: "Explicit data nodes expression for a sharding table rule."}
         storage_units: {type: string, description: "Comma-separated storage units for an auto table rule."}
         strategy_type: {type: string, description: "Sharding strategy type.", enum: [standard, complex, hint, none]}
@@ -896,7 +908,7 @@ tools:
         plan_id: {type: string, description: "Existing workflow plan id for continuing a previous plan. Omit for a new plan; never use placeholder values such as `plan_id`."}
         database: {type: string, description: "Logical database."}
         rule: {type: string, description: "Table reference rule name."}
-        operation_type: {type: string, description: "create, alter, or drop.", enum: [create, alter, drop]}
+        operation_type: {type: string, description: "create or drop.", enum: [create, drop]}
         reference_tables: {type: string, description: "Comma-separated reference table names."}
         natural_language_intent: {type: string, description: "Original user request."}
         structured_intent_evidence: {type: object, description: "Structured intent extracted by the model.", additionalProperties: true}
@@ -932,7 +944,7 @@ tools:
       properties:
         plan_id: {type: string, description: "Existing workflow plan id for continuing a previous plan. Omit for a new plan; never use placeholder values such as `plan_id`."}
         database: {type: string, description: "Logical database."}
-        operation_type: {type: string, description: "create, alter, or drop.", enum: [create, alter, drop]}
+        operation_type: {type: string, description: "create or drop.", enum: [create, drop]}
         default_strategy_type: {type: string, description: "DATABASE or TABLE default strategy type.", enum: [DATABASE, TABLE]}
         strategy_type: {type: string, description: "Sharding strategy type.", enum: [standard, complex, hint, none]}
         column: {type: string, description: "Default sharding column for standard strategies."}
@@ -975,7 +987,7 @@ tools:
         plan_id: {type: string, description: "Existing workflow plan id for continuing a previous plan. Omit for a new plan; never use placeholder values such as `plan_id`."}
         database: {type: string, description: "Logical database."}
         key_generator: {type: string, description: "Key generator name."}
-        operation_type: {type: string, description: "create, alter, or drop.", enum: [create, alter, drop]}
+        operation_type: {type: string, description: "create or drop.", enum: [create, drop]}
         key_generator_type: {type: string, description: "Key generator algorithm type."}
         key_generator_properties: {type: object, description: "Key generator properties.", additionalProperties: {type: string}}
         natural_language_intent: {type: string, description: "Original user request."}
@@ -1014,7 +1026,7 @@ tools:
         plan_id: {type: string, description: "Existing workflow plan id for continuing a previous plan. Omit for a new plan; never use placeholder values such as `plan_id`."}
         database: {type: string, description: "Logical database."}
         key_generate_strategy: {type: string, description: "Key generate strategy name."}
-        operation_type: {type: string, description: "create, alter, or drop.", enum: [create, alter, drop]}
+        operation_type: {type: string, description: "create or drop.", enum: [create, drop]}
         table: {type: string, description: "Logical table for a table-based key generate strategy."}
         column: {type: string, description: "Key generate column for a table-based strategy."}
         sequence: {type: string, description: "Sequence name for a sequence-based strategy."}

--- a/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/prompts/plan-sharding-key-generator.md
+++ b/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/prompts/plan-sharding-key-generator.md
@@ -6,4 +6,4 @@ Inputs:
 - key_generator_type: {{key_generator_type}}
 - plan_id: {{plan_id}}
 
-Plan only ShardingSphere sharding key generator DistSQL. Require key generator name and key generator algorithm type before create or alter.
+Plan only ShardingSphere sharding key generator DistSQL. Require key generator name for create or drop, and require key generator algorithm type before create.

--- a/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/prompts/plan-sharding-table-rule.md
+++ b/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/prompts/plan-sharding-table-rule.md
@@ -7,12 +7,12 @@ Inputs:
 - plan_id: {{plan_id}}
 
 Plan only ShardingSphere sharding table rule DistSQL.
-Use this workflow before raw side-effect SQL when the user asks in natural language to create, alter, or drop database/table sharding rules, including generated key rules such as Snowflake.
+Use this workflow before raw side-effect SQL when the user asks in natural language to create or drop database/table sharding rules, including generated key rules such as Snowflake.
 
 Before planning:
 - Read existing table rules, algorithm plugins, and key-generate algorithm plugins for the logical database.
 - Preserve existing rule details that the user did not ask to change.
-- Do not create physical databases, physical tables, indexes, storage units, migrations, backfills, or data probes.
+- Do not create physical databases, physical tables, indexes, storage units, physical data-change jobs, or data probes.
 
 Ask before planning when any required rule input is unclear:
 - logical table and actual data nodes

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingDescriptorContractTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingDescriptorContractTest.java
@@ -66,7 +66,21 @@ class ShardingDescriptorContractTest {
         MCPToolDescriptor actual = findTool(catalog, ShardingFeatureDefinition.PLAN_TABLE_RULE_TOOL_NAME);
         assertThat(actual.getDescription(),
                 is("Plan reviewable sharding table rule DistSQL without executing it. "
-                        + "Use this before raw SQL for natural-language requests to create, alter, or drop database/table sharding rules."));
+                        + "Use this before raw SQL for natural-language requests to create or drop database/table sharding rules."));
+    }
+    
+    @Test
+    void assertPlanningToolOperationTypesExposeOnlySupportedLifecycleActions() {
+        MCPDescriptorCatalog catalog = MCPDescriptorCatalogLoader.load();
+        for (String each : List.of(
+                ShardingFeatureDefinition.PLAN_TABLE_RULE_TOOL_NAME,
+                ShardingFeatureDefinition.PLAN_TABLE_REFERENCE_TOOL_NAME,
+                ShardingFeatureDefinition.PLAN_DEFAULT_STRATEGY_TOOL_NAME,
+                ShardingFeatureDefinition.PLAN_KEY_GENERATOR_TOOL_NAME,
+                ShardingFeatureDefinition.PLAN_KEY_GENERATE_STRATEGY_TOOL_NAME)) {
+            assertOperationTypeEnum(findTool(catalog, each), List.of("create", "drop"));
+        }
+        assertOperationTypeEnum(findTool(catalog, ShardingFeatureDefinition.PLAN_COMPONENT_CLEANUP_TOOL_NAME), List.of("drop"));
     }
     
     private MCPPromptDescriptor findPrompt(final MCPDescriptorCatalog catalog, final String promptName) {
@@ -75,6 +89,12 @@ class ShardingDescriptorContractTest {
     
     private MCPToolDescriptor findTool(final MCPDescriptorCatalog catalog, final String toolName) {
         return catalog.getProtocolDescriptors().getToolDescriptors().stream().filter(each -> toolName.equals(each.getName())).findFirst().orElseThrow();
+    }
+    
+    private void assertOperationTypeEnum(final MCPToolDescriptor descriptor, final List<String> expectedValues) {
+        Map<?, ?> properties = (Map<?, ?>) descriptor.getInputSchema().get("properties");
+        Map<?, ?> operationType = (Map<?, ?>) properties.get("operation_type");
+        assertThat(operationType.get("enum"), is(expectedValues));
     }
     
     private void assertCompletionTargetArguments(final MCPDescriptorCatalog catalog, final String promptName, final String... expectedArguments) {

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningKernelTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningKernelTest.java
@@ -23,13 +23,16 @@ import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowPlanPayloadBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 
 class ShardingWorkflowPlanningKernelTest {
@@ -46,6 +49,18 @@ class ShardingWorkflowPlanningKernelTest {
     }
     
     @Test
+    void assertPlanTableRuleRejectsUnsupportedOperation() {
+        ShardingWorkflowRequest request = new ShardingWorkflowRequest();
+        request.setOperationType("replace");
+        WorkflowContextSnapshot actual = kernel.planTableRule(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), "session-1", request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getInteractionPlan().getCurrentStep(), is(WorkflowLifecycle.STEP_FAILED));
+        assertThat(actual.getClarifiedIntent().getOperationType(), is(""));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
+        assertRuleDistSQLOnlyPayloadDoesNotExpose(actual, "replace");
+    }
+    
+    @Test
     void assertPlanComponentCleanupRejectsNonDropOperation() {
         ShardingWorkflowRequest request = new ShardingWorkflowRequest();
         request.setDatabase("logic_db");
@@ -57,5 +72,10 @@ class ShardingWorkflowPlanningKernelTest {
         assertThat(actual.getInteractionPlan().getCurrentStep(), is(WorkflowLifecycle.STEP_FAILED));
         assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
         assertThat(actual.getIssues().getFirst().getDetails(), is(Map.of("operation_type", "create")));
+    }
+    
+    private void assertRuleDistSQLOnlyPayloadDoesNotExpose(final WorkflowContextSnapshot snapshot, final String term) {
+        Map<String, Object> actualPayload = WorkflowPlanPayloadBuilder.buildRuleDistSQLOnly(snapshot, snapshot.getRequest());
+        assertFalse(String.valueOf(actualPayload).toLowerCase(Locale.ENGLISH).contains(term));
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowIssueCode.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowIssueCode.java
@@ -38,23 +38,13 @@ public final class WorkflowIssueCode {
     
     public static final String COLUMN_NOT_FOUND = "WF-META-002";
     
-    public static final String LOGICAL_METADATA_UNAVAILABLE = "WF-META-003";
-    
-    public static final String FEATURE_TYPE_UNCLEAR = "WF-INTENT-001";
-    
     public static final String ALGORITHM_NOT_FOUND = "WF-ALGO-001";
     
     public static final String ALGORITHM_CAPABILITY_CONFLICT = "WF-ALGO-002";
     
     public static final String REQUIRED_PROPERTY_MISSING = "WF-PROP-001";
     
-    public static final String SECRET_PROPERTY_REQUIRED = "WF-PROP-002";
-    
-    public static final String SECRET_REFERENCE_MANUAL_EXECUTION_REQUIRED = "WF-PROP-003";
-    
-    public static final String USER_OVERRIDE_NAME_UNSAFE = "WF-NAME-001";
-    
-    public static final String AUTO_RENAMED_DUE_TO_CONFLICT = "WF-NAME-002";
+    public static final String SECRET_REFERENCE_MANUAL_EXECUTION_REQUIRED = "WF-PROP-002";
     
     public static final String DROP_TARGET_RULE_NOT_FOUND = "WF-LIFE-001";
     
@@ -64,13 +54,11 @@ public final class WorkflowIssueCode {
     
     public static final String PHYSICAL_CLEANUP_REQUIRED = "WF-LIFE-004";
     
-    public static final String ENCRYPT_ALTER_SCOPE_LIMITED = "WF-LIFE-005";
+    public static final String ENCRYPT_RULE_REWRITE_LIMITED = "WF-LIFE-005";
     
-    public static final String MASK_ALTER_SCOPE_LIMITED = "WF-LIFE-006";
+    public static final String MASK_RULE_REWRITE_LIMITED = "WF-LIFE-006";
     
-    public static final String DDL_PERMISSION_DENIED = "WF-DDL-001";
-    
-    public static final String DDL_EXECUTION_FAILED = "WF-DDL-002";
+    public static final String DDL_EXECUTION_FAILED = "WF-DDL-001";
     
     public static final String RULE_EXECUTION_FAILED = "WF-RULE-001";
     
@@ -84,7 +72,5 @@ public final class WorkflowIssueCode {
     
     public static final String RULE_STATE_MISMATCH = "WF-VAL-002";
     
-    public static final String LOGICAL_METADATA_MISMATCH = "WF-VAL-003";
-    
-    public static final String SQL_EXECUTABILITY_FAILED = "WF-VAL-004";
+    public static final String SQL_EXECUTABILITY_FAILED = "WF-VAL-003";
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningSupport.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningSupport.java
@@ -23,9 +23,11 @@ import org.apache.shardingsphere.mcp.support.workflow.model.ClarifiedIntent;
 import org.apache.shardingsphere.mcp.support.workflow.model.InteractionPlan;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFeatureData;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
 
 import java.util.Collection;
@@ -94,12 +96,13 @@ public final class WorkflowPlanningSupport {
         String actualOperationType = clarifiedIntent.getOperationType().toLowerCase(Locale.ENGLISH);
         if ("create".equals(actualOperationType) && ruleExists) {
             snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.RULE_STATE_MISMATCH, "error", "discovering",
-                    String.format("%s already exists for the target column.", ruleLabel), "Use alter instead of create.", false, Map.of()));
+                    String.format("%s already exists for the target column.", ruleLabel), "Use a supported change path for the existing rule, or drop it before creating a replacement.", false,
+                    Map.of()));
             return false;
         }
         if ("alter".equals(actualOperationType) && !ruleExists) {
             snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.RULE_STATE_MISMATCH, "error", "discovering",
-                    String.format("%s does not exist for the target column.", ruleLabel), "Use create instead of alter or confirm the target column.", false, Map.of()));
+                    String.format("%s does not exist for the target column.", ruleLabel), "Use create or confirm the target column.", false, Map.of()));
             return false;
         }
         if ("drop".equals(actualOperationType) && !ruleExists) {
@@ -108,6 +111,39 @@ public final class WorkflowPlanningSupport {
             return false;
         }
         return true;
+    }
+    
+    /**
+     * Ensure workflow operation type is exposed by the feature contract.
+     *
+     * @param clarifiedIntent clarified intent
+     * @param supportedOperationTypes supported operation types
+     * @param snapshot workflow snapshot
+     * @return whether the operation type is supported
+     */
+    public boolean ensureSupportedOperationType(final ClarifiedIntent clarifiedIntent, final Collection<String> supportedOperationTypes, final WorkflowContextSnapshot snapshot) {
+        if (containsOperationType(supportedOperationTypes, clarifiedIntent.getOperationType())) {
+            return true;
+        }
+        snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.WORKFLOW_STATUS_INVALID, "error", "intaking",
+                "Unsupported workflow operation type.", String.format("Use one of: %s.", String.join(", ", supportedOperationTypes)), false,
+                Map.of("supported_operation_types", supportedOperationTypes)));
+        clarifiedIntent.getInferredValues().remove(WorkflowFieldNames.OPERATION_TYPE);
+        clarifiedIntent.setOperationType("");
+        if (null != snapshot.getRequest()) {
+            snapshot.getRequest().setOperationType("");
+        }
+        snapshot.setStatus(WorkflowLifecycle.STATUS_FAILED);
+        return false;
+    }
+    
+    private boolean containsOperationType(final Collection<String> supportedOperationTypes, final String actualOperationType) {
+        for (String each : supportedOperationTypes) {
+            if (each.equalsIgnoreCase(actualOperationType)) {
+                return true;
+            }
+        }
+        return false;
     }
     
     /**

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningSupportTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningSupportTest.java
@@ -25,9 +25,11 @@ import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPSchemaMe
 import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPTableMetadata;
 import org.apache.shardingsphere.mcp.support.workflow.model.ClarifiedIntent;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -258,6 +260,35 @@ class WorkflowPlanningSupportTest {
         if (null != expectedIssueCode) {
             assertThat(snapshot.getIssues().getFirst().getCode(), is(expectedIssueCode));
         }
+    }
+    
+    @Test
+    void assertEnsureSupportedOperationTypeAllowsSupportedOperation() {
+        ClarifiedIntent clarifiedIntent = new ClarifiedIntent();
+        clarifiedIntent.setOperationType("create");
+        WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
+        boolean actual = planningSupport.ensureSupportedOperationType(clarifiedIntent, List.of("create", WorkflowLifecycle.OPERATION_DROP), snapshot);
+        assertTrue(actual);
+        assertTrue(snapshot.getIssues().isEmpty());
+    }
+    
+    @Test
+    void assertEnsureSupportedOperationTypeRejectsUnsupportedOperation() {
+        ClarifiedIntent clarifiedIntent = new ClarifiedIntent();
+        clarifiedIntent.setOperationType("replace");
+        clarifiedIntent.getInferredValues().put(WorkflowFieldNames.OPERATION_TYPE, "replace");
+        WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
+        WorkflowRequest request = new WorkflowRequest();
+        request.setOperationType("replace");
+        snapshot.setRequest(request);
+        boolean actual = planningSupport.ensureSupportedOperationType(clarifiedIntent, List.of("create", WorkflowLifecycle.OPERATION_DROP), snapshot);
+        assertFalse(actual);
+        assertThat(clarifiedIntent.getOperationType(), is(""));
+        assertFalse(clarifiedIntent.getInferredValues().containsKey(WorkflowFieldNames.OPERATION_TYPE));
+        assertThat(request.getOperationType(), is(""));
+        assertThat(snapshot.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(snapshot.getIssues().getFirst().getCode(), is(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
+        assertThat(snapshot.getIssues().getFirst().getDetails(), is(Map.of("supported_operation_types", List.of("create", WorkflowLifecycle.OPERATION_DROP))));
     }
     
     @Test

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
@@ -208,7 +208,7 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
                             "natural_language_intent", "encrypt amount with reversible encryption, no equality, no like", "algorithm_type", "AES",
                             "primary_algorithm_properties", Map.of("aes-key-value", "second-secret")));
             assertThat(String.valueOf(actualSecondPlanResponse.get("status")), is("clarifying"));
-            assertThat(getIssueCodes(actualSecondPlanResponse), hasItem(WorkflowIssueCode.ENCRYPT_ALTER_SCOPE_LIMITED));
+            assertThat(getIssueCodes(actualSecondPlanResponse), hasItem(WorkflowIssueCode.ENCRYPT_RULE_REWRITE_LIMITED));
             assertFalse(getClarificationMessages(actualSecondPlanResponse).isEmpty());
             assertFalse(actualSecondPlanResponse.containsKey("ddl_artifacts"));
             assertThat(getMapList(actualSecondPlanResponse.get("distsql_artifacts")).size(), is(0));
@@ -265,18 +265,18 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
     }
     
     @Test
-    void assertPlanRejectsUnsupportedEncryptAlterExpansionThroughProxy() throws IOException, InterruptedException {
+    void assertPlanRejectsUnsupportedEncryptOperationThroughProxy() throws IOException, InterruptedException {
         try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
             createEncryptRuleWithoutEquality(interactionClient);
-            Map<String, Object> actualAlterPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
+            Map<String, Object> actualUnsupportedPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
                     Map.of("database", getLogicalDatabaseName(), "table", "orders", "column", "status",
-                            "natural_language_intent", "encrypt status with reversible encryption, update to require equality and no like", "operation_type", "alter",
-                            "primary_algorithm_properties", Map.of("aes-key-value", "alter-secret")));
-            assertThat(String.valueOf(actualAlterPlanResponse.get("status")), is("clarifying"));
-            assertThat(getIssueCodes(actualAlterPlanResponse), hasItem(WorkflowIssueCode.ENCRYPT_ALTER_SCOPE_LIMITED));
-            assertFalse(getClarificationMessages(actualAlterPlanResponse).isEmpty());
-            assertFalse(actualAlterPlanResponse.containsKey("ddl_artifacts"));
-            assertThat(getMapList(actualAlterPlanResponse.get("distsql_artifacts")).size(), is(0));
+                            "natural_language_intent", "encrypt status with reversible encryption, update to require equality and no like", "operation_type", "replace",
+                            "primary_algorithm_properties", Map.of("aes-key-value", "replace-secret")));
+            assertThat(String.valueOf(actualUnsupportedPlanResponse.get("status")), is("failed"));
+            assertThat(getIssueCodes(actualUnsupportedPlanResponse), hasItem(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
+            assertFalse(String.valueOf(actualUnsupportedPlanResponse).toLowerCase(Locale.ENGLISH).contains("replace"));
+            assertFalse(actualUnsupportedPlanResponse.containsKey("ddl_artifacts"));
+            assertThat(getMapList(actualUnsupportedPlanResponse.get("distsql_artifacts")).size(), is(0));
         }
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
@@ -270,11 +270,11 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
             createEncryptRuleWithoutEquality(interactionClient);
             Map<String, Object> actualUnsupportedPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
                     Map.of("database", getLogicalDatabaseName(), "table", "orders", "column", "status",
-                            "natural_language_intent", "encrypt status with reversible encryption, update to require equality and no like", "operation_type", "replace",
-                            "primary_algorithm_properties", Map.of("aes-key-value", "replace-secret")));
+                            "natural_language_intent", "encrypt status with reversible encryption, update to require equality and no like",
+                            "primary_algorithm_properties", Map.of("aes-key-value", "unsupported-secret")));
             assertThat(String.valueOf(actualUnsupportedPlanResponse.get("status")), is("failed"));
             assertThat(getIssueCodes(actualUnsupportedPlanResponse), hasItem(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
-            assertFalse(String.valueOf(actualUnsupportedPlanResponse).toLowerCase(Locale.ENGLISH).contains("replace"));
+            assertFalse(String.valueOf(actualUnsupportedPlanResponse).toLowerCase(Locale.ENGLISH).contains("alter"));
             assertFalse(actualUnsupportedPlanResponse.containsKey("ddl_artifacts"));
             assertThat(getMapList(actualUnsupportedPlanResponse.get("distsql_artifacts")).size(), is(0));
         }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
@@ -80,11 +80,11 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
                     is("KEEP_FIRST_N_LAST_M"));
             Map<String, Object> actualUnsupportedPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
                     Map.of("database", getLogicalDatabaseName(), "table", "orders", "column", "status",
-                            "operation_type", "replace", "algorithm_type", "KEEP_FIRST_N_LAST_M",
+                            "natural_language_intent", "update status mask rule", "algorithm_type", "KEEP_FIRST_N_LAST_M",
                             "primary_algorithm_properties", Map.of("first-n", "2", "last-m", "2", "replace-char", "#")));
             assertThat(String.valueOf(actualUnsupportedPlanResponse.get("status")), is("failed"));
             assertThat(getIssueCodes(actualUnsupportedPlanResponse), hasItem(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
-            assertFalse(String.valueOf(actualUnsupportedPlanResponse).toLowerCase(Locale.ENGLISH).contains("replace"));
+            assertFalse(String.valueOf(actualUnsupportedPlanResponse).toLowerCase(Locale.ENGLISH).contains("alter"));
             assertThat(getMapList(actualUnsupportedPlanResponse.get("distsql_artifacts")).size(), is(0));
         }
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @EnabledIf("isEnabled")
 class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWorkflowE2ETest {
@@ -63,7 +64,7 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
     }
     
     @Test
-    void assertPlanApplyValidateAndRejectMaskAlterWorkflowThroughProxy() throws IOException, InterruptedException {
+    void assertPlanApplyValidateAndRejectUnsupportedMaskWorkflowThroughProxy() throws IOException, InterruptedException {
         try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
             Map<String, Object> actualCreatePlanResponse = interactionClient.call(PLAN_TOOL_NAME,
                     Map.of("database", getLogicalDatabaseName(), "table", "orders", "column", "status",
@@ -77,13 +78,14 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
             assertValidationPassed(actualCreateValidationResponse);
             assertThat(String.valueOf(getMapList(getMap(actualCreateValidationResponse.get("rule_validation")).get("evidence")).getFirst().get("algorithm_type")).toUpperCase(Locale.ENGLISH),
                     is("KEEP_FIRST_N_LAST_M"));
-            Map<String, Object> actualAlterPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
+            Map<String, Object> actualUnsupportedPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
                     Map.of("database", getLogicalDatabaseName(), "table", "orders", "column", "status",
-                            "operation_type", "alter", "algorithm_type", "KEEP_FIRST_N_LAST_M",
+                            "operation_type", "replace", "algorithm_type", "KEEP_FIRST_N_LAST_M",
                             "primary_algorithm_properties", Map.of("first-n", "2", "last-m", "2", "replace-char", "#")));
-            assertThat(String.valueOf(actualAlterPlanResponse.get("status")), is("clarifying"));
-            assertThat(getIssueCodes(actualAlterPlanResponse), hasItem(WorkflowIssueCode.MASK_ALTER_SCOPE_LIMITED));
-            assertThat(getMapList(actualAlterPlanResponse.get("distsql_artifacts")).size(), is(0));
+            assertThat(String.valueOf(actualUnsupportedPlanResponse.get("status")), is("failed"));
+            assertThat(getIssueCodes(actualUnsupportedPlanResponse), hasItem(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
+            assertFalse(String.valueOf(actualUnsupportedPlanResponse).toLowerCase(Locale.ENGLISH).contains("replace"));
+            assertThat(getMapList(actualUnsupportedPlanResponse.get("distsql_artifacts")).size(), is(0));
         }
     }
     
@@ -112,7 +114,7 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
                             "operation_type", "create", "algorithm_type", "KEEP_FIRST_N_LAST_M",
                             "primary_algorithm_properties", Map.of("first-n", "1", "last-m", "1", "replace-char", "#")));
             assertThat(String.valueOf(actualSecondCreatePlanResponse.get("status")), is("clarifying"));
-            assertThat(getIssueCodes(actualSecondCreatePlanResponse), hasItem(WorkflowIssueCode.MASK_ALTER_SCOPE_LIMITED));
+            assertThat(getIssueCodes(actualSecondCreatePlanResponse), hasItem(WorkflowIssueCode.MASK_RULE_REWRITE_LIMITED));
             assertThat(getMapList(actualSecondCreatePlanResponse.get("distsql_artifacts")).size(), is(0));
         }
     }

--- a/test/e2e/mcp/src/test/resources/llm/evaluation/mcp-builder-evaluation.xml
+++ b/test/e2e/mcp/src/test/resources/llm/evaluation/mcp-builder-evaluation.xml
@@ -159,7 +159,7 @@
       database_gateway_plan_broadcast_rule, database_gateway_plan_readwrite_splitting_rule, database_gateway_plan_shadow_rule, or
       database_gateway_plan_sharding_table_rule. The model should then report plan_id, reviewable DistSQL artifacts, resources_to_read,
       and next_actions. It must not call database_gateway_apply_workflow in execute mode, execute SQL updates, create physical metadata,
-      or perform migration while the request is still a read-only review.
+      or perform physical data changes while the request is still a read-only review.
     </expected_answer>
     <verification>
       <step>Confirm the answer discovers feature resources and tool schemas before selecting a planning workflow.</step>


### PR DESCRIPTION
- Limit encrypt, mask, and sharding planners to create/drop contracts
- Prevent unsupported operation values from leaking into workflow payloads
- Simplify rule DistSQL artifact builders and cover descriptors/runtime payloads