### PR TITLE
Fix Oracle metadata version comparison for 18c and later

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
 1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)
+1. Metadata: Fix Oracle metadata version comparison skipping identity and collation columns on 18c and later - [#39104](https://github.com/apache/shardingsphere/pull/39104)
 
 ### Enhancements
 

--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
@@ -177,11 +177,16 @@ public final class OracleMetaDataLoader implements DialectMetaDataLoader {
     }
     
     private boolean versionContainsCollation(final DatabaseMetaData databaseMetaData) throws SQLException {
-        return databaseMetaData.getDatabaseMajorVersion() >= COLLATION_START_MAJOR_VERSION && databaseMetaData.getDatabaseMinorVersion() >= COLLATION_START_MINOR_VERSION;
+        return isVersionAtLeast(databaseMetaData, COLLATION_START_MAJOR_VERSION, COLLATION_START_MINOR_VERSION);
     }
     
     private boolean versionContainsIdentityColumn(final DatabaseMetaData databaseMetaData) throws SQLException {
-        return databaseMetaData.getDatabaseMajorVersion() >= COLLATION_START_MAJOR_VERSION && databaseMetaData.getDatabaseMinorVersion() >= IDENTITY_COLUMN_START_MINOR_VERSION;
+        return isVersionAtLeast(databaseMetaData, COLLATION_START_MAJOR_VERSION, IDENTITY_COLUMN_START_MINOR_VERSION);
+    }
+    
+    private boolean isVersionAtLeast(final DatabaseMetaData databaseMetaData, final int major, final int minor) throws SQLException {
+        int majorVersion = databaseMetaData.getDatabaseMajorVersion();
+        return majorVersion > major || majorVersion == major && databaseMetaData.getDatabaseMinorVersion() >= minor;
     }
     
     private Map<String, Collection<IndexMetaData>> loadIndexMetaData(final Connection connection, final Collection<String> tableNames, final String schema) throws SQLException {

--- a/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoaderTest.java
+++ b/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoaderTest.java
@@ -221,18 +221,18 @@ class OracleMetaDataLoaderTest {
     }
     
     private String getTableMetaDataSQL(final int majorVersion, final int minorVersion) {
-        if (majorVersion >= 12 && minorVersion >= 2) {
+        if (majorVersion > 12 || majorVersion == 12 && minorVersion >= 2) {
             return ALL_TAB_COLUMNS_SQL_WITH_IDENTITY_AND_COLLATION;
         }
-        if (majorVersion >= 12 && minorVersion == 1) {
+        if (majorVersion == 12 && minorVersion == 1) {
             return ALL_TAB_COLUMNS_SQL_WITH_IDENTITY;
         }
         return ALL_TAB_COLUMNS_SQL_WITHOUT_IDENTITY_AND_COLLATION;
     }
     
     private ColumnMetaData getExpectedFirstColumnMetaData(final int majorVersion, final int minorVersion, final boolean withPrimaryKey) {
-        boolean generated = majorVersion >= 12 && minorVersion >= 1;
-        boolean caseSensitive = majorVersion >= 12 && minorVersion >= 2;
+        boolean generated = majorVersion > 12 || majorVersion == 12 && minorVersion >= 1;
+        boolean caseSensitive = majorVersion > 12 || majorVersion == 12 && minorVersion >= 2;
         return new ColumnMetaData("id", Types.NUMERIC, withPrimaryKey, generated, caseSensitive, true, false, false);
     }
     
@@ -276,6 +276,7 @@ class OracleMetaDataLoaderTest {
                 Arguments.of("major12Minor2WithPrimaryKey", 12, 2, true, false),
                 Arguments.of("major12Minor1WithPrimaryKey", 12, 1, true, false),
                 Arguments.of("major11Minor2WithPrimaryKey", 11, 2, true, false),
+                Arguments.of("major19Minor0WithPrimaryKey", 19, 0, true, false),
                 Arguments.of("major12Minor2WithPrimaryKeyAndNullCollation", 12, 2, true, true));
     }
 }


### PR DESCRIPTION
Fixes #39101.

Changes proposed in this pull request:
  - `OracleMetaDataLoader.versionContainsCollation()` and `versionContainsIdentityColumn()` compared major and minor version independently (`major >= 12 && minor >= N`), so Oracle 18c and later (which report `getDatabaseMinorVersion() = 0`) always failed the gate and dropped the `IDENTITY_COLUMN` and `COLLATION` columns.
  - Extract a shared `isVersionAtLeast(databaseMetaData, major, minor)` helper doing a lexicographic comparison (`major > X || major == X && minor >= N`), removing the duplicated buggy logic.
  - Aligns with `SQLServerMetaDataLoader.versionContainsHiddenColumn()`, which already gates on major version.
  - Sync the mirrored version logic in `OracleMetaDataLoaderTest` and add a `major19Minor0WithPrimaryKey` regression case asserting `generated` and `caseSensitive` are true on 19c.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
