### PR TITLE
Fix stale Jaeger exporter in agent sample tracing config

### DIFF
--- a/distribution/agent/src/main/resources/conf/agent.yaml
+++ b/distribution/agent/src/main/resources/conf/agent.yaml
@@ -28,6 +28,6 @@ plugins:
 #    OpenTelemetry:
 #      props:
 #        otel.service.name: "shardingsphere"
-#        otel.traces.exporter: "jaeger"
+#        otel.traces.exporter: "otlp"
 #        otel.traces.sampler: "always_on"
-#        otel.exporter.otlp.traces.endpoint: "http://localhost:14250"
+#        otel.exporter.otlp.traces.endpoint: "http://localhost:4317"

--- a/docs/document/content/user-manual/shardingsphere-agent/configuration/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-agent/configuration/_index.cn.md
@@ -21,7 +21,7 @@ plugins:
 #    OpenTelemetry:
 #      props:
 #        otel.service.name: "shardingsphere"
-#        otel.traces.exporter: "jaeger"
-#        otel.exporter.otlp.traces.endpoint: "http://localhost:14250"
+#        otel.traces.exporter: "otlp"
+#        otel.exporter.otlp.traces.endpoint: "http://localhost:4317"
 #        otel.traces.sampler: "always_on"
 ```

--- a/docs/document/content/user-manual/shardingsphere-agent/configuration/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-agent/configuration/_index.en.md
@@ -22,7 +22,7 @@ plugins:
 #    OpenTelemetry:
 #      props:
 #        otel.service.name: "shardingsphere"
-#        otel.traces.exporter: "jaeger"
-#        otel.exporter.otlp.traces.endpoint: "http://localhost:14250"
+#        otel.traces.exporter: "otlp"
+#        otel.exporter.otlp.traces.endpoint: "http://localhost:4317"
 #        otel.traces.sampler: "always_on"
 ```

--- a/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.cn.md
@@ -64,8 +64,8 @@ plugins:
 #    OpenTelemetry:
 #      props:
 #        otel.service.name: "shardingsphere"
-#        otel.traces.exporter: "jaeger"
-#        otel.exporter.otlp.traces.endpoint: "http://localhost:14250"
+#        otel.traces.exporter: "otlp"
+#        otel.exporter.otlp.traces.endpoint: "http://localhost:4317"
 #        otel.traces.sampler: "always_on"
 ```
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.en.md
@@ -66,8 +66,8 @@ plugins:
 #    OpenTelemetry:
 #      props:
 #        otel.service.name: "shardingsphere"
-#        otel.traces.exporter: "jaeger"
-#        otel.exporter.otlp.traces.endpoint: "http://localhost:14250"
+#        otel.traces.exporter: "otlp"
+#        otel.exporter.otlp.traces.endpoint: "http://localhost:4317"
 #        otel.traces.sampler: "always_on"
 ```
 


### PR DESCRIPTION
No issue: sample/docs correctness fix (no runtime behavior change).

Changes proposed in this pull request:
  - The commented OpenTelemetry sample set `otel.traces.exporter: "jaeger"`, but the bundled OpenTelemetry Java SDK is `1.58.0` and the tracing plugin bundles only the `otlp` and `zipkin` exporters. So uncommenting this sample makes `AutoConfiguredOpenTelemetrySdk` fail at startup on an unrecognized exporter.
  - `OpenTelemetryTracingPluginLifecycleService#start` forwards every prop to a system property before autoconfigure runs, so the value is really consumed rather than inert.
  - Corrected the exporter to `otlp` and the endpoint to the OTLP gRPC default port `4317`, matching the project's own E2E Jaeger config `test/e2e/agent/engine/src/test/resources/env/agent/conf/jaeger/agent.yaml` (Jaeger natively ingests OTLP).
  - Applied the identical fix to the four docs that mirror this sample: agent configuration (en/cn) and proxy observability (en/cn).

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally <!-- ran scoped `./mvnw spotless:check apache-rat:check -Pcheck -pl distribution/agent` → BUILD SUCCESS; full `clean install` skipped because no Java is compiled (only a commented YAML sample and Markdown docs changed). -->
- [x] I have made corresponding changes to the documentation. <!-- fixed the same stale sample in the agent configuration and proxy observability docs. -->
- [ ] I have added corresponding unit tests for my changes. <!-- none: the changed lines are commented sample config and docs; shipped runtime behavior is unchanged, and the correct form is already covered by the E2E jaeger config. -->
- [ ] I have updated the Release Notes of the current development version. <!-- skipped: docs/sample-only change, no behavior or API change. -->

