### PR TITLE
Remove Optional from provide method in case policy providers

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyProvider.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyProvider.java
@@ -20,8 +20,6 @@ package org.apache.shardingsphere.database.connector.core.metadata.identifier;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPI;
 import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 
-import java.util.Optional;
-
 /**
  * Provider of identifier case policies.
  */
@@ -32,7 +30,7 @@ public interface IdentifierCasePolicyProvider extends DatabaseTypedSPI {
      * Provide identifier case rules.
      *
      * @param context provider context
-     * @return identifier case rules
+     * @return identifier case rules, or insensitive rules if they cannot be determined
      */
-    Optional<IdentifierCasePolicySet> provide(IdentifierCasePolicyProviderContext context);
+    IdentifierCasePolicySet provide(IdentifierCasePolicyProviderContext context);
 }

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProvider.java
@@ -18,10 +18,10 @@
 package org.apache.shardingsphere.database.connector.mysql.metadata.identifier;
 
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProviderContext;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 
 import java.sql.Connection;
@@ -30,7 +30,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * MySQL provider of identifier case policies.
@@ -40,36 +39,36 @@ public final class MySQLIdentifierCasePolicyProvider implements IdentifierCasePo
     private static final String QUERY_LOWER_CASE_TABLE_NAMES = "SELECT @@lower_case_table_names";
     
     @Override
-    public Optional<IdentifierCasePolicySet> provide(final IdentifierCasePolicyProviderContext context) {
+    public IdentifierCasePolicySet provide(final IdentifierCasePolicyProviderContext context) {
         if (null == context.getDataSource()) {
-            return Optional.empty();
+            return IdentifierCasePolicyFactory.newInsensitivePolicySet();
         }
         try (Connection connection = context.getDataSource().getConnection()) {
             if (null == connection) {
-                return Optional.empty();
+                return IdentifierCasePolicyFactory.newInsensitivePolicySet();
             }
             try (
                     PreparedStatement preparedStatement = connection.prepareStatement(QUERY_LOWER_CASE_TABLE_NAMES);
                     ResultSet resultSet = preparedStatement.executeQuery()) {
-                return resultSet.next() ? createPolicySet(resultSet.getInt(1)) : Optional.empty();
+                return resultSet.next() ? createPolicySet(resultSet.getInt(1)) : IdentifierCasePolicyFactory.newInsensitivePolicySet();
             }
         } catch (final SQLException ignored) {
-            return Optional.empty();
+            return IdentifierCasePolicyFactory.newInsensitivePolicySet();
         }
     }
     
-    private Optional<IdentifierCasePolicySet> createPolicySet(final int lowerCaseTableNames) {
+    private IdentifierCasePolicySet createPolicySet(final int lowerCaseTableNames) {
         if (1 == lowerCaseTableNames || 2 == lowerCaseTableNames) {
-            return Optional.of(IdentifierCasePolicyFactory.newMySQLInsensitivePolicySet());
+            return IdentifierCasePolicyFactory.newMySQLInsensitivePolicySet();
         }
         if (0 == lowerCaseTableNames) {
             Map<IdentifierScope, IdentifierCasePolicy> scopedPolicies = new EnumMap<>(IdentifierScope.class);
             scopedPolicies.put(IdentifierScope.SCHEMA, IdentifierCasePolicyFactory.newMySQLInsensitivePolicySet().getPolicy(IdentifierScope.SCHEMA));
             scopedPolicies.put(IdentifierScope.TABLE, IdentifierCasePolicyFactory.newSensitivePolicySet().getPolicy(IdentifierScope.TABLE));
             scopedPolicies.put(IdentifierScope.VIEW, IdentifierCasePolicyFactory.newSensitivePolicySet().getPolicy(IdentifierScope.VIEW));
-            return Optional.of(new IdentifierCasePolicySet(IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.TABLE), scopedPolicies));
+            return new IdentifierCasePolicySet(IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.TABLE), scopedPolicies);
         }
-        return Optional.empty();
+        return IdentifierCasePolicyFactory.newInsensitivePolicySet();
     }
     
     @Override

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
@@ -46,7 +46,6 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class MySQLIdentifierCasePolicyProviderTest {
     
@@ -57,55 +56,40 @@ class MySQLIdentifierCasePolicyProviderTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("provideArguments")
     void assertProvide(final String name, final IdentifierCasePolicyProviderContext context, final LookupMode expectedQuotedLookupMode,
-                       final LookupMode expectedUnquotedLookupMode, final Boolean expectedMatch) {
-        IdentifierCasePolicy actual = provider.provide(context).map(policySet -> policySet.getPolicy(IdentifierScope.TABLE)).orElse(null);
-        assertLookupMode(actual, QuoteCharacter.BACK_QUOTE, expectedQuotedLookupMode);
-        assertLookupMode(actual, QuoteCharacter.NONE, expectedUnquotedLookupMode);
-        assertMatch(actual, expectedMatch);
+                       final LookupMode expectedUnquotedLookupMode, final boolean expectedMatch) {
+        IdentifierCasePolicy actual = provider.provide(context).getPolicy(IdentifierScope.TABLE);
+        assertThat(actual.getLookupMode(QuoteCharacter.BACK_QUOTE), is(expectedQuotedLookupMode));
+        assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(expectedUnquotedLookupMode));
+        assertThat(actual.matches("foo", "FOO", QuoteCharacter.NONE), is(expectedMatch));
     }
     
     @Test
     void assertProvideWithQuotedTableName() {
-        IdentifierCasePolicy actual = provider.provide(new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 1)))
-                .map(policySet -> policySet.getPolicy(IdentifierScope.TABLE)).orElseThrow(AssertionError::new);
+        IdentifierCasePolicy actual = provider.provide(new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 1))).getPolicy(IdentifierScope.TABLE);
         assertThat(actual.getLookupMode(QuoteCharacter.BACK_QUOTE), is(LookupMode.NORMALIZED));
         assertThat(actual.matches("t_mask", "T_MASK", QuoteCharacter.BACK_QUOTE), is(Boolean.TRUE));
     }
     
