### PR TITLE
Fix unexpanded LOCAL_PATH in Proxy Native Dockerfile ENTRYPOINT

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,7 @@
 1. Proxy: Fix microseconds decoded as nanoseconds in MySQL binary TIME value - [#39138](https://github.com/apache/shardingsphere/pull/39138)
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
 1. Proxy: Fix MySQL prepared statement parameter signedness decoding - [#39204](https://github.com/apache/shardingsphere/pull/39204)
+1. Proxy: Fix Proxy Native Docker image failing to start due to unexpanded LOCAL_PATH in ENTRYPOINT - [#39146](https://github.com/apache/shardingsphere/pull/39146)
 1. JDBC & Proxy: Remove default MySQL prepared statement query properties when creating data sources - [#38593](https://github.com/apache/shardingsphere/pull/38593)
 1. Mode: Fix rule metadata not removed from memory after dropping rules in Etcd cluster mode - [#38561](https://github.com/apache/shardingsphere/pull/38561)
 1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)

--- a/distribution/proxy-native/Dockerfile-linux-dynamic
+++ b/distribution/proxy-native/Dockerfile-linux-dynamic
@@ -22,7 +22,6 @@ RUN --mount=type=cache,target=/root/.m2 ./mvnw -am -pl distribution/proxy-native
 
 FROM gcr.io/distroless/java-base-debian12:latest
 LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
-ENV LOCAL_PATH=/opt/shardingsphere-proxy
 ARG PROJECT_VERSION
-COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin ${LOCAL_PATH}
+COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin /opt/shardingsphere-proxy
 ENTRYPOINT ["/opt/shardingsphere-proxy/bin/shardingsphere-proxy-native", "3307", "/opt/shardingsphere-proxy/conf", "0.0.0.0"]

--- a/distribution/proxy-native/Dockerfile-linux-dynamic
+++ b/distribution/proxy-native/Dockerfile-linux-dynamic
@@ -25,4 +25,4 @@ LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache
 ENV LOCAL_PATH=/opt/shardingsphere-proxy
 ARG PROJECT_VERSION
 COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin ${LOCAL_PATH}
-ENTRYPOINT ["${LOCAL_PATH}/bin/shardingsphere-proxy-native", "3307", "${LOCAL_PATH}/conf", "0.0.0.0"]
+ENTRYPOINT ["/opt/shardingsphere-proxy/bin/shardingsphere-proxy-native", "3307", "/opt/shardingsphere-proxy/conf", "0.0.0.0"]

--- a/distribution/proxy-native/Dockerfile-linux-mostly
+++ b/distribution/proxy-native/Dockerfile-linux-mostly
@@ -23,7 +23,6 @@ RUN --mount=type=cache,target=/root/.m2 ./mvnw -am -pl distribution/proxy-native
 
 FROM gcr.io/distroless/base-debian12:latest
 LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
-ENV LOCAL_PATH=/opt/shardingsphere-proxy
 ARG PROJECT_VERSION
-COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin ${LOCAL_PATH}
+COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin /opt/shardingsphere-proxy
 ENTRYPOINT ["/opt/shardingsphere-proxy/bin/shardingsphere-proxy-native", "3307", "/opt/shardingsphere-proxy/conf", "0.0.0.0"]

--- a/distribution/proxy-native/Dockerfile-linux-mostly
+++ b/distribution/proxy-native/Dockerfile-linux-mostly
@@ -26,4 +26,4 @@ LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache
 ENV LOCAL_PATH=/opt/shardingsphere-proxy
 ARG PROJECT_VERSION
 COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin ${LOCAL_PATH}
-ENTRYPOINT ["${LOCAL_PATH}/bin/shardingsphere-proxy-native", "3307", "${LOCAL_PATH}/conf", "0.0.0.0"]
+ENTRYPOINT ["/opt/shardingsphere-proxy/bin/shardingsphere-proxy-native", "3307", "/opt/shardingsphere-proxy/conf", "0.0.0.0"]

--- a/distribution/proxy-native/Dockerfile-linux-static
+++ b/distribution/proxy-native/Dockerfile-linux-static
@@ -26,4 +26,4 @@ LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache
 ENV LOCAL_PATH=/opt/shardingsphere-proxy
 ARG PROJECT_VERSION
 COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin ${LOCAL_PATH}
-ENTRYPOINT ["${LOCAL_PATH}/bin/shardingsphere-proxy-native", "3307", "${LOCAL_PATH}/conf", "0.0.0.0"]
+ENTRYPOINT ["/opt/shardingsphere-proxy/bin/shardingsphere-proxy-native", "3307", "/opt/shardingsphere-proxy/conf", "0.0.0.0"]

--- a/distribution/proxy-native/Dockerfile-linux-static
+++ b/distribution/proxy-native/Dockerfile-linux-static
@@ -23,7 +23,6 @@ RUN --mount=type=cache,target=/root/.m2 ./mvnw -am -pl distribution/proxy-native
 
 FROM scratch
 LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
-ENV LOCAL_PATH=/opt/shardingsphere-proxy
 ARG PROJECT_VERSION
-COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin ${LOCAL_PATH}
+COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin /opt/shardingsphere-proxy
 ENTRYPOINT ["/opt/shardingsphere-proxy/bin/shardingsphere-proxy-native", "3307", "/opt/shardingsphere-proxy/conf", "0.0.0.0"]


### PR DESCRIPTION
Fixes #39143.

Changes proposed in this pull request:
  - Replace the exec-form `ENTRYPOINT` `${LOCAL_PATH}` references with the literal `/opt/shardingsphere-proxy` in all three Proxy Native Dockerfiles (`Dockerfile-linux-dynamic`, `Dockerfile-linux-mostly`, `Dockerfile-linux-static`).
  - Reason: Docker exec form (JSON array) invokes no shell, so `${LOCAL_PATH}` was never expanded; the container exec'd the literal path and failed to start. `COPY` expands it, so images built/pushed fine and CI never runs the container, keeping the bug latent.
  - The literal is provably equivalent: `LOCAL_PATH` is `ENV LOCAL_PATH=/opt/shardingsphere-proxy` (not `ARG`), so it cannot be overridden by `--build-arg`; the pom's `docker.build/push.native.linux` executions pass only `PROJECT_VERSION`. The value always matches the `COPY --from=nativebuild ... ${LOCAL_PATH}` destination.
  - Exec form is kept for correct PID-1 signal handling. Shell-form is not an option because the base images (`gcr.io/distroless/*`, `scratch`) have no shell; the sibling `distribution/proxy/Dockerfile` uses shell-form only because its `eclipse-temurin` base has one. Backward-compatible: only repairs broken startup.
  - Verification is static plus Docker-runtime only; this module is `packaging=pom` with no Java sources.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw spotless:check checkstyle:check apache-rat:check -Pcheck -T1C -pl distribution/proxy-native` (module is `packaging=pom`; full `install` triggers the GraalVM native build, not run locally).
- [ ] I have made corresponding changes to the documentation.
- [ ] No unit tests: `distribution/proxy-native` is a packaging-only (`pom`) module with no Java sources; a Dockerfile `ENTRYPOINT` is only exercisable at Docker runtime, not by `./mvnw ... test`.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)


