### PR TITLE
Optimize MCP E2E build and test workflow

### DIFF
--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -65,79 +65,17 @@ jobs:
         run: |
           docker version
           docker system df
-      - name: Load MCP E2E Properties
-        id: mcp-e2e-properties
-        shell: bash
-        run: |
-          set -euo pipefail
-          property_file="test/e2e/mcp/src/test/resources/env/e2e-env.properties"
-          load_property() {
-            local value
-            value="$(awk -F= -v key="$1" '$1 == key {sub(/^[^=]*=/, ""); print; found = 1; exit} END {if (!found) exit 1}' "${property_file}")"
-            if [[ -z "${value}" ]]; then
-              echo "MCP E2E property is required: $1" >&2
-              exit 1
-            fi
-            printf '%s' "${value}"
-          }
-          load_optional_property() {
-            awk -F= -v key="$1" '$1 == key {sub(/^[^=]*=/, ""); print; found = 1; exit} END {if (!found) exit 1}' "${property_file}" || true
-          }
-          normalize_arch() {
-            case "$1" in
-              x86_64)
-                echo "amd64"
-                ;;
-              aarch64)
-                echo "arm64"
-                ;;
-              *)
-                echo "$1"
-                ;;
-            esac
-          }
-          target_platform="$(load_optional_property 'mcp.llm.target-platform')"
-          if [[ -z "${target_platform}" ]]; then
-            target_platform="$(docker version --format '{{.Server.Os}}')/$(normalize_arch "$(docker version --format '{{.Server.Arch}}')")"
-          fi
-          base_server_image="$(load_property 'mcp.llm.base-server-image')"
-          base_server_image_digest="$(load_optional_property 'mcp.llm.base-server-image-digest')"
-          if [[ "${base_server_image}" != *@sha256:* && -n "${base_server_image_digest}" ]]; then
-            base_server_image="${base_server_image}@${base_server_image_digest}"
-          fi
-          {
-            echo "target_platform=${target_platform}"
-            echo "server_image=$(load_property 'mcp.llm.server-image')"
-            echo "base_server_image=${base_server_image}"
-            echo "model_repository=$(load_property 'mcp.llm.model-repository')"
-            echo "model_quantization=$(load_property 'mcp.llm.model-quantization')"
-            echo "model_reference=$(load_property 'mcp.llm.model')"
-            echo "model_revision=$(load_property 'mcp.llm.model-revision')"
-            echo "model_file_name=$(load_property 'mcp.llm.model-file-name')"
-            echo "model_sha256=$(load_property 'mcp.llm.model-sha256')"
-          } >> "${GITHUB_OUTPUT}"
-      - name: Build MCP E2E Test Dependencies
-        run: ./mvnw -pl test/e2e/mcp -am install -DskipTests -DskipITs -Dspotless.skip=true -B -ntp
-      - name: Package MCP Distribution
-        run: ./mvnw -pl distribution/mcp -am -DskipTests package -B -ntp
+      - name: Build MCP E2E Test Dependencies and Distribution
+        run: ./mvnw -pl test/e2e/mcp,distribution/mcp -am install -DskipTests -DskipITs -Dspotless.skip=true -B -ntp
+      - name: Run MCP E2E Harness Tests
+        run: ./mvnw -pl test/e2e/mcp test -DskipITs -Dspotless.skip=true -Dtest='*Test,!*E2ETest' -Dsurefire.failIfNoSpecifiedTests=true -T1C -B -ntp
       - name: Build MCP Distribution Image
-        run: docker build --platform "${{ steps.mcp-e2e-properties.outputs.target_platform }}" -f distribution/mcp/Dockerfile -t "${{ env.MCP_DISTRIBUTION_IMAGE }}" distribution/mcp/target
-      - name: Build MCP LLM Runtime Image
-        shell: bash
         run: |
-          set -euo pipefail
           docker build \
