### PR TITLE
Use COALESCE as the if-null function name for Presto

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
 1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)
+1. SQL Binder: Use COALESCE as the if-null function name for Presto - [#39098](https://github.com/apache/shardingsphere/pull/39098)
 
 ### Enhancements
 

--- a/database/connector/dialect/presto/src/main/java/org/apache/shardingsphere/database/connector/presto/metadata/database/option/PrestoFunctionOption.java
+++ b/database/connector/dialect/presto/src/main/java/org/apache/shardingsphere/database/connector/presto/metadata/database/option/PrestoFunctionOption.java
@@ -33,7 +33,7 @@ public final class PrestoFunctionOption implements DialectFunctionOption {
     
     @Override
     public String getIfNullFunctionName() {
-        return "IFNULL";
+        return "COALESCE";
     }
     
     @Override

--- a/database/connector/dialect/presto/src/test/java/org/apache/shardingsphere/database/connector/presto/metadata/database/option/PrestoFunctionOptionTest.java
+++ b/database/connector/dialect/presto/src/test/java/org/apache/shardingsphere/database/connector/presto/metadata/database/option/PrestoFunctionOptionTest.java
@@ -29,7 +29,7 @@ class PrestoFunctionOptionTest {
     
     @Test
     void assertGetIfNullFunctionName() {
-        assertThat(functionOption.getIfNullFunctionName(), is("IFNULL"));
+        assertThat(functionOption.getIfNullFunctionName(), is("COALESCE"));
     }
     
     @Test


### PR DESCRIPTION
Fixes #39096.

Changes proposed in this pull request:
  - Change `PrestoFunctionOption.getIfNullFunctionName()` to return `COALESCE` instead of `IFNULL`, because Presto/Trino has no `IFNULL` function and `COALESCE` is its null-coalescing function.
  - Aligns Presto with the sibling `PostgreSQLFunctionOption`, which already returns `COALESCE` for the same reason (PR #38466); the `IFNULL` default was inherited from PR #38350.
  - Update the existing `PrestoFunctionOptionTest.assertGetIfNullFunctionName()` expectation accordingly.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
