### PR TITLE
Add get connection attributes for PostgreSQL and openGauss

### DIFF
--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/handshake/PostgreSQLComStartupPacket.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/handshake/PostgreSQLComStartupPacket.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.database.protocol.postgresql.payload.PostgreSQL
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Startup packet for PostgreSQL.
@@ -73,6 +74,22 @@ public final class PostgreSQLComStartupPacket extends PostgreSQLPacket {
      */
     public String getClientEncoding() {
         return parametersMap.getOrDefault(CLIENT_ENCODING_KEY, "UTF8");
+    }
+    
+    /**
+     * Get connection attributes.
+     *
+     * @return connection attributes
+     */
+    public Map<String, String> getConnectionAttributes() {
+        Map<String, String> result = new HashMap<>(parametersMap.size());
+        for (Entry<String, String> entry : parametersMap.entrySet()) {
+            if (DATABASE_NAME_KEY.equalsIgnoreCase(entry.getKey()) || USER_NAME_KEY.equalsIgnoreCase(entry.getKey()) || CLIENT_ENCODING_KEY.equalsIgnoreCase(entry.getKey())) {
+                continue;
+            }
+            result.put(entry.getKey(), entry.getValue());
+        }
+        return result;
     }
     
     @Override

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/handshake/PostgreSQLComStartupPacketTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/handshake/PostgreSQLComStartupPacketTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.database.protocol.postgresql.payload.PostgreSQL
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -47,8 +48,17 @@ class PostgreSQLComStartupPacketTest {
         assertThat(byteBuf.writerIndex(), is(packetMessageLength));
     }
     
+    @Test
+    void assertGetConnectionAttributes() {
+        Map<String, String> parametersMap = createParametersMap();
+        parametersMap.put("application_name", "foo_app");
+        int packetMessageLength = getPacketMessageLength(parametersMap);
+        PostgreSQLPacketPayload payload = createPayload(parametersMap, packetMessageLength, ByteBufTestUtils.createByteBuf(packetMessageLength));
+        assertThat(new PostgreSQLComStartupPacket(payload).getConnectionAttributes(), is(Collections.singletonMap("application_name", "foo_app")));
+    }
+    
     private Map<String, String> createParametersMap() {
-        Map<String, String> result = new LinkedHashMap<>(2, 1F);
+        Map<String, String> result = new LinkedHashMap<>(3, 1F);
         result.put("database", "test_db");
         result.put("user", "postgres");
         result.put("client_encoding", "UTF8");

--- a/proxy/frontend/dialect/opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/authentication/OpenGaussAuthenticationEngine.java
+++ b/proxy/frontend/dialect/opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/authentication/OpenGaussAuthenticationEngine.java
@@ -63,7 +63,6 @@ import org.apache.shardingsphere.proxy.frontend.connection.ConnectionIdGenerator
 import org.apache.shardingsphere.proxy.frontend.opengauss.authentication.authenticator.OpenGaussAuthenticatorType;
 import org.apache.shardingsphere.proxy.frontend.ssl.ProxySSLContext;
 
-import java.util.Collections;
 import java.util.Optional;
 
 /**
@@ -159,7 +158,7 @@ public final class OpenGaussAuthenticationEngine implements AuthenticationEngine
         String username = startupPacket.getUsername();
         ShardingSpherePreconditions.checkNotEmpty(username, EmptyUsernameException::new);
         context.writeAndFlush(getIdentifierPacket(username, rule, startupPacket.getVersion()));
-        currentAuthResult = AuthenticationResultBuilder.continued(username, "", startupPacket.getDatabase(), Collections.emptyMap());
+        currentAuthResult = AuthenticationResultBuilder.continued(username, "", startupPacket.getDatabase(), startupPacket.getConnectionAttributes());
         return currentAuthResult;
     }
     

--- a/proxy/frontend/dialect/opengauss/src/test/java/org/apache/shardingsphere/proxy/frontend/opengauss/authentication/OpenGaussAuthenticationEngineTest.java
+++ b/proxy/frontend/dialect/opengauss/src/test/java/org/apache/shardingsphere/proxy/frontend/opengauss/authentication/OpenGaussAuthenticationEngineTest.java
@@ -200,11 +200,12 @@ class OpenGaussAuthenticationEngineTest {
                 authenticators, PostgreSQLAuthenticationMethod.MD5.getMethodName(), new AlgorithmConfiguration("ALL_PERMITTED", new Properties()));
         MetaDataContexts metaDataContexts = createMetaDataContexts(authorityRule, true, DATABASE_NAME);
         mockProxyContext(metaDataContexts);
-        PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, DATABASE_NAME, OpenGaussProtocolVersion.PROTOCOL_351.getVersion());
+        PostgreSQLPacketPayload payload = createStartupPayloadWithConnectionAttributes();
         AuthenticationResult actual = authenticationEngine.authenticate(channelHandlerContext, payload);
         verify(channelHandlerContext).writeAndFlush(any(PostgreSQLMD5PasswordAuthenticationPacket.class));
         assertFalse(actual.isFinished());
         assertThat(getMd5Salt(authenticationEngine).length, is(4));
+        assertThat(actual.getConnectionAttributes(), is(Collections.singletonMap("application_name", "foo_app")));
     }
     
     @Test
@@ -347,6 +348,13 @@ class OpenGaussAuthenticationEngineTest {
         payload.writeStringNul("client_encoding");
         payload.writeStringNul("UTF8");
         return payload;
+    }
+    
+    private PostgreSQLPacketPayload createStartupPayloadWithConnectionAttributes() {
+        PostgreSQLPacketPayload result = createStartupPayload(USERNAME, DATABASE_NAME, OpenGaussProtocolVersion.PROTOCOL_351.getVersion());
+        result.writeStringNul("application_name");
+        result.writeStringNul("foo_app");
+        return result;
     }
     
     private PostgreSQLPacketPayload createPasswordMessage(final String digest) {

--- a/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
+++ b/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
@@ -27,8 +27,8 @@ import org.apache.shardingsphere.authentication.result.AuthenticationResultBuild
 import org.apache.shardingsphere.authority.checker.AuthorityChecker;
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.database.exception.core.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.database.exception.core.exception.data.InvalidParameterValueException;
+import org.apache.shardingsphere.database.exception.core.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.database.exception.postgresql.exception.authority.EmptyUsernameException;
 import org.apache.shardingsphere.database.exception.postgresql.exception.authority.InvalidPasswordException;
 import org.apache.shardingsphere.database.exception.postgresql.exception.authority.PrivilegeNotGrantedException;
@@ -63,7 +63,6 @@ import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authen
 import org.apache.shardingsphere.proxy.frontend.ssl.ProxySSLContext;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -143,7 +142,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         ShardingSpherePreconditions.checkNotEmpty(username, EmptyUsernameException::new);
         startupMessageReceived = true;
         context.writeAndFlush(getIdentifierPacket(username, rule));
-        currentAuthResult = AuthenticationResultBuilder.continued(username, "", startupPacket.getDatabase(), Collections.emptyMap());
+        currentAuthResult = AuthenticationResultBuilder.continued(username, "", startupPacket.getDatabase(), startupPacket.getConnectionAttributes());
         return currentAuthResult;
     }
     

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
@@ -189,11 +189,12 @@ class PostgreSQLAuthenticationEngineTest {
         MetaDataContexts metaDataContexts = createMetaDataContexts(authorityRule, false, null);
         ContextManager contextManager = mockContextManager(metaDataContexts);
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
-        AuthenticationResult actual = authenticationEngine.authenticate(channelHandlerContext, createStartupPayload(USERNAME, DATABASE_NAME));
+        AuthenticationResult actual = authenticationEngine.authenticate(channelHandlerContext, createStartupPayloadWithConnectionAttributes());
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(channelHandlerContext).writeAndFlush(argumentCaptor.capture());
         assertThat(argumentCaptor.getValue().getClass(), is((Object) PostgreSQLPasswordAuthenticationPacket.class));
         assertFalse(actual.isFinished());
+        assertThat(actual.getConnectionAttributes(), is(Collections.singletonMap("application_name", "foo_app")));
     }
     
     @Test
@@ -365,6 +366,13 @@ class PostgreSQLAuthenticationEngineTest {
             payload.writeStringNul(clientEncoding);
         }
         return payload;
+    }
+    
+    private PostgreSQLPacketPayload createStartupPayloadWithConnectionAttributes() {
+        PostgreSQLPacketPayload result = createStartupPayload(USERNAME, DATABASE_NAME);
+        result.writeStringNul("application_name");
+        result.writeStringNul("foo_app");
+        return result;
     }
     
     private PostgreSQLPacketPayload createPasswordMessage(final String digest) {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add get connection attributes for PostgreSQL and openGauss

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
