### PR TITLE
Fix wrong target class name in StaticMethodAdviceExecutor error logs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@
 1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
-1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#PR](https://github.com/apache/shardingsphere/pull/PR)
+1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)
 
 ### Enhancements
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,7 @@
 1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
+1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#PR](https://github.com/apache/shardingsphere/pull/PR)
 
 ### Enhancements
 

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/executor/type/StaticMethodAdviceExecutor.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/executor/type/StaticMethodAdviceExecutor.java
@@ -89,7 +89,7 @@ public final class StaticMethodAdviceExecutor implements AdviceExecutor {
             // CHECKSTYLE:OFF
         } catch (final Throwable ex) {
             // CHECKSTYLE:ON
-            LOGGER.log(Level.SEVERE, "Failed to execute the pre-method of method `{0}` in class `{1}`, {2}.", new String[]{method.getName(), klass.getClass().getName(), ex.getMessage()});
+            LOGGER.log(Level.SEVERE, "Failed to execute the pre-method of method `{0}` in class `{1}`, {2}.", new String[]{method.getName(), klass.getName(), ex.getMessage()});
         }
     }
     
@@ -105,7 +105,7 @@ public final class StaticMethodAdviceExecutor implements AdviceExecutor {
             // CHECKSTYLE:OFF
         } catch (final Throwable ignored) {
             // CHECKSTYLE:ON
-            LOGGER.log(Level.SEVERE, "Failed to execute the error handler of method `{0}` in class `{1}`, {2}.", new String[]{method.getName(), klass.getClass().getName(), ex.getMessage()});
+            LOGGER.log(Level.SEVERE, "Failed to execute the error handler of method `{0}` in class `{1}`, {2}.", new String[]{method.getName(), klass.getName(), ex.getMessage()});
         }
     }
     
@@ -121,7 +121,7 @@ public final class StaticMethodAdviceExecutor implements AdviceExecutor {
             // CHECKSTYLE:OFF
         } catch (final Throwable ex) {
             // CHECKSTYLE:ON
-            LOGGER.log(Level.SEVERE, "Failed to execute the post-method of method `{0}` in class `{1}` {2}.", new String[]{method.getName(), klass.getClass().getName(), ex.getMessage()});
+            LOGGER.log(Level.SEVERE, "Failed to execute the post-method of method `{0}` in class `{1}` {2}.", new String[]{method.getName(), klass.getName(), ex.getMessage()});
         }
     }
     

--- a/agent/core/src/test/java/org/apache/shardingsphere/agent/core/advisor/executor/type/StaticMethodAdviceExecutorTest.java
+++ b/agent/core/src/test/java/org/apache/shardingsphere/agent/core/advisor/executor/type/StaticMethodAdviceExecutorTest.java
@@ -38,6 +38,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -129,6 +132,68 @@ class StaticMethodAdviceExecutorTest {
         assertThat(queue, is(Arrays.asList("first before foo", "second before bar", "origin call")));
     }
     
