### PR TITLE
Remove Oracle ROWNUM from SQLServer unparenthesized functions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,7 @@
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)
+1. SQL Binder: Remove Oracle ROWNUM pseudo-columns from SQLServer unparenthesized function names to fix wrong column bind skip - [#39103](https://github.com/apache/shardingsphere/pull/39103)
 1. Metadata: Fix MySQL metadata loading fallback when JDBC catalog is null for named tables - [#38855](https://github.com/apache/shardingsphere/pull/38855)
 1. Metadata: Fix Oracle metadata version comparison skipping identity and collation columns on 18c and later - [#39104](https://github.com/apache/shardingsphere/pull/39104)
 1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)

--- a/database/connector/dialect/sqlserver/src/main/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/option/SQLServerFunctionOption.java
+++ b/database/connector/dialect/sqlserver/src/main/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/option/SQLServerFunctionOption.java
@@ -28,9 +28,8 @@ import java.util.Collection;
  */
 public final class SQLServerFunctionOption implements DialectFunctionOption {
     
-    // TODO remove ROWNUM, ROWNUM_ and ROW_NUMBER @duanzhengqiang
     private static final Collection<String> UNPARENTHESIZED_FUNCTION_NAMES = new CaseInsensitiveSet<>(Arrays.asList(
-            "CURRENT_TIMESTAMP", "CURRENT_USER", "ROWNUM", "ROWNUM_", "ROW_NUMBER", "SESSION_USER", "SYSTEM_USER", "USER"));
+            "CURRENT_TIMESTAMP", "CURRENT_USER", "SESSION_USER", "SYSTEM_USER", "USER"));
     
     @Override
     public Collection<String> getUnparenthesizedFunctionNames() {

--- a/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/option/SQLServerFunctionOptionTest.java
+++ b/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/option/SQLServerFunctionOptionTest.java
@@ -19,7 +19,10 @@ package org.apache.shardingsphere.database.connector.sql92.sqlserver.metadata.da
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
 
 class SQLServerFunctionOptionTest {
     
@@ -27,13 +30,9 @@ class SQLServerFunctionOptionTest {
     
     @Test
     void assertGetUnparenthesizedFunctionNames() {
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("CURRENT_TIMESTAMP"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("CURRENT_USER"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("ROWNUM"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("ROWNUM_"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("ROW_NUMBER"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("SESSION_USER"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("SYSTEM_USER"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("USER"));
+        assertThat(functionOption.getUnparenthesizedFunctionNames(), hasItems("CURRENT_TIMESTAMP", "CURRENT_USER", "SESSION_USER", "SYSTEM_USER", "USER"));
+        assertThat(functionOption.getUnparenthesizedFunctionNames(), not(hasItem("ROWNUM")));
+        assertThat(functionOption.getUnparenthesizedFunctionNames(), not(hasItem("ROWNUM_")));
+        assertThat(functionOption.getUnparenthesizedFunctionNames(), not(hasItem("ROW_NUMBER")));
     }
 }


### PR DESCRIPTION
Fixes #39100.

Changes proposed in this pull request:
  - Remove `ROWNUM`, `ROWNUM_` and `ROW_NUMBER` from `SQLServerFunctionOption.getUnparenthesizedFunctionNames()`; these are Oracle pseudo-columns that SQL Server does not have (`ROW_NUMBER` always needs `()` + `OVER`).
  - Resolve the existing maintainer TODO that already asked to remove these three names.
  - The set is consumed by `ColumnSegmentBinder.isUnparenthesizedFunction()`, which skipped binding for any identifier in it; a real SQL Server column named `ROWNUM` was therefore left unbound (wrong output).
  - Restore parity with the sibling dialects: among all dialect `FunctionOption`s only Oracle legitimately keeps these pseudo-columns; SQLServer was an Oracle copy remnant.
  - Update `SQLServerFunctionOptionTest` to assert the remaining niladic functions stay and the three Oracle names are gone.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
