### PR TITLE
Move MCP system schemas to connector dialect SPI

### DIFF
--- a/database/connector/dialect/clickhouse/src/main/java/org/apache/shardingsphere/database/connector/clickhouse/database/system/ClickHouseSystemDatabase.java
+++ b/database/connector/dialect/clickhouse/src/main/java/org/apache/shardingsphere/database/connector/clickhouse/database/system/ClickHouseSystemDatabase.java
@@ -36,7 +36,7 @@ public final class ClickHouseSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public Collection<String> getSystemSchemas(final String databaseName) {
-        return SYSTEM_SCHEMAS;
+        return Collections.emptyList();
     }
     
     @Override

--- a/database/connector/dialect/clickhouse/src/main/java/org/apache/shardingsphere/database/connector/clickhouse/database/system/ClickHouseSystemDatabase.java
+++ b/database/connector/dialect/clickhouse/src/main/java/org/apache/shardingsphere/database/connector/clickhouse/database/system/ClickHouseSystemDatabase.java
@@ -15,20 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.clickhouse.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
 /**
- * System database of Firebird.
+ * System database of ClickHouse.
  */
-public final class FirebirdSystemDatabase implements DialectSystemDatabase {
+public final class ClickHouseSystemDatabase implements DialectSystemDatabase {
     
-    private static final Collection<String> SYSTEM_SCHEMAS = Arrays.asList("system_lobs", "system_tables");
+    private static final Collection<String> SYSTEM_SCHEMAS = Collections.singleton("information_schema");
     
     @Override
     public Collection<String> getSystemDatabases() {
@@ -47,6 +46,6 @@ public final class FirebirdSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public String getDatabaseType() {
-        return "Firebird";
+        return "ClickHouse";
     }
 }

--- a/database/connector/dialect/clickhouse/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
+++ b/database/connector/dialect/clickhouse/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.database.connector.clickhouse.database.system.ClickHouseSystemDatabase

--- a/database/connector/dialect/clickhouse/src/test/java/org/apache/shardingsphere/database/connector/clickhouse/database/system/ClickHouseSystemDatabaseTest.java
+++ b/database/connector/dialect/clickhouse/src/test/java/org/apache/shardingsphere/database/connector/clickhouse/database/system/ClickHouseSystemDatabaseTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.clickhouse.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -23,30 +23,30 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class FirebirdSystemDatabaseTest {
+class ClickHouseSystemDatabaseTest {
     
-    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Firebird");
+    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "ClickHouse");
     
     private final DialectSystemDatabase systemDatabase = DatabaseTypedSPILoader.getService(DialectSystemDatabase.class, databaseType);
     
     @Test
-    void assertGetSystemDatabases() {
+    void assertGetSystemDatabasesEmpty() {
         assertTrue(systemDatabase.getSystemDatabases().isEmpty());
     }
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Collections.singleton("information_schema")));
     }
     
     @Test
     void assertGetSystemSchemas() {
-        assertThat(systemDatabase.getSystemSchemas(), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas(), is(Collections.singleton("information_schema")));
     }
 }

--- a/database/connector/dialect/clickhouse/src/test/java/org/apache/shardingsphere/database/connector/clickhouse/database/system/ClickHouseSystemDatabaseTest.java
+++ b/database/connector/dialect/clickhouse/src/test/java/org/apache/shardingsphere/database/connector/clickhouse/database/system/ClickHouseSystemDatabaseTest.java
@@ -42,7 +42,7 @@ class ClickHouseSystemDatabaseTest {
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Collections.singleton("information_schema")));
+        assertTrue(systemDatabase.getSystemSchemas("foo_db").isEmpty());
     }
     
     @Test