-            --platform "${{ steps.mcp-e2e-properties.outputs.target_platform }}" \
-            -f test/e2e/mcp/src/test/resources/docker/llm-runtime/Dockerfile \
-            -t "${{ steps.mcp-e2e-properties.outputs.server_image }}" \
-            --build-arg "BASE_IMAGE=${{ steps.mcp-e2e-properties.outputs.base_server_image }}" \
-            --build-arg "MODEL_REPOSITORY=${{ steps.mcp-e2e-properties.outputs.model_repository }}" \
-            --build-arg "MODEL_QUANTIZATION=${{ steps.mcp-e2e-properties.outputs.model_quantization }}" \
-            --build-arg "MODEL_REFERENCE=${{ steps.mcp-e2e-properties.outputs.model_reference }}" \
-            --build-arg "MODEL_REVISION=${{ steps.mcp-e2e-properties.outputs.model_revision }}" \
-            --build-arg "MODEL_FILE_NAME=${{ steps.mcp-e2e-properties.outputs.model_file_name }}" \
-            --build-arg "MODEL_SHA256=${{ steps.mcp-e2e-properties.outputs.model_sha256 }}" \
-            test/e2e/mcp/src/test/resources/docker/llm-runtime
+            --platform "$(docker version --format '{{.Server.Os}}/{{.Server.Arch}}')" \
+            -f distribution/mcp/Dockerfile \
+            -t "${{ env.MCP_DISTRIBUTION_IMAGE }}" \
+            distribution/mcp/target
       - name: Package MCP Distribution Home
         shell: bash
         run: |
@@ -157,6 +95,31 @@ jobs:
           artifact-dir: ${{ runner.temp }}/mcp-e2e-build-artifacts
           docker-images: |
             ${{ env.MCP_DISTRIBUTION_IMAGE }}=mcp-distribution-image.tar
+
+  e2e-mcp-build-llm-image:
+    name: E2E - MCP Build LLM Image
+    if: github.repository == 'apache/shardingsphere'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6.0.1
+      - name: Check Docker Environment
+        run: |
+          docker version
+          docker system df
+      - name: Build MCP LLM Runtime Image
+        id: mcp-llm-runtime-image
+        shell: bash
+        run: |
+          set -euo pipefail
+          build_script="test/e2e/mcp/src/test/resources/docker/llm-runtime/build-local.sh"
+          image_tag="$(sh "${build_script}" --print | sed -n 's/^image_tag=//p')"
+          if [[ -z "${image_tag}" || "${image_tag}" == *$'\n'* ]]; then
+            echo "MCP LLM build script must print exactly one non-empty image_tag." >&2
+            exit 1
+          fi
+          printf 'image_tag=%s\n' "${image_tag}" >> "${GITHUB_OUTPUT}"
+          sh "${build_script}"
       - name: Upload MCP LLM Runtime Image
         uses: ./.github/workflows/resources/actions/upload-e2e-artifacts
         with:
@@ -164,7 +127,7 @@ jobs:
           artifact-dir: ${{ runner.temp }}/mcp-e2e-llm-runtime-artifacts
           include-maven-repository: 'false'
           docker-images: |
-            ${{ steps.mcp-e2e-properties.outputs.server_image }}=mcp-llm-runtime-image.tar
+            ${{ steps.mcp-llm-runtime-image.outputs.image_tag }}=mcp-llm-runtime-image.tar
 
   e2e-mcp-core:
     name: E2E - MCP Core
@@ -214,7 +177,7 @@ jobs:
   e2e-mcp-llm:
     name: E2E - MCP LLM
     if: github.repository == 'apache/shardingsphere'
-    needs: e2e-mcp-build-images
+    needs: [ e2e-mcp-build-images, e2e-mcp-build-llm-image ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
- run Harness unit tests before E2E jobs
- combine Maven reactors for test and distribution artifacts
- isolate the LLM image build and reuse build-local.sh