-    private void assertMatch(final IdentifierCasePolicy actual, final Boolean expected) {
-        if (null == expected) {
-            assertNull(actual);
-        } else {
-            assertThat(actual.matches("foo", "FOO", QuoteCharacter.NONE), is(expected));
-        }
-    }
-    
-    private void assertLookupMode(final IdentifierCasePolicy actual, final QuoteCharacter quoteCharacter, final LookupMode expected) {
-        if (null == expected) {
-            assertNull(actual);
-        } else {
-            assertThat(actual.getLookupMode(quoteCharacter), is(expected));
-        }
-    }
-    
     private static Stream<Arguments> provideArguments() {
         return Stream.of(
-                Arguments.of("null_data_source", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, null), null, null, null),
-                Arguments.of("null_connection", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new NullConnectionFixtureDataSource()), null, null, null),
+                Arguments.of("null_data_source", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, null), LookupMode.EXACT, LookupMode.NORMALIZED, true),
+                Arguments.of("null_connection", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new NullConnectionFixtureDataSource()), LookupMode.EXACT, LookupMode.NORMALIZED, true),
                 Arguments.of("lower_case_table_names_0", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 0)),
-                        LookupMode.EXACT, LookupMode.EXACT, Boolean.FALSE),
+                        LookupMode.EXACT, LookupMode.EXACT, false),
                 Arguments.of("lower_case_table_names_1", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 1)),
-                        LookupMode.NORMALIZED, LookupMode.NORMALIZED, Boolean.TRUE),
+                        LookupMode.NORMALIZED, LookupMode.NORMALIZED, true),
                 Arguments.of("lower_case_table_names_2", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 2)),