--- a/database/connector/dialect/firebird/src/main/java/org/apache/shardingsphere/database/connector/firebird/metadata/database/system/FirebirdSystemDatabase.java
+++ b/database/connector/dialect/firebird/src/main/java/org/apache/shardingsphere/database/connector/firebird/metadata/database/system/FirebirdSystemDatabase.java
@@ -37,7 +37,7 @@ public final class FirebirdSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public Collection<String> getSystemSchemas(final String databaseName) {
-        return SYSTEM_SCHEMAS;
+        return Collections.singleton("system_tables");
     }
     
     @Override

--- a/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/database/system/FirebirdSystemDatabaseTest.java
+++ b/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/database/system/FirebirdSystemDatabaseTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,7 +43,7 @@ class FirebirdSystemDatabaseTest {
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Collections.singleton("system_tables")));
     }
     
     @Test

--- a/database/connector/dialect/hive/src/main/java/org/apache/shardingsphere/database/connector/hive/metadata/database/system/HiveSystemDatabase.java
+++ b/database/connector/dialect/hive/src/main/java/org/apache/shardingsphere/database/connector/hive/metadata/database/system/HiveSystemDatabase.java
@@ -37,7 +37,7 @@ public final class HiveSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public Collection<String> getSystemSchemas(final String databaseName) {
-        return SYSTEM_SCHEMAS;
+        return Collections.emptyList();
     }
     
     @Override

--- a/database/connector/dialect/hive/src/main/java/org/apache/shardingsphere/database/connector/hive/metadata/database/system/HiveSystemDatabase.java
+++ b/database/connector/dialect/hive/src/main/java/org/apache/shardingsphere/database/connector/hive/metadata/database/system/HiveSystemDatabase.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.hive.metadata.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 
@@ -24,11 +24,11 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * System database of Firebird.
+ * System database of Hive.
  */
-public final class FirebirdSystemDatabase implements DialectSystemDatabase {
+public final class HiveSystemDatabase implements DialectSystemDatabase {
     
-    private static final Collection<String> SYSTEM_SCHEMAS = Arrays.asList("system_lobs", "system_tables");
+    private static final Collection<String> SYSTEM_SCHEMAS = Arrays.asList("information_schema", "sys");
     
     @Override
     public Collection<String> getSystemDatabases() {
@@ -47,6 +47,6 @@ public final class FirebirdSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public String getDatabaseType() {
-        return "Firebird";
+        return "Hive";
     }
 }

--- a/database/connector/dialect/hive/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
+++ b/database/connector/dialect/hive/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.database.connector.hive.metadata.database.system.HiveSystemDatabase

--- a/database/connector/dialect/hive/src/test/java/org/apache/shardingsphere/database/connector/hive/metadata/database/system/HiveSystemDatabaseTest.java
+++ b/database/connector/dialect/hive/src/test/java/org/apache/shardingsphere/database/connector/hive/metadata/database/system/HiveSystemDatabaseTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.hive.metadata.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -25,28 +25,28 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class FirebirdSystemDatabaseTest {
+class HiveSystemDatabaseTest {
     
-    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Firebird");
+    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Hive");
     
     private final DialectSystemDatabase systemDatabase = DatabaseTypedSPILoader.getService(DialectSystemDatabase.class, databaseType);
     
     @Test
-    void assertGetSystemDatabases() {
+    void assertGetSystemDatabasesEmpty() {
         assertTrue(systemDatabase.getSystemDatabases().isEmpty());
     }
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("information_schema", "sys")));
     }
     
     @Test
     void assertGetSystemSchemas() {
-        assertThat(systemDatabase.getSystemSchemas(), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas(), is(Arrays.asList("information_schema", "sys")));
     }
 }

--- a/database/connector/dialect/hive/src/test/java/org/apache/shardingsphere/database/connector/hive/metadata/database/system/HiveSystemDatabaseTest.java
+++ b/database/connector/dialect/hive/src/test/java/org/apache/shardingsphere/database/connector/hive/metadata/database/system/HiveSystemDatabaseTest.java
@@ -42,7 +42,7 @@ class HiveSystemDatabaseTest {
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("information_schema", "sys")));
+        assertTrue(systemDatabase.getSystemSchemas("foo_db").isEmpty());
     }
     
     @Test

