### PR TITLE
Support view table type in openGauss meta data loader

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -54,6 +54,7 @@
 
 ### Enhancements
 
+1. Metadata: Support view table type in openGauss meta data loader - [#39097](https://github.com/apache/shardingsphere/pull/39097)
 1. Build: Support compiling and using ShardingSphere under OpenJDK 26 - [#38625](https://github.com/apache/shardingsphere/issues/38625)
 1. SQL Parser: Support Hive OPTIMIZE Statement about iceberg statement parse - [#38877](https://github.com/apache/shardingsphere/pull/38877)
 1. SQL Parser: Support Hive DELETE ORPHAN-FILES Statement about iceberg statement parse - [#38669](https://github.com/apache/shardingsphere/pull/38669)

--- a/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussMetaDataLoader.java
+++ b/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussMetaDataLoader.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.model.Ind
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.SchemaMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.TableMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.datatype.DataTypeRegistry;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -70,17 +71,21 @@ public final class OpenGaussMetaDataLoader implements DialectMetaDataLoader {
                     + " FROM pg_index pgi JOIN pg_class idx ON idx.oid = pgi.indexrelid JOIN pg_namespace insp ON insp.oid = idx.relnamespace JOIN pg_class tbl ON tbl.oid = pgi.indrelid"
                     + " JOIN pg_namespace tnsp ON tnsp.oid = tbl.relnamespace JOIN pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = ANY(pgi.indkey) WHERE tnsp.nspname IN (%s)";
     
+    private static final String VIEW_META_DATA_SQL = "SELECT table_schema, table_name FROM information_schema.views WHERE table_schema IN (%s) and table_name IN (%s)";
+    
     @Override
     public Collection<SchemaMetaData> load(final MetaDataLoaderMaterial material) throws SQLException {
         try (Connection connection = material.getDataSource().getConnection()) {
             Collection<String> schemaNames = new SchemaMetaDataLoader(getType()).loadSchemaNames(connection);
             Map<String, Multimap<String, IndexMetaData>> schemaIndexMetaDataMap = loadIndexMetaDataMap(connection, schemaNames);
             Map<String, Multimap<String, ColumnMetaData>> schemaColumnMetaDataMap = loadColumnMetaDataMap(connection, material.getActualTableNames(), schemaNames);
+            Map<String, Collection<String>> schemaViewNames = loadViewNames(connection, schemaNames, material.getActualTableNames());
             Collection<SchemaMetaData> result = new LinkedList<>();
             for (String each : schemaNames) {
                 Multimap<String, IndexMetaData> tableIndexMetaDataMap = schemaIndexMetaDataMap.getOrDefault(each, LinkedHashMultimap.create());
                 Multimap<String, ColumnMetaData> tableColumnMetaDataMap = schemaColumnMetaDataMap.getOrDefault(each, LinkedHashMultimap.create());
-                result.add(new SchemaMetaData(each, createTableMetaDataList(tableIndexMetaDataMap, tableColumnMetaDataMap)));
+                Collection<String> viewNames = schemaViewNames.getOrDefault(each, Collections.emptySet());
+                result.add(new SchemaMetaData(each, createTableMetaDataList(tableIndexMetaDataMap, tableColumnMetaDataMap, viewNames)));
             }
             return result;
         }
@@ -186,12 +191,33 @@ public final class OpenGaussMetaDataLoader implements DialectMetaDataLoader {
         return new ColumnMetaData(columnName, DataTypeRegistry.getDataType(getDatabaseType(), dataType).orElse(Types.OTHER), isPrimaryKey, generated, caseSensitive, true, false, isNullable);
     }
     
-    private Collection<TableMetaData> createTableMetaDataList(final Multimap<String, IndexMetaData> tableIndexMetaDataMap, final Multimap<String, ColumnMetaData> tableColumnMetaDataMap) {
+    private Map<String, Collection<String>> loadViewNames(final Connection connection, final Collection<String> schemaNames, final Collection<String> tables) throws SQLException {
+        Map<String, Collection<String>> result = new LinkedHashMap<>(schemaNames.size(), 1F);
+        try (
+                PreparedStatement preparedStatement = connection.prepareStatement(getViewMetaDataSQL(schemaNames, tables));
+                ResultSet resultSet = preparedStatement.executeQuery()) {
+            while (resultSet.next()) {
+                String schemaName = resultSet.getString("table_schema");
+                Collection<String> viewMetaData = result.computeIfAbsent(schemaName, key -> new HashSet<>());
+                String tableName = resultSet.getString("table_name");
+                viewMetaData.add(tableName);
+            }
+        }
+        return result;
+    }
+    
+    private String getViewMetaDataSQL(final Collection<String> schemaNames, final Collection<String> tables) {
+        return String.format(VIEW_META_DATA_SQL, schemaNames.stream().map(each -> String.format("'%s'", each)).collect(Collectors.joining(",")),
+                tables.stream().map(each -> String.format("'%s'", each)).collect(Collectors.joining(",")));
+    }
+    
+    private Collection<TableMetaData> createTableMetaDataList(final Multimap<String, IndexMetaData> tableIndexMetaDataMap, final Multimap<String, ColumnMetaData> tableColumnMetaDataMap,
+                                                              final Collection<String> viewNames) {
         Collection<TableMetaData> result = new LinkedList<>();
         for (String each : tableColumnMetaDataMap.keySet()) {
             Collection<ColumnMetaData> columnMetaDataList = tableColumnMetaDataMap.get(each);
             Collection<IndexMetaData> indexMetaDataList = tableIndexMetaDataMap.get(each);
-            result.add(new TableMetaData(each, columnMetaDataList, indexMetaDataList, Collections.emptyList()));
+            result.add(new TableMetaData(each, columnMetaDataList, indexMetaDataList, Collections.emptyList(), viewNames.contains(each) ? TableType.VIEW : TableType.TABLE));
         }
         return result;
     }

--- a/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussMetaDataLoader.java
+++ b/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussMetaDataLoader.java
@@ -71,7 +71,11 @@ public final class OpenGaussMetaDataLoader implements DialectMetaDataLoader {
                     + " FROM pg_index pgi JOIN pg_class idx ON idx.oid = pgi.indexrelid JOIN pg_namespace insp ON insp.oid = idx.relnamespace JOIN pg_class tbl ON tbl.oid = pgi.indrelid"
                     + " JOIN pg_namespace tnsp ON tnsp.oid = tbl.relnamespace JOIN pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = ANY(pgi.indkey) WHERE tnsp.nspname IN (%s)";
     
-    private static final String VIEW_META_DATA_SQL = "SELECT table_schema, table_name FROM information_schema.views WHERE table_schema IN (%s) and table_name IN (%s)";
+    private static final String BASIC_VIEW_META_DATA_SQL = "SELECT table_schema, table_name FROM information_schema.views WHERE table_schema IN (%s)";
+    
+    private static final String VIEW_META_DATA_SQL_WITHOUT_TABLES = BASIC_VIEW_META_DATA_SQL;
+    
+    private static final String VIEW_META_DATA_SQL_WITH_TABLES = BASIC_VIEW_META_DATA_SQL + " AND table_name IN (%s)";
     
     @Override
     public Collection<SchemaMetaData> load(final MetaDataLoaderMaterial material) throws SQLException {
@@ -207,8 +211,9 @@ public final class OpenGaussMetaDataLoader implements DialectMetaDataLoader {
     }
     
     private String getViewMetaDataSQL(final Collection<String> schemaNames, final Collection<String> tables) {
-        return String.format(VIEW_META_DATA_SQL, schemaNames.stream().map(each -> String.format("'%s'", each)).collect(Collectors.joining(",")),
-                tables.stream().map(each -> String.format("'%s'", each)).collect(Collectors.joining(",")));
+        String schemaNameParam = schemaNames.stream().map(each -> String.format("'%s'", each)).collect(Collectors.joining(","));
+        return tables.isEmpty() ? String.format(VIEW_META_DATA_SQL_WITHOUT_TABLES, schemaNameParam)
+                : String.format(VIEW_META_DATA_SQL_WITH_TABLES, schemaNameParam, tables.stream().map(each -> String.format("'%s'", each)).collect(Collectors.joining(",")));
     }
     
     private Collection<TableMetaData> createTableMetaDataList(final Multimap<String, IndexMetaData> tableIndexMetaDataMap, final Multimap<String, ColumnMetaData> tableColumnMetaDataMap,

--- a/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussMetaDataLoaderTest.java
+++ b/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussMetaDataLoaderTest.java
@@ -69,9 +69,9 @@ class OpenGaussMetaDataLoaderTest {
                     + " FROM pg_index pgi JOIN pg_class idx ON idx.oid = pgi.indexrelid JOIN pg_namespace insp ON insp.oid = idx.relnamespace JOIN pg_class tbl ON tbl.oid = pgi.indrelid"
                     + " JOIN pg_namespace tnsp ON tnsp.oid = tbl.relnamespace JOIN pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = ANY(pgi.indkey) WHERE tnsp.nspname IN ('public')";
     
-    private static final String VIEW_META_DATA_SQL_WITHOUT_TABLES = "SELECT table_schema, table_name FROM information_schema.views WHERE table_schema IN ('public') and table_name IN ()";
+    private static final String VIEW_META_DATA_SQL_WITHOUT_TABLES = "SELECT table_schema, table_name FROM information_schema.views WHERE table_schema IN ('public')";
     
-    private static final String VIEW_META_DATA_SQL_WITH_TABLES = "SELECT table_schema, table_name FROM information_schema.views WHERE table_schema IN ('public') and table_name IN ('tbl')";
+    private static final String VIEW_META_DATA_SQL_WITH_TABLES = "SELECT table_schema, table_name FROM information_schema.views WHERE table_schema IN ('public') AND table_name IN ('tbl')";
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "openGauss");
     
@@ -171,7 +171,7 @@ class OpenGaussMetaDataLoaderTest {
         when(result.getString("table_name")).thenReturn("tbl");
         return result;
     }
-
+    
     private void assertTableMetaDataMap(final Collection<SchemaMetaData> schemaMetaDataList, final TableType expectedTableType, final boolean expectedNameColumnCaseSensitive) {
         assertThat(schemaMetaDataList.size(), is(1));
         TableMetaData actualTableMetaData = schemaMetaDataList.iterator().next().getTables().iterator().next();
@@ -215,7 +215,7 @@ class OpenGaussMetaDataLoaderTest {
                 Arguments.of("without tables and binary collation", Collections.emptyList(), TABLE_META_DATA_SQL_WITHOUT_TABLES,
                         (Callable<ResultSet>) () -> mockTableMetaDataResultSet("", "pg_catalog", "utf8mb4_bin"),
                         (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet,
-                        VIEW_META_DATA_SQL_WITHOUT_TABLES, false, TableType.TABLE, true),
+                        VIEW_META_DATA_SQL_WITHOUT_TABLES, true, TableType.VIEW, true),
                 Arguments.of("with view table", Collections.singletonList("tbl"), TABLE_META_DATA_SQL_WITH_TABLES,
                         (Callable<ResultSet>) () -> mockTableMetaDataResultSet("", "pg_catalog", "utf8mb4_bin"),
                         (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet,

--- a/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussMetaDataLoaderTest.java
+++ b/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussMetaDataLoaderTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.model.Ind
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.SchemaMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.TableMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.datatype.DataTypeRegistry;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -68,6 +69,10 @@ class OpenGaussMetaDataLoaderTest {
                     + " FROM pg_index pgi JOIN pg_class idx ON idx.oid = pgi.indexrelid JOIN pg_namespace insp ON insp.oid = idx.relnamespace JOIN pg_class tbl ON tbl.oid = pgi.indrelid"
                     + " JOIN pg_namespace tnsp ON tnsp.oid = tbl.relnamespace JOIN pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = ANY(pgi.indkey) WHERE tnsp.nspname IN ('public')";
     
+    private static final String VIEW_META_DATA_SQL_WITHOUT_TABLES = "SELECT table_schema, table_name FROM information_schema.views WHERE table_schema IN ('public') and table_name IN ()";
+    
+    private static final String VIEW_META_DATA_SQL_WITH_TABLES = "SELECT table_schema, table_name FROM information_schema.views WHERE table_schema IN ('public') and table_name IN ('tbl')";
+    
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "openGauss");
     
     private final DialectMetaDataLoader dialectMetaDataLoader = DatabaseTypedSPILoader.getService(DialectMetaDataLoader.class, databaseType);
@@ -77,7 +82,7 @@ class OpenGaussMetaDataLoaderTest {
     @MethodSource("loadArguments")
     void assertLoad(final String name, final Collection<String> actualTableNames, final String tableMetaDataSQL,
                     final Callable<ResultSet> tableMetaDataResultSetFactory, final Callable<ResultSet> advanceIndexMetaDataResultSetFactory,
-                    final boolean expectedNameColumnCaseSensitive) throws Exception {
+                    final String viewMetaDataSQL, final boolean hasView, final TableType expectedTableType, final boolean expectedNameColumnCaseSensitive) throws Exception {
         DataSource dataSource = mockDataSource();
         ResultSet schemaResultSet = mockSchemaMetaDataResultSet();
         when(dataSource.getConnection().getMetaData().getSchemas()).thenReturn(schemaResultSet);
@@ -89,9 +94,11 @@ class OpenGaussMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(BASIC_INDEX_META_DATA_SQL).executeQuery()).thenReturn(indexResultSet);
         ResultSet advanceIndexResultSet = advanceIndexMetaDataResultSetFactory.call();
         when(dataSource.getConnection().prepareStatement(ADVANCE_INDEX_META_DATA_SQL).executeQuery()).thenReturn(advanceIndexResultSet);
+        ResultSet viewResultSet = mockViewMetaDataResultSet(hasView);
+        when(dataSource.getConnection().prepareStatement(viewMetaDataSQL).executeQuery()).thenReturn(viewResultSet);
         DataTypeRegistry.load(dataSource, "openGauss");
         assertTableMetaDataMap(dialectMetaDataLoader.load(new MetaDataLoaderMaterial(actualTableNames, "foo_ds", dataSource, databaseType, "sharding_db")),
-                expectedNameColumnCaseSensitive);
+                expectedTableType, expectedNameColumnCaseSensitive);
     }
     
     private ResultSet mockSchemaMetaDataResultSet() throws SQLException {
@@ -157,9 +164,18 @@ class OpenGaussMetaDataLoaderTest {
         return result;
     }
     
-    private void assertTableMetaDataMap(final Collection<SchemaMetaData> schemaMetaDataList, final boolean expectedNameColumnCaseSensitive) {
+    private static ResultSet mockViewMetaDataResultSet(final boolean hasView) throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(hasView, false);
+        when(result.getString("table_schema")).thenReturn("public");
+        when(result.getString("table_name")).thenReturn("tbl");
+        return result;
+    }
+
+    private void assertTableMetaDataMap(final Collection<SchemaMetaData> schemaMetaDataList, final TableType expectedTableType, final boolean expectedNameColumnCaseSensitive) {
         assertThat(schemaMetaDataList.size(), is(1));
         TableMetaData actualTableMetaData = schemaMetaDataList.iterator().next().getTables().iterator().next();
+        assertThat(actualTableMetaData.getType(), is(expectedTableType));
         assertThat(actualTableMetaData.getColumns().size(), is(2));
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
         assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("id", Types.INTEGER, true, true, true, true, false, false));
@@ -193,20 +209,29 @@ class OpenGaussMetaDataLoaderTest {
                 "utf8mb4_general_ci", "utf8mb4_unicode_ci", "utf8_general_ci", "utf8_unicode_ci", "gbk_chinese_ci", "gb18030_chinese_ci")
                 .map(each -> Arguments.of("with official case-insensitive collation " + each, Collections.singletonList("tbl"), TABLE_META_DATA_SQL_WITH_TABLES,
                         (Callable<ResultSet>) () -> mockTableMetaDataResultSet("", "pg_catalog", each),
-                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet, false));
+                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet,
+                        VIEW_META_DATA_SQL_WITH_TABLES, false, TableType.TABLE, false));
         return Stream.concat(officialCaseInsensitiveCollationArguments, Stream.of(
                 Arguments.of("without tables and binary collation", Collections.emptyList(), TABLE_META_DATA_SQL_WITHOUT_TABLES,
                         (Callable<ResultSet>) () -> mockTableMetaDataResultSet("", "pg_catalog", "utf8mb4_bin"),
-                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet, true),
+                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet,
+                        VIEW_META_DATA_SQL_WITHOUT_TABLES, false, TableType.TABLE, true),
+                Arguments.of("with view table", Collections.singletonList("tbl"), TABLE_META_DATA_SQL_WITH_TABLES,
+                        (Callable<ResultSet>) () -> mockTableMetaDataResultSet("", "pg_catalog", "utf8mb4_bin"),
+                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet,
+                        VIEW_META_DATA_SQL_WITH_TABLES, true, TableType.VIEW, true),
                 Arguments.of("with unknown case-insensitive collation", Collections.singletonList("tbl"), TABLE_META_DATA_SQL_WITH_TABLES,
                         (Callable<ResultSet>) () -> mockTableMetaDataResultSet("", "pg_catalog", "custom_ci"),
-                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet, true),
+                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet,
+                        VIEW_META_DATA_SQL_WITH_TABLES, false, TableType.TABLE, true),
                 Arguments.of("with user-defined collation", Collections.singletonList("tbl"), TABLE_META_DATA_SQL_WITH_TABLES,
                         (Callable<ResultSet>) () -> mockTableMetaDataResultSet("", "foo_schema", "utf8mb4_general_ci"),
-                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet, true),
+                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSet,
+                        VIEW_META_DATA_SQL_WITH_TABLES, false, TableType.TABLE, true),
                 Arguments.of("with unmatched advance index rows and null default", Collections.singletonList("tbl"), TABLE_META_DATA_SQL_WITH_TABLES,
                         (Callable<ResultSet>) () -> mockTableMetaDataResultSet(null, null, null),
-                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSetWithUnmatchedRows, true)));
+                        (Callable<ResultSet>) OpenGaussMetaDataLoaderTest::mockAdvanceIndexMetaDataResultSetWithUnmatchedRows,
+                        VIEW_META_DATA_SQL_WITH_TABLES, false, TableType.TABLE, true)));
     }
     
     private static ResultSet mockTableMetaDataResultSet(final String nameColumnDefault, final String nameColumnCollationSchema, final String nameColumnCollationName) throws SQLException {


### PR DESCRIPTION
Fixes #39095.

Changes proposed in this pull request:
  - Add `VIEW_META_DATA_SQL` and `loadViewNames()` to `OpenGaussMetaDataLoader` to query `information_schema.views` for view names per schema.
  - Pass the resolved view names into `createTableMetaDataList()` and use the 5-arg `TableMetaData` constructor so views become `TableType.VIEW` instead of always `TableType.TABLE`.
  - Aligns openGauss with the PostgreSQL, MySQL and Oracle dialect loaders that already classify views; fixes openGauss views being dropped by `TableType.VIEW` consumers such as `MetadataResourcePayloadMapper`.
  - Add view scenarios to `OpenGaussMetaDataLoaderTest` asserting `getType()` is `VIEW` (positive) and `TABLE` (negative).

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
