### PR TITLE
Remove stale LOCK state from proxy_state metric description

### DIFF
--- a/agent/plugins/metrics/core/src/main/java/org/apache/shardingsphere/agent/plugin/metrics/core/exporter/impl/proxy/ProxyStateExporter.java
+++ b/agent/plugins/metrics/core/src/main/java/org/apache/shardingsphere/agent/plugin/metrics/core/exporter/impl/proxy/ProxyStateExporter.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public final class ProxyStateExporter implements MetricsExporter {
     
     private final MetricConfiguration config = new MetricConfiguration("proxy_state",
-            MetricCollectorType.GAUGE_METRIC_FAMILY, "State of ShardingSphere-Proxy. 0 is OK; 1 is CIRCUIT BREAK; 2 is LOCK", Collections.emptyList(), Collections.emptyMap());
+            MetricCollectorType.GAUGE_METRIC_FAMILY, "State of ShardingSphere-Proxy. 0 is OK; 1 is CIRCUIT BREAK", Collections.emptyList(), Collections.emptyMap());
     
     @Override
     public Optional<GaugeMetricFamilyMetricsCollector> export(final String pluginType) {

--- a/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.en.md
@@ -125,7 +125,7 @@ After startup, you can find the plugin info in the log of ShardingSphere-Proxy, 
 | routed_sql_total             | COUNTER   | Total count of routed by database and SQL type (INSERT, UPDATE, DELETE, SELECT)                                                           |
 | routed_storage_unit_total    | COUNTER   | Total count of routed by storage unit of database                                                                                         |
 | routed_table_total           | COUNTER   | Total count of routed by table of database                                                                                                |
-| proxy_state                  | GAUGE     | Status information of ShardingSphere-Proxy. 0 is OK; 1 is CIRCUIT BREAK; 2 is LOCK                                                        |
+| proxy_state                  | GAUGE     | Status information of ShardingSphere-Proxy. 0 is OK; 1 is CIRCUIT BREAK                                                                   |
 | proxy_meta_data_info         | GAUGE     | Meta data information of ShardingSphere-Proxy. database_count is logic number of databases; storage_unit_count is number of storage units |
 | proxy_current_connections    | GAUGE     | Current connections of ShardingSphere-Proxy                                                                                               |
 | proxy_requests_total         | COUNTER   | Total requests of ShardingSphere-Proxy                                                                                                    |


### PR DESCRIPTION
No issue: non-behavioral description typo fix.

Changes proposed in this pull request:
  - Drop the stale `2 is LOCK` reference from the `proxy_state` metric description in `ProxyStateExporter`; the `LOCK` value of `InstanceState` was removed by merged PR #31312, leaving only `OK` (0) and `CIRCUIT_BREAK` (1), so ordinal 2 can never be emitted.
  - Apply the same correction to the `proxy_state` row in the proxy observability user manual (`shardingsphere-proxy/observability/_index.en.md`) so the docs match the code.
  - Aligns with the sibling `JDBCStateExporter`, whose description was already corrected to `0 is OK; 1 is CIRCUIT BREAK`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
