### PR TITLE
Remove redundant MCP EXPLAIN execution semantics

### DIFF
--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPSQLRecoveryPayloadFactory.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPSQLRecoveryPayloadFactory.java
@@ -66,7 +66,8 @@ final class MCPSQLRecoveryPayloadFactory {
         result.put("rejected_explain_sql", cause.getExplainSql());
         result.put("suggested_arguments", createExplainRetryArguments(cause));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, MCPNextActionUtils.ordered(
-                MCPNextActionUtils.readResource(createDatabaseCapabilityUri(cause.getDatabase()), "Read explain tool semantics before regenerating explain_sql."),
+                MCPNextActionUtils.readResource(createDatabaseCapabilityUri(cause.getDatabase()),
+                        "Read the target database type before regenerating database-native explain_sql."),
                 MCPNextActionUtils.dependsOn(MCPNextActionUtils.callTool("database_gateway_execute_explain_query",
                         "Regenerate explain_sql from sql without changing sql, then retry the explain tool with the generated explain_sql.",
                         createExplainRetryArguments(cause)), 1)));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorConverterTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorConverterTest.java
@@ -295,8 +295,10 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("category"), is("invalid_explain_sql"));
         assertThat(actualRecovery.get("rejected_explain_sql"), is("EXPLAIN BROKEN SELECT * FROM orders"));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("database", "logic_db", "schema", "public", "sql", "SELECT * FROM orders")));
-        Map<?, ?> actualRetryAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).get(1);
-        assertThat(actualRetryAction.get("tool_name"), is("database_gateway_execute_explain_query"));
+        List<?> actualNextActions = (List<?>) actualRecovery.get("next_actions");
+        assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("reason"),
+                is("Read the target database type before regenerating database-native explain_sql."));
+        assertThat(((Map<?, ?>) actualNextActions.get(1)).get("tool_name"), is("database_gateway_execute_explain_query"));
         assertFalse((Boolean) actualRecovery.get("ask_user_when_uncertain"));
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/response/MCPDatabaseCapabilityResponse.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/response/MCPDatabaseCapabilityResponse.java
@@ -46,11 +46,7 @@ public final class MCPDatabaseCapabilityResponse implements MCPResponse {
         result.put("defaultSchemaSemantics", databaseCapability.getDefaultSchemaSemantics());
         result.put("schemaExecutionSemantics", databaseCapability.getSchemaExecutionSemantics());
         result.put("supportsCrossSchemaSql", databaseCapability.isSupportsCrossSchemaSql());
-        boolean supportsExplain = databaseCapability.isSupportsExplain();
-        result.put("supportsExplain", supportsExplain);
-        result.put("explainExecutionSemantics", supportsExplain
-                ? "database_gateway_execute_explain_query executes model-generated database-native EXPLAIN SQL for one classifier-approved SELECT. EXPLAIN ANALYZE is not supported."
-                : "database_gateway_execute_explain_query is not supported for this database type.");
+        result.put("supportsExplain", databaseCapability.isSupportsExplain());
         return result;
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/response/MCPDatabaseCapabilityResponseTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/response/MCPDatabaseCapabilityResponseTest.java
@@ -40,7 +40,7 @@ class MCPDatabaseCapabilityResponseTest {
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("assertToPayloadArguments")
-    void assertToPayload(final String name, final boolean supportsExplain, final String explainExecutionSemantics) {
+    void assertToPayload(final String name, final boolean supportsExplain) {
         MCPDatabaseCapability actualCapability = mock(MCPDatabaseCapability.class);
         when(actualCapability.getDatabaseName()).thenReturn("logic_db");
         when(actualCapability.getDatabaseType()).thenReturn("FixtureDB");
@@ -70,14 +70,12 @@ class MCPDatabaseCapabilityResponseTest {
                 Map.entry("defaultSchemaSemantics", DialectSchemaSemantics.DATABASE_AS_SCHEMA),
                 Map.entry("schemaExecutionSemantics", SchemaExecutionSemantics.FIXED_TO_DATABASE),
                 Map.entry("supportsCrossSchemaSql", false),
-                Map.entry("supportsExplain", supportsExplain),
-                Map.entry("explainExecutionSemantics", explainExecutionSemantics))));
+                Map.entry("supportsExplain", supportsExplain))));
     }
     
     private static Stream<Arguments> assertToPayloadArguments() {
         return Stream.of(
-                Arguments.of("supported", true,
-                        "database_gateway_execute_explain_query executes model-generated database-native EXPLAIN SQL for one classifier-approved SELECT. EXPLAIN ANALYZE is not supported."),
-                Arguments.of("unsupported", false, "database_gateway_execute_explain_query is not supported for this database type."));
+                Arguments.of("supported", true),
+                Arguments.of("unsupported", false));
     }
 }


### PR DESCRIPTION
Keep supportsExplain as the machine-readable capability and update EXPLAIN recovery guidance to use the target database type.
