### PR TITLE
Skip sharding conditions irrelevant to the routed table

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
 1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)
 1. Metadata: Fix Oracle metadata version comparison skipping identity and collation columns on 18c and later - [#39104](https://github.com/apache/shardingsphere/pull/39104)
+1. Sharding: Skip sharding conditions irrelevant to the routed table to avoid full-route broadcast for subqueries over non-binding sharding tables - [#39112](https://github.com/apache/shardingsphere/pull/39112)
 
 ### Enhancements
 

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngine.java
@@ -131,8 +131,11 @@ public final class ShardingStandardRouteEngine implements ShardingRouteEngine {
     private Collection<DataNode> routeByShardingConditionsWithCondition(final ShardingRule shardingRule, final ShardingTable shardingTable,
                                                                         final ShardingStrategy databaseShardingStrategy, final ShardingStrategy tableShardingStrategy) {
         Collection<DataNode> result = new LinkedList<>();
+        boolean anyConditionRelevant = false;
         for (ShardingCondition each : shardingConditions.getConditions()) {
-            Collection<DataNode> dataNodes = isConditionRelevantToTable(shardingRule, each)
+            boolean relevant = isConditionRelevantToTable(shardingRule, each);
+            anyConditionRelevant |= relevant;
+            Collection<DataNode> dataNodes = relevant
                     ? route0(shardingTable,
                             databaseShardingStrategy, getShardingValuesFromShardingConditions(shardingRule, databaseShardingStrategy.getShardingColumns(), each),
                             tableShardingStrategy, getShardingValuesFromShardingConditions(shardingRule, tableShardingStrategy.getShardingColumns(), each))
@@ -140,7 +143,10 @@ public final class ShardingStandardRouteEngine implements ShardingRouteEngine {
             result.addAll(dataNodes);
             originalDataNodes.add(dataNodes);
         }
-        return result.isEmpty()
+        // Full-route only when every condition was irrelevant; a relevant condition that legitimately
+        // routes to no target (e.g. an out-of-range interval value) must keep its empty result rather
+        // than broadcast to every shard.
+        return result.isEmpty() && !anyConditionRelevant
                 ? route0(shardingTable, databaseShardingStrategy, Collections.emptyList(), tableShardingStrategy, Collections.emptyList())
                 : result;
     }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngine.java
@@ -132,13 +132,33 @@ public final class ShardingStandardRouteEngine implements ShardingRouteEngine {
                                                                         final ShardingStrategy databaseShardingStrategy, final ShardingStrategy tableShardingStrategy) {
         Collection<DataNode> result = new LinkedList<>();
         for (ShardingCondition each : shardingConditions.getConditions()) {
-            Collection<DataNode> dataNodes = route0(shardingTable,
-                    databaseShardingStrategy, getShardingValuesFromShardingConditions(shardingRule, databaseShardingStrategy.getShardingColumns(), each),
-                    tableShardingStrategy, getShardingValuesFromShardingConditions(shardingRule, tableShardingStrategy.getShardingColumns(), each));
+            Collection<DataNode> dataNodes = isConditionRelevantToTable(shardingRule, each)
+                    ? route0(shardingTable,
+                            databaseShardingStrategy, getShardingValuesFromShardingConditions(shardingRule, databaseShardingStrategy.getShardingColumns(), each),
+                            tableShardingStrategy, getShardingValuesFromShardingConditions(shardingRule, tableShardingStrategy.getShardingColumns(), each))
+                    : Collections.<DataNode>emptyList();
             result.addAll(dataNodes);
             originalDataNodes.add(dataNodes);
         }
-        return result;
+        return result.isEmpty()
+                ? route0(shardingTable, databaseShardingStrategy, Collections.emptyList(), tableShardingStrategy, Collections.emptyList())
+                : result;
+    }
+    
+    private boolean isConditionRelevantToTable(final ShardingRule shardingRule, final ShardingCondition shardingCondition) {
+        if (shardingCondition.getValues().isEmpty()) {
+            return true;
+        }
+        for (ShardingConditionValue each : shardingCondition.getValues()) {
+            if (logicTableName.equalsIgnoreCase(each.getTableName())) {
+                return true;
+            }
+            Optional<BindingTableRule> bindingTableRule = shardingRule.findBindingTableRule(each.getTableName());
+            if (bindingTableRule.isPresent() && bindingTableRule.get().hasLogicTable(logicTableName)) {
+                return true;
+            }
+        }
+        return false;
     }
     
     private Collection<DataNode> routeByMixedConditions(final ShardingRule shardingRule, final ShardingTable shardingTable,

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngineTest.java
@@ -24,7 +24,9 @@ import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.apache.shardingsphere.sharding.exception.algorithm.ShardingRouteAlgorithmException;
+import org.apache.shardingsphere.sharding.route.engine.condition.ShardingCondition;
 import org.apache.shardingsphere.sharding.route.engine.condition.ShardingConditions;
+import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.fixture.ShardingRouteEngineFixtureBuilder;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.junit.jupiter.api.AfterEach;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -203,6 +206,34 @@ class ShardingStandardRouteEngineTest {
         assertThat(routeUnits.get(0).getTableMappers().size(), is(1));
         assertThat(routeUnits.get(0).getTableMappers().iterator().next().getActualName(), is("t_interval_test_202101"));
         assertThat(routeUnits.get(0).getTableMappers().iterator().next().getLogicName(), is("t_interval_test"));
+    }
+    
+    @Test
+    void assertRouteByShardingConditionsWithIrrelevantTableCondition() {
+        ShardingCondition relevantCondition = new ShardingCondition();
+        relevantCondition.getValues().add(new ListShardingConditionValue<>("order_id", "t_order", Collections.singletonList(1)));
+        relevantCondition.getValues().add(new ListShardingConditionValue<>("user_id", "t_order", Collections.singletonList(1)));
+        ShardingCondition irrelevantCondition = new ShardingCondition();
+        irrelevantCondition.getValues().add(new ListShardingConditionValue<>("user_id", "t_user", Collections.singletonList(1)));
+        ShardingStandardRouteEngine routeEngine = createShardingStandardRouteEngine("t_order",
+                new ShardingConditions(Arrays.asList(relevantCondition, irrelevantCondition), mock(SQLStatementContext.class), mock(ShardingRule.class)),
+                mock(SQLStatementContext.class), new HintValueContext());
+        RouteContext routeContext = routeEngine.route(ShardingRouteEngineFixtureBuilder.createBasedShardingRule());
+        List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
+        assertThat(routeContext.getRouteUnits().size(), is(1));
+        assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_1"));
+        assertThat(routeUnits.get(0).getTableMappers().iterator().next().getActualName(), is("t_order_1"));
+    }
+    
+    @Test
+    void assertRouteByShardingConditionWithoutShardingValues() {
+        ShardingStandardRouteEngine routeEngine = createShardingStandardRouteEngine("t_order",
+                new ShardingConditions(Collections.singletonList(new ShardingCondition()), mock(SQLStatementContext.class), mock(ShardingRule.class)),
+                mock(SQLStatementContext.class), new HintValueContext());
+        RouteContext routeContext = routeEngine.route(ShardingRouteEngineFixtureBuilder.createBasedShardingRule());
+        assertThat(routeContext.getRouteUnits().size(), is(4));
+        assertThat(routeContext.getOriginalDataNodes().size(), is(1));
+        assertThat(routeContext.getOriginalDataNodes().iterator().next().size(), is(4));
     }
     
     private ShardingStandardRouteEngine createShardingStandardRouteEngine(final String logicTableName, final ShardingConditions shardingConditions,

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngineTest.java
@@ -235,7 +235,20 @@ class ShardingStandardRouteEngineTest {
         assertThat(routeContext.getOriginalDataNodes().size(), is(1));
         assertThat(routeContext.getOriginalDataNodes().iterator().next().size(), is(4));
     }
-    
+
+    @Test
+    void assertRouteByRelevantConditionRoutingToNoTargetKeepsEmptyResult() {
+        SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_interval_test"));
+        ShardingCondition outOfRangeCondition = new ShardingCondition();
+        outOfRangeCondition.getValues().add(new ListShardingConditionValue<>("create_at", "t_interval_test", Collections.singletonList("2025-06-01 20:20:20")));
+        ShardingStandardRouteEngine routeEngine = createShardingStandardRouteEngine("t_interval_test",
+                new ShardingConditions(Collections.singletonList(outOfRangeCondition), mock(SQLStatementContext.class), mock(ShardingRule.class)),
+                sqlStatementContext, new HintValueContext());
+        RouteContext routeContext = routeEngine.route(ShardingRouteEngineFixtureBuilder.createIntervalTableShardingRule());
+        assertThat(routeContext.getRouteUnits().size(), is(0));
+    }
+
     private ShardingStandardRouteEngine createShardingStandardRouteEngine(final String logicTableName, final ShardingConditions shardingConditions,
                                                                           final SQLStatementContext sqlStatementContext, final HintValueContext hintValueContext) {
         return new ShardingStandardRouteEngine(logicTableName, shardingConditions, sqlStatementContext, hintValueContext, new ConfigurationProperties(new Properties()));


### PR DESCRIPTION
Fixes #38456.

Changes proposed in this pull request:
  - Skip sharding conditions that carry no value for the routed table or its binding table group, so a subquery over two non-binding sharding tables no longer broadcasts to every data node.
  - Record a placeholder entry in `originalDataNodes` for the skipped conditions, keeping it positionally aligned with the condition list.
  - Treat a condition that has no sharding values at all as relevant, preserving its existing full-route behaviour.

### Why the route explodes

For a subquery over two non-binding sharding tables, `ShardingConditionEngine` emits one `ShardingCondition` per table instead of merging them into a single condition the way it does for the equivalent JOIN. While routing one of the tables, the condition that belongs to the *other* table yields no sharding values, so `route0` reads it as "no condition given" and broadcasts. The reporter saw 512 actual SQLs (4 datasources x 128 shards) for a query that should reach one shard.

### Why this does not repeat #38527

[#38527](https://github.com/apache/shardingsphere/pull/38527) filtered the same conditions but dropped them with `continue`, and fell back to a bare `route0` when every condition was dropped. Two things went wrong, and [#38639](https://github.com/apache/shardingsphere/pull/38639) reverted it:

1. `RouteSQLRewriteEngine#buildRouteParameters` walks `originalDataNodes` **by index** and feeds that index straight to `paramBuilder.getParameters(count)`. Dropping an entry shifts every later index, so parameters can land on the wrong row. This PR appends an empty collection instead of skipping, which leaves the indices intact and reads as "matches every route unit" in `isInSameDataNode`, exactly as before.
2. A condition with no sharding values (for example an INSERT into a table with no sharding strategy) was classed as irrelevant and sent down the fallback path, which never populated `originalDataNodes`. `RouteSQLRewriteEngine#getParameters` then took the short path instead of `buildRouteParameters`. Here such a condition is treated as relevant, so its full-route behaviour is unchanged.

`assertRouteByShardingConditionWithoutShardingValues` covers the second point: dropping the empty-values guard turns `originalDataNodes` from `[4 nodes]` into `[]` and the test fails, so the regression cannot come back unnoticed.

### Scope

`routeByMixedConditionsWithCondition` is left alone on purpose, even though the issue mentions the same shape there. That path mixes hint strategies, where a condition that looks irrelevant can still contribute a valid hint value, so the same filter is not obviously safe. Happy to extend it in this PR or a follow-up if you would prefer.

### Verification

- `assertRouteByShardingConditionsWithIrrelevantTableCondition` fails on master (`expected: <1> but: was <4>`) and passes with the fix.
- `./mvnw -pl features/sharding/core -Drat.skip=true test` — 853 tests, checkstyle included.
- `./mvnw -pl infra/rewrite/core -Drat.skip=true test` — 87 tests.

This was written with AI assistance (disclosed in the commit trailer); I have reviewed the reasoning and the diff and can speak to every line.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)