+    @Test
+    void assertAdviceLogsTargetClassNameWhenBeforeThrows() throws ReflectiveOperationException {
+        List<String> queue = new LinkedList<>();
+        Map<String, Collection<StaticMethodAdvice>> advices = Collections.singletonMap(
+                "foo", Collections.singletonList(new ConfigurableStaticMethodAdvice(queue, "first", true, true, false, false)));
+        StaticMethodAdviceExecutor executor = new StaticMethodAdviceExecutor(advices);
+        Method method = TargetObjectFixture.class.getMethod("staticCall", List.class);
+        Callable<Object> callable = () -> "result";
+        List<LogRecord> records = new LinkedList<>();
+        Logger logger = Logger.getLogger(StaticMethodAdviceExecutor.class.getName());
+        Handler handler = new RecordingHandler(records);
+        logger.addHandler(handler);
+        try {
+            executor.advice(TargetObjectFixture.class, method, new Object[]{queue}, callable);
+            assertThat(records.get(0).getParameters()[1], is(TargetObjectFixture.class.getName()));
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+    
+    @Test
+    void assertAdviceLogsTargetClassNameWhenThrowingThrows() throws ReflectiveOperationException {
+        List<String> queue = new LinkedList<>();
+        Map<String, Collection<StaticMethodAdvice>> advices = Collections.singletonMap(
+                "foo", Collections.singletonList(new ConfigurableStaticMethodAdvice(queue, "first", true, false, false, true)));
+        StaticMethodAdviceExecutor executor = new StaticMethodAdviceExecutor(advices);
+        Method method = TargetObjectFixture.class.getMethod("staticCallWhenExceptionThrown", List.class);
+        Callable<Object> callable = () -> {
+            throw new IllegalStateException("callable error");
+        };
+        List<LogRecord> records = new LinkedList<>();
+        Logger logger = Logger.getLogger(StaticMethodAdviceExecutor.class.getName());
+        Handler handler = new RecordingHandler(records);
+        logger.addHandler(handler);
+        try {
+            assertThrows(IllegalStateException.class, () -> executor.advice(TargetObjectFixture.class, method, new Object[]{queue}, callable));
+            assertThat(records.get(0).getParameters()[1], is(TargetObjectFixture.class.getName()));
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+    
+    @Test
+    void assertAdviceLogsTargetClassNameWhenAfterThrows() throws ReflectiveOperationException {
+        List<String> queue = new LinkedList<>();
+        Map<String, Collection<StaticMethodAdvice>> advices = Collections.singletonMap(
+                "foo", Collections.singletonList(new ConfigurableStaticMethodAdvice(queue, "first", true, false, true, false)));
+        StaticMethodAdviceExecutor executor = new StaticMethodAdviceExecutor(advices);
+        Method method = TargetObjectFixture.class.getMethod("staticCall", List.class);
+        Callable<Object> callable = () -> "result";
+        List<LogRecord> records = new LinkedList<>();
+        Logger logger = Logger.getLogger(StaticMethodAdviceExecutor.class.getName());
+        Handler handler = new RecordingHandler(records);
+        logger.addHandler(handler);
+        try {
+            executor.advice(TargetObjectFixture.class, method, new Object[]{queue}, callable);
+            assertThat(records.get(0).getParameters()[1], is(TargetObjectFixture.class.getName()));
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+    
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     void assertIntercept() {
@@ -140,6 +205,25 @@ class StaticMethodAdviceExecutorTest {
         when(implementationDefinition.intercept(any())).thenReturn((ReceiverTypeDefinition) intercepted);
         AdviceExecutor executor = new StaticMethodAdviceExecutor(Collections.emptyMap());
         assertThat(executor.intercept(builder, methodDescription), is(intercepted));
+    }
+    
+    @RequiredArgsConstructor
+    private static final class RecordingHandler extends Handler {
+        
+        private final List<LogRecord> records;
+        
+        @Override
+        public void publish(final LogRecord record) {
+            records.add(record);
+        }
+        
+        @Override
+        public void flush() {
+        }
+        
+        @Override
+        public void close() {
+        }
     }
     
     @RequiredArgsConstructor


### PR DESCRIPTION
Fixes #39076.

Changes proposed in this pull request:
  - Replace `klass.getClass().getName()` with `klass.getName()` in the three error handlers of `StaticMethodAdviceExecutor` (`adviceBefore`, `adviceThrow`, `adviceAfter`).
  - `klass` is the `@Origin final Class<?>` target class, so `klass.getClass()` always resolved to `java.lang.Class`, making every failure log report `java.lang.Class` instead of the instrumented class.
  - Aligns with the sibling `InstanceMethodAdviceExecutor`, which correctly uses `target.getClass().getName()` because `target` is an instance.
  - Add focused log assertions for the before, throwing, and after failure paths to verify each SEVERE `LogRecord` reports the real target class name.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)