-                        LookupMode.NORMALIZED, LookupMode.NORMALIZED, Boolean.TRUE),
-                Arguments.of("no_result_row", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(false, 0)), null, null, null),
-                Arguments.of("sql_exception", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FailingFixtureDataSource()), null, null, null));
+                        LookupMode.NORMALIZED, LookupMode.NORMALIZED, true),
+                Arguments.of("no_result_row", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(false, 0)), LookupMode.EXACT, LookupMode.NORMALIZED, true),
+                Arguments.of("sql_exception", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FailingFixtureDataSource()), LookupMode.EXACT, LookupMode.NORMALIZED, true),
+                Arguments.of("unexpected_lower_case_table_names", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 3)), LookupMode.EXACT, LookupMode.NORMALIZED,
+                        true));
     }
     
     @Test
     void assertProvideWithLowerCaseTableNamesZeroUsesScopedPolicies() {
         IdentifierCasePolicyProviderContext context = new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 0));
-        IdentifierCasePolicySet actual = provider.provide(context).orElseThrow(AssertionError::new);
+        IdentifierCasePolicySet actual = provider.provide(context);
         assertThat(actual.getPolicy(IdentifierScope.SCHEMA).matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE), is(Boolean.TRUE));
         assertThat(actual.getPolicy(IdentifierScope.TABLE).matches("foo_tbl", "FOO_TBL", QuoteCharacter.NONE), is(Boolean.FALSE));
         assertThat(actual.getPolicy(IdentifierScope.VIEW).matches("foo_view", "FOO_VIEW", QuoteCharacter.NONE), is(Boolean.FALSE));

