### PR TITLE
Fix typos in ShardingSphere distribution README

### DIFF
--- a/distribution/jdbc/src/main/release-docs/README.txt
+++ b/distribution/jdbc/src/main/release-docs/README.txt
@@ -7,9 +7,9 @@ The goal is to minimize or eliminate the challenges caused by underlying databas
 
 The concepts at the core of the project are Connect, Enhance and Pluggable.
 
-- `Connect:` Flexible adaptation of database protocol, SQL dialect and database storage. It can quickly connect applications and heterogeneous databases quickly.
+- `Connect:` Flexible adaptation of database protocol, SQL dialect and database storage. It can quickly connect applications and heterogeneous databases.
 - `Enhance:` Capture database access entry to provide additional features transparently, such as: redirect (sharding, readwrite-splitting and shadow), transform (data encrypt and mask), authentication (security, audit and authority), governance (circuit breaker and access limitation and analyze, QoS and observability).
-- `Pluggable:` Leveraging the micro kernel and 3 layers pluggable mode, features and database ecosystem can be embedded flexibily. Developers can customize their ShardingSphere just like building with LEGO blocks.
+- `Pluggable:` Leveraging the micro kernel and 3 layers pluggable mode, features and database ecosystem can be embedded flexibly. Developers can customize their ShardingSphere just like building with LEGO blocks.
 
 Apache ShardingSphere including 2 independent products: JDBC & Proxy.
 They all provide functions of data scale-out, distributed transaction and distributed governance,

--- a/distribution/proxy/src/main/release-docs/README.txt
+++ b/distribution/proxy/src/main/release-docs/README.txt
@@ -7,9 +7,9 @@ The goal is to minimize or eliminate the challenges caused by underlying databas
 
 The concepts at the core of the project are Connect, Enhance and Pluggable.
 
-- `Connect:` Flexible adaptation of database protocol, SQL dialect and database storage. It can quickly connect applications and heterogeneous databases quickly.
+- `Connect:` Flexible adaptation of database protocol, SQL dialect and database storage. It can quickly connect applications and heterogeneous databases.
 - `Enhance:` Capture database access entry to provide additional features transparently, such as: redirect (sharding, readwrite-splitting and shadow), transform (data encrypt and mask), authentication (security, audit and authority), governance (circuit breaker and access limitation and analyze, QoS and observability).
-- `Pluggable:` Leveraging the micro kernel and 3 layers pluggable mode, features and database ecosystem can be embedded flexibily. Developers can customize their ShardingSphere just like building with LEGO blocks.
+- `Pluggable:` Leveraging the micro kernel and 3 layers pluggable mode, features and database ecosystem can be embedded flexibly. Developers can customize their ShardingSphere just like building with LEGO blocks.
 
 Apache ShardingSphere including 2 independent products: JDBC & Proxy.
 They all provide functions of data scale-out, distributed transaction and distributed governance,


### PR DESCRIPTION
No issue: typo fix (documentation-only, no behavior change).

Changes proposed in this pull request:
  - Correct the misspelling `flexibily` to `flexibly` in the `Pluggable` bullet.
  - Remove the duplicated adverb `quickly` in the `Connect` bullet (`... connect applications and heterogeneous databases quickly.` → `... connect applications and heterogeneous databases.`).
  - Apply the same fixes to both `distribution/proxy` and `distribution/jdbc` release-docs README.txt, which share this identical header, keeping the sibling files consistent.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
