### PR TITLE
Fix microseconds decoded as nanoseconds in MySQL binary TIME value

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
 1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)
 1. Metadata: Fix Oracle metadata version comparison skipping identity and collation columns on 18c and later - [#39104](https://github.com/apache/shardingsphere/pull/39104)
+1. Proxy: Fix microseconds decoded as nanoseconds in MySQL binary TIME value - [#39138](https://github.com/apache/shardingsphere/pull/39138)
 
 ### Enhancements
 

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValue.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValue.java
@@ -44,7 +44,7 @@ public final class MySQLTimeBinaryProtocolValue implements MySQLBinaryProtocolVa
                 return getTimestamp(payload);
             case 12:
                 Timestamp result = getTimestamp(payload);
-                result.setNanos(payload.readInt4());
+                result.setNanos(payload.readInt4() * 1000);
                 return result;
             default:
                 throw new SQLFeatureNotSupportedException(String.format("Wrong length `%d` of MYSQL_TYPE_DATE", length));

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValueTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValueTest.java
@@ -97,7 +97,8 @@ class MySQLTimeBinaryProtocolValueTest {
         return Stream.of(
                 Arguments.of("zero_length", new int[]{0, 0, 0, 0, 0}, new int[]{0, 0}, new Timestamp(0L)),
                 Arguments.of("eight_bytes", new int[]{8, 0, 10, 59, 0}, new int[]{0, 0}, createTimestamp(0)),
-                Arguments.of("twelve_bytes", new int[]{12, 0, 10, 59, 0}, new int[]{0, 1000}, createTimestamp(1000)));
+                Arguments.of("twelve_bytes", new int[]{12, 0, 10, 59, 0}, new int[]{0, 1000}, createTimestamp(1_000_000)),
+                Arguments.of("twelve_bytes_fractional_second", new int[]{12, 0, 10, 59, 0}, new int[]{0, 230000}, createTimestamp(230_000_000)));
     }
     
     private static Stream<Arguments> writeArguments() {


### PR DESCRIPTION

Fixes #39135.

Changes proposed in this pull request:
  - In `MySQLTimeBinaryProtocolValue.read()` (length 12 case), multiply the 4-byte fractional field by 1000 before `Timestamp#setNanos`, since the MySQL binary protocol encodes it as microseconds while `setNanos` expects nanoseconds.
  - Aligns with the sibling `MySQLDateBinaryProtocolValue.read()`, which already applies `readInt4() * 1000`, and with this class's own `writeNanos()` writing `nanos / 1000`.
  - Correct the existing `twelve_bytes` test expectation (which locked in the bug) and add a `twelve_bytes_fractional_second` case asserting 230000 microseconds decode to 230,000,000 nanoseconds.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