--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/system/OracleSystemDatabase.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/system/OracleSystemDatabase.java
@@ -37,7 +37,7 @@ public final class OracleSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public Collection<String> getSystemSchemas(final String databaseName) {
-        return SYSTEM_SCHEMAS;
+        return Collections.emptyList();
     }
     
     @Override

--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/system/OracleSystemDatabase.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/system/OracleSystemDatabase.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.oracle.metadata.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 
@@ -24,11 +24,11 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * System database of Firebird.
+ * System database of Oracle.
  */
-public final class FirebirdSystemDatabase implements DialectSystemDatabase {
+public final class OracleSystemDatabase implements DialectSystemDatabase {
     
-    private static final Collection<String> SYSTEM_SCHEMAS = Arrays.asList("system_lobs", "system_tables");
+    private static final Collection<String> SYSTEM_SCHEMAS = Arrays.asList("sys", "system_lobs");
     
     @Override
     public Collection<String> getSystemDatabases() {
@@ -47,6 +47,6 @@ public final class FirebirdSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public String getDatabaseType() {
-        return "Firebird";
+        return "Oracle";
     }
 }

--- a/database/connector/dialect/oracle/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
+++ b/database/connector/dialect/oracle/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.database.connector.oracle.metadata.database.system.OracleSystemDatabase

--- a/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/system/OracleSystemDatabaseTest.java
+++ b/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/system/OracleSystemDatabaseTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.oracle.metadata.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -25,28 +25,28 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class FirebirdSystemDatabaseTest {
+class OracleSystemDatabaseTest {
     
-    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Firebird");
+    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Oracle");
     
     private final DialectSystemDatabase systemDatabase = DatabaseTypedSPILoader.getService(DialectSystemDatabase.class, databaseType);
     
     @Test
-    void assertGetSystemDatabases() {
+    void assertGetSystemDatabasesEmpty() {
         assertTrue(systemDatabase.getSystemDatabases().isEmpty());
     }
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("sys", "system_lobs")));
     }
     
     @Test
     void assertGetSystemSchemas() {
-        assertThat(systemDatabase.getSystemSchemas(), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas(), is(Arrays.asList("sys", "system_lobs")));
     }
 }

--- a/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/system/OracleSystemDatabaseTest.java
+++ b/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/system/OracleSystemDatabaseTest.java
@@ -42,7 +42,7 @@ class OracleSystemDatabaseTest {
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("sys", "system_lobs")));
+        assertTrue(systemDatabase.getSystemSchemas("foo_db").isEmpty());
     }
     
     @Test

--- a/database/connector/dialect/presto/src/main/java/org/apache/shardingsphere/database/connector/presto/metadata/database/system/PrestoSystemDatabase.java
+++ b/database/connector/dialect/presto/src/main/java/org/apache/shardingsphere/database/connector/presto/metadata/database/system/PrestoSystemDatabase.java
@@ -36,7 +36,7 @@ public final class PrestoSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public Collection<String> getSystemSchemas(final String databaseName) {
-        return SYSTEM_SCHEMAS;
+        return Collections.emptyList();
     }
     
     @Override

--- a/database/connector/dialect/presto/src/main/java/org/apache/shardingsphere/database/connector/presto/metadata/database/system/PrestoSystemDatabase.java
+++ b/database/connector/dialect/presto/src/main/java/org/apache/shardingsphere/database/connector/presto/metadata/database/system/PrestoSystemDatabase.java
@@ -15,20 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.presto.metadata.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
 /**
- * System database of Firebird.
+ * System database of Presto.
  */