--- a/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCasePolicyProvider.java
@@ -26,7 +26,6 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * openGauss provider of identifier case rules.
@@ -34,11 +33,11 @@ import java.util.Optional;
 public final class OpenGaussIdentifierCasePolicyProvider implements IdentifierCasePolicyProvider {
     
     @Override
-    public Optional<IdentifierCasePolicySet> provide(final IdentifierCasePolicyProviderContext context) {
+    public IdentifierCasePolicySet provide(final IdentifierCasePolicyProviderContext context) {
         IdentifierCasePolicySet lowerCasePolicySet = IdentifierCasePolicyFactory.newLowerCasePolicySet();
         Map<IdentifierScope, IdentifierCasePolicy> scopedRules = new EnumMap<>(IdentifierScope.class);
         scopedRules.put(IdentifierScope.SCHEMA, IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.SCHEMA));
-        return Optional.of(new IdentifierCasePolicySet(lowerCasePolicySet.getPolicy(IdentifierScope.TABLE), scopedRules));
+        return new IdentifierCasePolicySet(lowerCasePolicySet.getPolicy(IdentifierScope.TABLE), scopedRules);
     }
     
     @Override

--- a/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCasePolicyProviderTest.java
@@ -49,11 +49,11 @@ class OpenGaussIdentifierCasePolicyProviderTest {
     @Test
     void assertProvide() {
         IdentifierCasePolicyProviderContext context = new IdentifierCasePolicyProviderContext(databaseType, null);
-        IdentifierCasePolicy tableRule = provider.provide(context).orElseThrow(AssertionError::new).getPolicy(IdentifierScope.TABLE);
+        IdentifierCasePolicy tableRule = provider.provide(context).getPolicy(IdentifierScope.TABLE);
         assertThat(tableRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
         assertTrue(tableRule.matches("foo", "FOO", QuoteCharacter.NONE));
         assertFalse(tableRule.matches("Foo", "foo", QuoteCharacter.NONE));
-        IdentifierCasePolicy schemaRule = provider.provide(context).orElseThrow(AssertionError::new).getPolicy(IdentifierScope.SCHEMA);
+        IdentifierCasePolicy schemaRule = provider.provide(context).getPolicy(IdentifierScope.SCHEMA);
         assertThat(schemaRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
         assertTrue(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.NONE));
         assertFalse(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.QUOTE));

--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/identifier/OracleIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/identifier/OracleIdentifierCasePolicyProvider.java
@@ -22,16 +22,14 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 
-import java.util.Optional;
-
 /**
  * Oracle provider of identifier case rules.
  */
 public final class OracleIdentifierCasePolicyProvider implements IdentifierCasePolicyProvider {
     
     @Override
-    public Optional<IdentifierCasePolicySet> provide(final IdentifierCasePolicyProviderContext context) {
-        return Optional.of(IdentifierCasePolicyFactory.newUpperCasePolicySet());
+    public IdentifierCasePolicySet provide(final IdentifierCasePolicyProviderContext context) {
+        return IdentifierCasePolicyFactory.newUpperCasePolicySet();
     }
     
     @Override

--- a/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/identifier/OracleIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/identifier/OracleIdentifierCasePolicyProviderTest.java
@@ -48,7 +48,7 @@ class OracleIdentifierCasePolicyProviderTest {
     
     @Test
     void assertProvide() {
-        IdentifierCasePolicy actual = provider.provide(new IdentifierCasePolicyProviderContext(databaseType, null)).orElseThrow(AssertionError::new).getPolicy(IdentifierScope.TABLE);
+        IdentifierCasePolicy actual = provider.provide(new IdentifierCasePolicyProviderContext(databaseType, null)).getPolicy(IdentifierScope.TABLE);
         assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
         assertTrue(actual.matches("FOO", "foo", QuoteCharacter.NONE));
         assertFalse(actual.matches("Foo", "foo", QuoteCharacter.NONE));

--- a/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCasePolicyProvider.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * PostgreSQL provider of identifier case rules.
@@ -33,11 +32,11 @@ import java.util.Optional;
 public final class PostgreSQLIdentifierCasePolicyProvider implements IdentifierCasePolicyProvider {
     
     @Override
-    public Optional<IdentifierCasePolicySet> provide(final IdentifierCasePolicyProviderContext context) {
+    public IdentifierCasePolicySet provide(final IdentifierCasePolicyProviderContext context) {
         IdentifierCasePolicySet lowerCasePolicySet = IdentifierCasePolicyFactory.newLowerCasePolicySet();
         Map<IdentifierScope, IdentifierCasePolicy> scopedRules = new EnumMap<>(IdentifierScope.class);
         scopedRules.put(IdentifierScope.SCHEMA, IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.SCHEMA));
-        return Optional.of(new IdentifierCasePolicySet(lowerCasePolicySet.getPolicy(IdentifierScope.TABLE), scopedRules));
+        return new IdentifierCasePolicySet(lowerCasePolicySet.getPolicy(IdentifierScope.TABLE), scopedRules);
     }
     
     @Override

--- a/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCasePolicyProviderTest.java
@@ -49,11 +49,11 @@ class PostgreSQLIdentifierCasePolicyProviderTest {
     @Test
     void assertProvide() {
         IdentifierCasePolicyProviderContext context = new IdentifierCasePolicyProviderContext(databaseType, null);
-        IdentifierCasePolicy tableRule = provider.provide(context).orElseThrow(AssertionError::new).getPolicy(IdentifierScope.TABLE);
+        IdentifierCasePolicy tableRule = provider.provide(context).getPolicy(IdentifierScope.TABLE);
         assertThat(tableRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
         assertTrue(tableRule.matches("foo", "FOO", QuoteCharacter.NONE));
         assertFalse(tableRule.matches("Foo", "foo", QuoteCharacter.NONE));
-        IdentifierCasePolicy schemaRule = provider.provide(context).orElseThrow(AssertionError::new).getPolicy(IdentifierScope.SCHEMA);
+        IdentifierCasePolicy schemaRule = provider.provide(context).getPolicy(IdentifierScope.SCHEMA);
         assertThat(schemaRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
         assertTrue(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.NONE));
         assertFalse(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.QUOTE));

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierCasePolicyResolver.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierCasePolicyResolver.java
@@ -54,7 +54,7 @@ public final class IdentifierCasePolicyResolver {
         }
         IdentifierCasePolicyProviderContext context = new IdentifierCasePolicyProviderContext(databaseType, dataSource);
         return DatabaseTypedSPILoader.findService(IdentifierCasePolicyProvider.class, databaseType)
-                .flatMap(each -> each.provide(context))
+                .map(each -> each.provide(context))
                 .orElseGet(IdentifierCasePolicyFactory::newInsensitivePolicySet);
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove Optional from provide method in case policy providers

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
