### PR TITLE
Remove isCaseSensitive of DialectDatabaseMetaData and related tests

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/DialectDatabaseMetaData.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/DialectDatabaseMetaData.java
@@ -66,15 +66,6 @@ public interface DialectDatabaseMetaData extends DatabaseTypedSPI {
     IdentifierPatternType getIdentifierPatternType();
     
     /**
-     * Whether identifier is case-sensitive.
-     *
-     * @return is case-sensitive or insensitive
-     */
-    default boolean isCaseSensitive() {
-        return false;
-    }
-    
-    /**
      * Get default nulls order type.
      *
      * @return default nulls order type

--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactory.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactory.java
@@ -90,10 +90,9 @@ public final class IdentifierCasePolicyFactory {
      * Create dialect default policy set.
      *
      * @param identifierPatternType identifier pattern type
-     * @param caseSensitive case-sensitive flag
      * @return dialect default policy set
      */
-    public static IdentifierCasePolicySet newDialectDefaultPolicySet(final IdentifierPatternType identifierPatternType, final boolean caseSensitive) {
+    public static IdentifierCasePolicySet newDialectDefaultPolicySet(final IdentifierPatternType identifierPatternType) {
         switch (identifierPatternType) {
             case LOWER_CASE:
                 return newLowerCasePolicySet();
@@ -101,7 +100,7 @@ public final class IdentifierCasePolicyFactory {
                 return newUpperCasePolicySet();
             case KEEP_ORIGIN:
             default:
-                return caseSensitive ? newSensitivePolicySet() : newInsensitivePolicySet();
+                return newInsensitivePolicySet();
         }
     }
     

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/DialectDatabaseMetaDataTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/DialectDatabaseMetaDataTest.java
@@ -42,11 +42,6 @@ class DialectDatabaseMetaDataTest {
     private final DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class, CALLS_REAL_METHODS);
     
     @Test
-    void assertIsCaseSensitive() {
-        assertFalse(dialectDatabaseMetaData.isCaseSensitive());
-    }
-    
-    @Test
     void assertGetDataTypeOption() {
         assertThat(dialectDatabaseMetaData.getDataTypeOption(), isA(DefaultDataTypeOption.class));
     }

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactoryTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactoryTest.java
@@ -80,10 +80,9 @@ class IdentifierCasePolicyFactoryTest {
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("newDialectDefaultPolicySetArguments")
-    void assertNewDialectDefaultPolicySet(final String name, final IdentifierPatternType identifierPatternType, final boolean caseSensitive,
-                                          final LookupMode expectedQuotedLookupMode, final LookupMode expectedUnquotedLookupMode,
+    void assertNewDialectDefaultPolicySet(final String name, final IdentifierPatternType identifierPatternType, final LookupMode expectedQuotedLookupMode, final LookupMode expectedUnquotedLookupMode,
                                           final String storedName, final String actualIdentifier, final boolean expected) {
-        IdentifierCasePolicy actual = IdentifierCasePolicyFactory.newDialectDefaultPolicySet(identifierPatternType, caseSensitive).getPolicy(IdentifierScope.TABLE);
+        IdentifierCasePolicy actual = IdentifierCasePolicyFactory.newDialectDefaultPolicySet(identifierPatternType).getPolicy(IdentifierScope.TABLE);
         assertThat(actual.getLookupMode(QuoteCharacter.QUOTE), is(expectedQuotedLookupMode));
         assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(expectedUnquotedLookupMode));
         assertThat(actual.matches(storedName, actualIdentifier, QuoteCharacter.NONE), is(expected));
@@ -91,9 +90,8 @@ class IdentifierCasePolicyFactoryTest {
     
     private static Stream<Arguments> newDialectDefaultPolicySetArguments() {
         return Stream.of(
-                Arguments.of("lower_case", IdentifierPatternType.LOWER_CASE, false, LookupMode.EXACT, LookupMode.NORMALIZED, "foo", "FOO", true),
-                Arguments.of("upper_case", IdentifierPatternType.UPPER_CASE, false, LookupMode.EXACT, LookupMode.NORMALIZED, "FOO", "foo", true),
-                Arguments.of("keep_origin_sensitive", IdentifierPatternType.KEEP_ORIGIN, true, LookupMode.EXACT, LookupMode.EXACT, "Foo", "foo", false),
-                Arguments.of("keep_origin_insensitive", IdentifierPatternType.KEEP_ORIGIN, false, LookupMode.EXACT, LookupMode.NORMALIZED, "Foo", "FOO", true));
+                Arguments.of("lower_case", IdentifierPatternType.LOWER_CASE, LookupMode.EXACT, LookupMode.NORMALIZED, "foo", "FOO", true),
+                Arguments.of("upper_case", IdentifierPatternType.UPPER_CASE, LookupMode.EXACT, LookupMode.NORMALIZED, "FOO", "foo", true),
+                Arguments.of("keep_origin", IdentifierPatternType.KEEP_ORIGIN, LookupMode.EXACT, LookupMode.NORMALIZED, "Foo", "FOO", true));
     }
 }

--- a/database/connector/dialect/clickhouse/src/main/java/org/apache/shardingsphere/database/connector/clickhouse/database/ClickHouseDatabaseMetaData.java
+++ b/database/connector/dialect/clickhouse/src/main/java/org/apache/shardingsphere/database/connector/clickhouse/database/ClickHouseDatabaseMetaData.java
@@ -46,11 +46,6 @@ public final class ClickHouseDatabaseMetaData implements DialectDatabaseMetaData
     }
     
     @Override
-    public boolean isCaseSensitive() {
-        return true;
-    }
-    
-    @Override
     public DialectSchemaOption getSchemaOption() {
         return new DefaultSchemaOption(false, null, DialectSchemaSemantics.DATABASE_AS_SCHEMA);
     }

--- a/database/connector/dialect/clickhouse/src/test/java/org/apache/shardingsphere/database/connector/clickhouse/database/ClickHouseDatabaseMetaDataTest.java
+++ b/database/connector/dialect/clickhouse/src/test/java/org/apache/shardingsphere/database/connector/clickhouse/database/ClickHouseDatabaseMetaDataTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClickHouseDatabaseMetaDataTest {
     
@@ -49,11 +48,6 @@ class ClickHouseDatabaseMetaDataTest {
     @Test
     void assertGetDefaultNullsOrderType() {
         assertThat(dialectDatabaseMetaData.getDefaultNullsOrderType(), is(NullsOrderType.LOW));
-    }
-    
-    @Test
-    void assertIsCaseSensitive() {
-        assertTrue(dialectDatabaseMetaData.isCaseSensitive());
     }
     
     @Test

--- a/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
+++ b/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
@@ -100,11 +100,6 @@ public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData 
     }
     
     @Override
-    public boolean isCaseSensitive() {
-        return true;
-    }
-    
-    @Override
     public String getDatabaseType() {
         return "openGauss";
     }

--- a/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/database/OpenGaussDatabaseMetaDataTest.java
+++ b/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/database/OpenGaussDatabaseMetaDataTest.java
@@ -125,11 +125,6 @@ class OpenGaussDatabaseMetaDataTest {
     }
     
     @Test
-    void assertIsCaseSensitive() {
-        assertTrue(dialectDatabaseMetaData.isCaseSensitive());
-    }
-    
-    @Test
     void assertGetFunctionOption() {
         assertThat(dialectDatabaseMetaData.getFunctionOption(), isA(PostgreSQLFunctionOption.class));
     }

--- a/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
+++ b/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
@@ -93,11 +93,6 @@ public final class PostgreSQLDatabaseMetaData implements DialectDatabaseMetaData
     }
     
     @Override
-    public boolean isCaseSensitive() {
-        return true;
-    }
-    
-    @Override
     public String getDatabaseType() {
         return "PostgreSQL";
     }

--- a/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/PostgreSQLDatabaseMetaDataTest.java
+++ b/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/PostgreSQLDatabaseMetaDataTest.java
@@ -110,11 +110,6 @@ class PostgreSQLDatabaseMetaDataTest {
     }
     
     @Test
-    void assertIsCaseSensitive() {
-        assertTrue(dialectDatabaseMetaData.isCaseSensitive());
-    }
-    
-    @Test
     void assertGetFunctionOption() {
         assertThat(dialectDatabaseMetaData.getFunctionOption(), isA(PostgreSQLFunctionOption.class));
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DefaultIdentifierCasePolicyProvider.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DefaultIdentifierCasePolicyProvider.java
@@ -34,7 +34,7 @@ public final class DefaultIdentifierCasePolicyProvider implements IdentifierCase
     @Override
     public Optional<IdentifierCasePolicySet> provide(final IdentifierCasePolicyProviderContext context) {
         DialectDatabaseMetaData dialectDatabaseMetaData = DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, context.getDatabaseType());
-        return Optional.of(IdentifierCasePolicyFactory.newDialectDefaultPolicySet(dialectDatabaseMetaData.getIdentifierPatternType(), dialectDatabaseMetaData.isCaseSensitive()));
+        return Optional.of(IdentifierCasePolicyFactory.newDialectDefaultPolicySet(dialectDatabaseMetaData.getIdentifierPatternType()));
     }
     
     @Override


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove isCaseSensitive of DialectDatabaseMetaData and related tests

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