-public final class FirebirdSystemDatabase implements DialectSystemDatabase {
+public final class PrestoSystemDatabase implements DialectSystemDatabase {
     
-    private static final Collection<String> SYSTEM_SCHEMAS = Arrays.asList("system_lobs", "system_tables");
+    private static final Collection<String> SYSTEM_SCHEMAS = Collections.singleton("information_schema");
     
     @Override
     public Collection<String> getSystemDatabases() {
@@ -47,6 +46,6 @@ public final class FirebirdSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public String getDatabaseType() {
-        return "Firebird";
+        return "Presto";
     }
 }

--- a/database/connector/dialect/presto/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
+++ b/database/connector/dialect/presto/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.database.connector.presto.metadata.database.system.PrestoSystemDatabase

--- a/database/connector/dialect/presto/src/test/java/org/apache/shardingsphere/database/connector/presto/metadata/database/system/PrestoSystemDatabaseTest.java
+++ b/database/connector/dialect/presto/src/test/java/org/apache/shardingsphere/database/connector/presto/metadata/database/system/PrestoSystemDatabaseTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.presto.metadata.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -23,30 +23,30 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class FirebirdSystemDatabaseTest {
+class PrestoSystemDatabaseTest {
     
-    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Firebird");
+    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Presto");
     
     private final DialectSystemDatabase systemDatabase = DatabaseTypedSPILoader.getService(DialectSystemDatabase.class, databaseType);
     
     @Test
-    void assertGetSystemDatabases() {
+    void assertGetSystemDatabasesEmpty() {
         assertTrue(systemDatabase.getSystemDatabases().isEmpty());
     }
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Collections.singleton("information_schema")));
     }
     
     @Test
     void assertGetSystemSchemas() {
-        assertThat(systemDatabase.getSystemSchemas(), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas(), is(Collections.singleton("information_schema")));
     }
 }

--- a/database/connector/dialect/presto/src/test/java/org/apache/shardingsphere/database/connector/presto/metadata/database/system/PrestoSystemDatabaseTest.java
+++ b/database/connector/dialect/presto/src/test/java/org/apache/shardingsphere/database/connector/presto/metadata/database/system/PrestoSystemDatabaseTest.java
@@ -42,7 +42,7 @@ class PrestoSystemDatabaseTest {
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Collections.singleton("information_schema")));
+        assertTrue(systemDatabase.getSystemSchemas("foo_db").isEmpty());
     }
     
     @Test

--- a/database/connector/dialect/sqlserver/src/main/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/system/SQLServerSystemDatabase.java
+++ b/database/connector/dialect/sqlserver/src/main/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/system/SQLServerSystemDatabase.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.sql92.sqlserver.metadata.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 
@@ -24,11 +24,11 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * System database of Firebird.
+ * System database of SQLServer.
  */
-public final class FirebirdSystemDatabase implements DialectSystemDatabase {
+public final class SQLServerSystemDatabase implements DialectSystemDatabase {
     
-    private static final Collection<String> SYSTEM_SCHEMAS = Arrays.asList("system_lobs", "system_tables");
+    private static final Collection<String> SYSTEM_SCHEMAS = Arrays.asList("information_schema", "sys");
     
     @Override
     public Collection<String> getSystemDatabases() {
@@ -47,6 +47,6 @@ public final class FirebirdSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public String getDatabaseType() {
-        return "Firebird";
+        return "SQLServer";
     }
 }

--- a/database/connector/dialect/sqlserver/src/main/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/system/SQLServerSystemDatabase.java
+++ b/database/connector/dialect/sqlserver/src/main/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/system/SQLServerSystemDatabase.java
@@ -37,7 +37,7 @@ public final class SQLServerSystemDatabase implements DialectSystemDatabase {
     
     @Override
     public Collection<String> getSystemSchemas(final String databaseName) {
-        return SYSTEM_SCHEMAS;
+        return Collections.emptyList();
     }
     
     @Override

--- a/database/connector/dialect/sqlserver/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
+++ b/database/connector/dialect/sqlserver/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.database.connector.sql92.sqlserver.metadata.database.system.SQLServerSystemDatabase

--- a/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/system/SQLServerSystemDatabaseTest.java
+++ b/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/system/SQLServerSystemDatabaseTest.java
@@ -42,7 +42,7 @@ class SQLServerSystemDatabaseTest {
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("information_schema", "sys")));
+        assertTrue(systemDatabase.getSystemSchemas("foo_db").isEmpty());
     }
     
     @Test

--- a/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/system/SQLServerSystemDatabaseTest.java
+++ b/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/system/SQLServerSystemDatabaseTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.firebird.metadata.database.system;
+package org.apache.shardingsphere.database.connector.sql92.sqlserver.metadata.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -25,28 +25,28 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class FirebirdSystemDatabaseTest {
+class SQLServerSystemDatabaseTest {
     
-    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Firebird");
+    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "SQLServer");
     
     private final DialectSystemDatabase systemDatabase = DatabaseTypedSPILoader.getService(DialectSystemDatabase.class, databaseType);
     
     @Test
-    void assertGetSystemDatabases() {
+    void assertGetSystemDatabasesEmpty() {
         assertTrue(systemDatabase.getSystemDatabases().isEmpty());
     }
     
     @Test
     void assertGetSystemSchemasWithDatabaseName() {
-        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas("foo_db"), is(Arrays.asList("information_schema", "sys")));
     }
     
     @Test
     void assertGetSystemSchemas() {
-        assertThat(systemDatabase.getSystemSchemas(), is(Arrays.asList("system_lobs", "system_tables")));
+        assertThat(systemDatabase.getSystemSchemas(), is(Arrays.asList("information_schema", "sys")));
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseCapabilityOption.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseCapabilityOption.java
@@ -22,8 +22,6 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPI;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -89,15 +87,6 @@ public interface MCPDatabaseCapabilityOption extends TypedSPI {
      */
     default IdentifierCasePolicySet getIdentifierCasePolicySet() {
         return IdentifierCasePolicyFactory.newSensitivePolicySet();
-    }
-    
-    /**
-     * Get system schemas.
-     *
-     * @return system schemas
-     */
-    default Collection<String> getSystemSchemas() {
-        return List.of();
     }
     
     /**

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialect.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialect.java
@@ -172,12 +172,7 @@ public final class MCPDatabaseDialect {
     }
     
     private Collection<String> getSystemSchemas() {
-        Collection<String> optionSystemSchemas = option.map(MCPDatabaseCapabilityOption::getSystemSchemas).orElseGet(List::of);
-        return optionSystemSchemas.isEmpty() ? findDialectSystemSchemas().orElse(optionSystemSchemas) : optionSystemSchemas;
-    }
-    
-    private Optional<Collection<String>> findDialectSystemSchemas() {
-        return systemDatabase.map(SystemDatabase::getSystemSchemas).filter(each -> !each.isEmpty());
+        return systemDatabase.map(SystemDatabase::getSystemSchemas).filter(each -> !each.isEmpty()).orElseGet(List::of);
     }
     
     private static boolean containsSystemSchema(final Collection<String> systemSchemas, final String schemaName) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/ClickHouseMCPDatabaseCapabilityOption.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/ClickHouseMCPDatabaseCapabilityOption.java
@@ -21,9 +21,6 @@ import org.apache.shardingsphere.mcp.support.database.capability.SchemaExecution
 import org.apache.shardingsphere.mcp.support.database.capability.SchemaSemantics;
 import org.apache.shardingsphere.mcp.support.database.capability.TransactionCapability;
 
-import java.util.Collection;
-import java.util.List;
-
 /**
  * MCP database capability option for ClickHouse.
  */
@@ -31,10 +28,5 @@ public final class ClickHouseMCPDatabaseCapabilityOption extends AbstractMCPData
     
     public ClickHouseMCPDatabaseCapabilityOption() {
         super("ClickHouse", TransactionCapability.NONE, false, SchemaSemantics.DATABASE_AS_SCHEMA, SchemaExecutionSemantics.FIXED_TO_DATABASE, false, false);
-    }
-    
-    @Override
-    public Collection<String> getSystemSchemas() {
-        return List.of("information_schema");
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/FirebirdMCPDatabaseCapabilityOption.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/FirebirdMCPDatabaseCapabilityOption.java
@@ -21,8 +21,6 @@ import org.apache.shardingsphere.mcp.support.database.capability.SchemaExecution
 import org.apache.shardingsphere.mcp.support.database.capability.SchemaSemantics;
 import org.apache.shardingsphere.mcp.support.database.capability.TransactionCapability;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -36,11 +34,6 @@ public final class FirebirdMCPDatabaseCapabilityOption extends AbstractMCPDataba
     public FirebirdMCPDatabaseCapabilityOption() {
         super("Firebird", TransactionCapability.LOCAL_WITH_SAVEPOINT, true,
                 SchemaSemantics.NATIVE_SCHEMA, SchemaExecutionSemantics.BEST_EFFORT, true, true);
-    }
-    
-    @Override
-    public Collection<String> getSystemSchemas() {
-        return List.of("system_lobs", "system_tables");
     }
     
     @Override

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/HiveMCPDatabaseCapabilityOption.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/HiveMCPDatabaseCapabilityOption.java
@@ -21,9 +21,6 @@ import org.apache.shardingsphere.mcp.support.database.capability.SchemaExecution
 import org.apache.shardingsphere.mcp.support.database.capability.SchemaSemantics;
 import org.apache.shardingsphere.mcp.support.database.capability.TransactionCapability;
 
-import java.util.Collection;
-import java.util.List;
-
 /**
  * MCP database capability option for Hive.
  */
@@ -31,10 +28,5 @@ public final class HiveMCPDatabaseCapabilityOption extends AbstractMCPDatabaseCa
     
     public HiveMCPDatabaseCapabilityOption() {
         super("Hive", TransactionCapability.NONE, false, SchemaSemantics.DATABASE_AS_SCHEMA, SchemaExecutionSemantics.FIXED_TO_DATABASE, false, false);
-    }
-    
-    @Override
-    public Collection<String> getSystemSchemas() {
-        return List.of("information_schema", "sys");
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/OracleMCPDatabaseCapabilityOption.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/OracleMCPDatabaseCapabilityOption.java
@@ -21,8 +21,6 @@ import org.apache.shardingsphere.mcp.support.database.capability.SchemaExecution
 import org.apache.shardingsphere.mcp.support.database.capability.SchemaSemantics;
 import org.apache.shardingsphere.mcp.support.database.capability.TransactionCapability;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -35,11 +33,6 @@ public final class OracleMCPDatabaseCapabilityOption extends AbstractMCPDatabase
     public OracleMCPDatabaseCapabilityOption() {
         super("Oracle", TransactionCapability.LOCAL_WITH_SAVEPOINT, true,
                 SchemaSemantics.NATIVE_SCHEMA, SchemaExecutionSemantics.BEST_EFFORT, true, true);
-    }
-    
-    @Override
-    public Collection<String> getSystemSchemas() {
-        return List.of("sys", "system_lobs");
     }
     
     @Override

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/PrestoMCPDatabaseCapabilityOption.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/PrestoMCPDatabaseCapabilityOption.java
@@ -21,9 +21,6 @@ import org.apache.shardingsphere.mcp.support.database.capability.SchemaExecution
 import org.apache.shardingsphere.mcp.support.database.capability.SchemaSemantics;
 import org.apache.shardingsphere.mcp.support.database.capability.TransactionCapability;
 
-import java.util.Collection;
-import java.util.List;
-
 /**
  * MCP database capability option for Presto.
  */
@@ -31,11 +28,6 @@ public final class PrestoMCPDatabaseCapabilityOption extends AbstractMCPDatabase
     
     public PrestoMCPDatabaseCapabilityOption() {
         super("Presto", TransactionCapability.LOCAL, false, SchemaSemantics.NATIVE_SCHEMA, SchemaExecutionSemantics.BEST_EFFORT, true, false);
-    }
-    
-    @Override
-    public Collection<String> getSystemSchemas() {
-        return List.of("information_schema");
     }
     
     @Override

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/SQLServerMCPDatabaseCapabilityOption.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/dialect/SQLServerMCPDatabaseCapabilityOption.java
@@ -21,8 +21,6 @@ import org.apache.shardingsphere.mcp.support.database.capability.SchemaExecution
 import org.apache.shardingsphere.mcp.support.database.capability.SchemaSemantics;
 import org.apache.shardingsphere.mcp.support.database.capability.TransactionCapability;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -36,11 +34,6 @@ public final class SQLServerMCPDatabaseCapabilityOption extends AbstractMCPDatab
     public SQLServerMCPDatabaseCapabilityOption() {
         super("SQLServer", TransactionCapability.LOCAL_WITH_SAVEPOINT, true,
                 SchemaSemantics.NATIVE_SCHEMA, SchemaExecutionSemantics.BEST_EFFORT, true, true);
-    }
-    
-    @Override
-    public Collection<String> getSystemSchemas() {
-        return List.of("information_schema", "sys");
     }
     
     @Override

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialectTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialectTest.java
@@ -172,38 +172,6 @@ class MCPDatabaseDialectTest {
     }
     
     @Test
-    void assertIsSystemSchemaWithOptionSystemSchema() {
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            DatabaseType databaseType = mockDatabaseType("FixtureWithOption", typedSPILoader);
-            mockDialectDatabaseMetaDataAbsent(databaseType, databaseTypedSPILoader);
-            DialectSystemDatabase dialectSystemDatabase = mockDialectSystemDatabase(databaseType, databaseTypedSPILoader);
-            when(dialectSystemDatabase.getSystemSchemas()).thenReturn(List.of("dialect_system"));
-            MCPDatabaseCapabilityOption option = mockMCPDatabaseCapabilityOption("FixtureWithOption", typedSPILoader);
-            when(option.getSystemSchemas()).thenReturn(List.of("option_system"));
-            boolean actual = MCPDatabaseDialect.of("FixtureWithOption").isSystemSchema("option_system");
-            assertTrue(actual);
-        }
-    }
-    
-    @Test
-    void assertIsSystemSchemaIgnoresDifferentDialectSystemSchema() {
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            DatabaseType databaseType = mockDatabaseType("FixtureWithOption", typedSPILoader);
-            mockDialectDatabaseMetaDataAbsent(databaseType, databaseTypedSPILoader);
-            DialectSystemDatabase dialectSystemDatabase = mockDialectSystemDatabase(databaseType, databaseTypedSPILoader);
-            when(dialectSystemDatabase.getSystemSchemas()).thenReturn(List.of("dialect_system"));
-            MCPDatabaseCapabilityOption option = mockMCPDatabaseCapabilityOption("FixtureWithOption", typedSPILoader);
-            when(option.getSystemSchemas()).thenReturn(List.of("option_system"));
-            boolean actual = MCPDatabaseDialect.of("FixtureWithOption").isSystemSchema("dialect_system");
-            assertFalse(actual);
-        }
-    }
-    
-    @Test
     void assertIsSystemSchemaWithUserSchema() {
         boolean actual = MCPDatabaseDialect.of("MySQL").isSystemSchema("orders");
         assertFalse(actual);


### PR DESCRIPTION
Add DialectSystemDatabase implementations for ClickHouse, Hive, Oracle, Presto, and SQLServer, and complete Firebird system schema metadata.

Remove MCP option-level system schema fallback so MCP consumes the connector-owned dialect capability instead.