### PR TITLE
Harden metadata contracts and workflow coverage

### DIFF
--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/MCPSyncServerFactory.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/MCPSyncServerFactory.java
@@ -31,12 +31,15 @@ import org.apache.shardingsphere.mcp.bootstrap.transport.capability.tool.MCPTool
 import org.apache.shardingsphere.mcp.core.context.MCPRuntimeContext;
 import org.apache.shardingsphere.mcp.support.markdown.MCPMarkdownResourceLoader;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
  * MCP sync server factory.
  */
 public final class MCPSyncServerFactory {
+    
+    private static final Duration CLIENT_REQUEST_TIMEOUT = Duration.ofMinutes(10L);
     
     private final McpJsonMapper jsonMapper;
     
@@ -78,6 +81,7 @@ public final class MCPSyncServerFactory {
     
     private McpSyncServer create(final McpServer.SyncSpecification<?> specification) {
         return specification.jsonMapper(jsonMapper)
+                .requestTimeout(CLIENT_REQUEST_TIMEOUT)
                 .serverInfo(MCPTransportConstants.SERVER_NAME, Optional.ofNullable(MCPSyncServerFactory.class.getPackage().getImplementationVersion()).orElse("development"))
                 .instructions(MCPMarkdownResourceLoader.load(MCPTransportConstants.SERVER_INSTRUCTIONS_RESOURCE, "server instruction"))
                 .capabilities(ServerCapabilities.builder().resources(false, false).tools(false).prompts(false).completions().build())

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/MCPSyncServerFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/MCPSyncServerFactoryTest.java
@@ -24,7 +24,9 @@ import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpec
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.DefaultMcpStreamableServerSessionFactory;
 import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.McpServerTransport;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import io.modelcontextprotocol.spec.McpStreamableServerSession;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
@@ -38,8 +40,10 @@ import org.apache.shardingsphere.mcp.core.context.MCPRuntimeContext;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import org.mockito.internal.configuration.plugins.Plugins;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -55,7 +59,7 @@ import static org.mockito.Mockito.when;
 class MCPSyncServerFactoryTest {
     
     @Test
-    void assertCreateWithTransportProvider() {
+    void assertCreateWithTransportProvider() throws NoSuchFieldException, IllegalAccessException {
         TestServerTransportProvider transportProvider = new TestServerTransportProvider();
         McpSyncServer actual = createFactory().create(transportProvider);
         assertNotNull(transportProvider.sessionFactory);
@@ -65,17 +69,20 @@ class MCPSyncServerFactoryTest {
         assertThat(actual.listResources().size(), is(1));
         assertThat(actual.listResourceTemplates().size(), is(1));
         assertThat(actual.listPrompts().size(), is(1));
+        McpServerSession session = transportProvider.sessionFactory.create(mock(McpServerTransport.class));
+        assertThat(getRequestTimeout(McpServerSession.class, session), is(Duration.ofMinutes(10L)));
         actual.closeGracefully();
     }
     
     @Test
-    void assertCreateWithStreamableTransportProvider() {
+    void assertCreateWithStreamableTransportProvider() throws NoSuchFieldException, IllegalAccessException {
         TestStreamableTransportProvider transportProvider = new TestStreamableTransportProvider();
         McpSyncServer actual = createFactory().create(transportProvider);
         assertNotNull(transportProvider.sessionFactory);
         assertThat(actual.listTools().size(), is(1));
         assertThat(actual.listResources().size(), is(1));
         assertThat(actual.listResourceTemplates().size(), is(1));
+        assertThat(getRequestTimeout(DefaultMcpStreamableServerSessionFactory.class, transportProvider.sessionFactory), is(Duration.ofMinutes(10L)));
         actual.closeGracefully();
     }
     
@@ -118,6 +125,10 @@ class MCPSyncServerFactoryTest {
                                 (exchange, request) -> new McpSchema.CompleteResult(new McpSchema.CompleteResult.CompleteCompletion(List.of(), 0, false))))))) {
             return new MCPSyncServerFactory(runtimeContext, MCPTransportJsonMapperFactory.create());
         }
+    }
+    
+    private Duration getRequestTimeout(final Class<?> targetClass, final Object target) throws NoSuchFieldException, IllegalAccessException {
+        return (Duration) Plugins.getMemberAccessor().get(targetClass.getDeclaredField("requestTimeout"), target);
     }
     
     private McpSchema.CallToolResult createFixtureToolResult() {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProvider.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProvider.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.mcp.core.completion.provider;
 
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPUnsupportedException;
 import org.apache.shardingsphere.mcp.core.metadata.GovernanceMetadataQueryService;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
@@ -30,6 +29,7 @@ import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProviderRes
 import org.apache.shardingsphere.mcp.support.completion.MCPCompletionRequest;
 import org.apache.shardingsphere.mcp.support.MCPFeatureRequestContext;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.resource.MCPUriPathSegmentUtils;
 
@@ -152,7 +152,7 @@ public final class MetadataCompletionProvider implements MCPCompletionProvider<M
         String schema = getSchema(contextArguments);
         String table = contextArguments.getOrDefault("table", "");
         return database.isEmpty() || schema.isEmpty() || table.isEmpty() ? List.of()
-                : handlerContext.getMetadataQueryFacade().queryTableColumns(database, schema, table).stream().map(ShardingSphereColumn::getName)
+                : handlerContext.getMetadataQueryFacade().queryTableColumns(database, schema, table).stream().map(MCPColumnMetadata::getName)
                         .map(each -> new MCPCompletionCandidate(each, "column", "metadata")).toList();
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourcePayloadMapper.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourcePayloadMapper.java
@@ -19,13 +19,13 @@ package org.apache.shardingsphere.mcp.core.resource.handler.metadata;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 import org.apache.shardingsphere.mcp.support.descriptor.ShardingSphereMCPResourceMetadata;
 
@@ -68,8 +68,8 @@ public final class MetadataResourcePayloadMapper {
             ShardingSphereTable table = (ShardingSphereTable) item;
             return "view".equals(metadata.getObjectScope()) ? createViewPayload(getDatabase(), getSchema(), table, detail) : createTablePayload(getDatabase(), getSchema(), table, detail);
         }
-        if (item instanceof ShardingSphereColumn) {
-            return createColumnPayload((ShardingSphereColumn) item);
+        if (item instanceof MCPColumnMetadata) {
+            return createColumnPayload((MCPColumnMetadata) item);
         }
         if (item instanceof ShardingSphereIndex) {
             return createIndexPayload((ShardingSphereIndex) item);
@@ -115,10 +115,11 @@ public final class MetadataResourcePayloadMapper {
         result.put("schema", schema);
         result.put("table", table.getName());
         result.put("columns", detail
-                ? table.getAllColumns().stream().sorted(Comparator.comparing(ShardingSphereColumn::getName)).map(each -> createColumnPayload(database, schema, table.getName(), "", each)).toList()
+                ? metadataQueryFacade.queryTableColumns(database, schema, table.getName()).stream()
+                        .map(each -> createColumnPayload(database, schema, table.getName(), "", each)).toList()
                 : List.of());
         result.put("indexes", detail
-                ? table.getAllIndexes().stream().sorted(Comparator.comparing(ShardingSphereIndex::getName)).map(each -> createIndexPayload(database, schema, table.getName(), each)).toList()
+                ? metadataQueryFacade.queryIndexes(database, schema, table.getName()).stream().map(each -> createIndexPayload(database, schema, table.getName(), each)).toList()
                 : List.of());
         return result;
     }
@@ -129,22 +130,27 @@ public final class MetadataResourcePayloadMapper {
         result.put("schema", schema);
         result.put("view", view.getName());
         result.put("columns", detail
-                ? view.getAllColumns().stream().sorted(Comparator.comparing(ShardingSphereColumn::getName)).map(each -> createColumnPayload(database, schema, "", view.getName(), each)).toList()
+                ? metadataQueryFacade.queryViewColumns(database, schema, view.getName()).stream()
+                        .map(each -> createColumnPayload(database, schema, "", view.getName(), each)).toList()
                 : List.of());
         return result;
     }
     
-    private Map<String, Object> createColumnPayload(final ShardingSphereColumn column) {
+    private Map<String, Object> createColumnPayload(final MCPColumnMetadata column) {
         return createColumnPayload(getDatabase(), getSchema(), getVariable("table"), getVariable("view"), column);
     }
     
-    private Map<String, Object> createColumnPayload(final String database, final String schema, final String table, final String view, final ShardingSphereColumn column) {
-        Map<String, Object> result = new LinkedHashMap<>(5, 1F);
+    private Map<String, Object> createColumnPayload(final String database, final String schema, final String table, final String view, final MCPColumnMetadata column) {
+        Map<String, Object> result = new LinkedHashMap<>(9, 1F);
         result.put("database", database);
         result.put("schema", schema);
         result.put("table", table);
         result.put("view", view);
         result.put("column", column.getName());
+        result.put("ordinalPosition", column.getOrdinalPosition());
+        result.put("jdbcType", column.getJdbcType());
+        result.put("nativeTypeName", column.getNativeTypeName());
+        result.put("nullability", column.getNullability().getValue());
         return result;
     }
     
@@ -153,11 +159,13 @@ public final class MetadataResourcePayloadMapper {
     }
     
     private Map<String, Object> createIndexPayload(final String database, final String schema, final String table, final ShardingSphereIndex index) {
-        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(6, 1F);
         result.put("database", database);
         result.put("schema", schema);
         result.put("table", table);
         result.put("index", index.getName());
+        result.put("columns", index.getColumns());
+        result.put("unique", index.isUnique());
         return result;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/MetadataSearchCollector.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/MetadataSearchCollector.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.mcp.core.tool.handler.metadata;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
@@ -29,9 +29,11 @@ import org.apache.shardingsphere.mcp.core.tool.request.MetadataSearchRequest;
 import org.apache.shardingsphere.mcp.core.tool.payload.MetadataSearchHit;
 import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPMetadataObjectType;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -129,16 +131,27 @@ final class MetadataSearchCollector {
     
     private List<MetadataSearchHit> queryColumnSearchHits(final String databaseName, final String schemaName) {
         List<MetadataSearchHit> result = new LinkedList<>();
-        for (TableSearchScope each : queryTables(databaseName, schemaName)) {
-            for (ShardingSphereColumn column : metadataQueryFacade.queryTableColumns(databaseName, each.schema, each.table.getName())) {
-                result.add(createColumnSearchHit(databaseName, each.schema, each.table.getName(), "", column));
+        List<String> schemaNames = schemaName.isEmpty()
+                ? metadataQueryFacade.querySchemas(databaseName).stream().map(ShardingSphereSchema::getName).toList()
+                : List.of(schemaName);
+        for (String each : schemaNames) {
+            Map<String, TableType> relationTypes = createRelationTypes(databaseName, each);
+            for (MCPColumnMetadata column : metadataQueryFacade.querySchemaColumns(databaseName, each)) {
+                TableType relationType = relationTypes.get(column.getRelationName());
+                if (TableType.TABLE == relationType) {
+                    result.add(createColumnSearchHit(databaseName, each, column.getRelationName(), "", column));
+                } else if (TableType.VIEW == relationType) {
+                    result.add(createColumnSearchHit(databaseName, each, "", column.getRelationName(), column));
+                }
             }
         }
-        for (TableSearchScope each : queryViews(databaseName, schemaName)) {
-            for (ShardingSphereColumn column : metadataQueryFacade.queryViewColumns(databaseName, each.schema, each.table.getName())) {
-                result.add(createColumnSearchHit(databaseName, each.schema, "", each.table.getName(), column));
-            }
-        }
+        return result;
+    }
+    
+    private Map<String, TableType> createRelationTypes(final String databaseName, final String schemaName) {
+        Map<String, TableType> result = new LinkedHashMap<>();
+        metadataQueryFacade.queryTables(databaseName, schemaName).forEach(each -> result.put(each.getName(), TableType.TABLE));
+        metadataQueryFacade.queryViews(databaseName, schemaName).forEach(each -> result.put(each.getName(), TableType.VIEW));
         return result;
     }
     
@@ -209,7 +222,7 @@ final class MetadataSearchCollector {
         return createSearchHit(database, view.schema, SupportedMCPMetadataObjectType.VIEW, "", view.table.getName(), view.table.getName());
     }
     
-    private MetadataSearchHit createColumnSearchHit(final String database, final String schema, final String table, final String view, final ShardingSphereColumn column) {
+    private MetadataSearchHit createColumnSearchHit(final String database, final String schema, final String table, final String view, final MCPColumnMetadata column) {
         return createSearchHit(database, schema, SupportedMCPMetadataObjectType.COLUMN, table, view, column.getName());
     }
     

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProviderTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProviderTest.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.mcp.core.completion.provider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
@@ -31,6 +30,8 @@ import org.apache.shardingsphere.mcp.support.completion.MCPCompletionRequest;
 import org.apache.shardingsphere.mcp.support.MCPFeatureRequestContext;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
 import org.apache.shardingsphere.mcp.support.database.metadata.TransactionCapability;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureCapabilityFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
@@ -160,7 +161,7 @@ class MetadataCompletionProviderTest {
     void assertCompleteColumn() {
         MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
         when(metadataQueryFacade.queryTableColumns("logic_db", "public", "t_order"))
-                .thenReturn(List.of(new ShardingSphereColumn("order_id", java.sql.Types.OTHER, false, false, false, true, false, true)));
+                .thenReturn(List.of(new MCPColumnMetadata("t_order", "order_id", 1, java.sql.Types.BIGINT, "BIGINT", Nullability.NOT_NULLABLE)));
         MCPCompletionProviderResult actual = new MetadataCompletionProvider().complete(createHandlerContext(metadataQueryFacade),
                 createRequestContext("column", Map.of("database", "logic_db", "schema", "public", "table", "t_order")));
         assertCandidate(actual, "order_id");

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/ResourceTestDataFactory.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/ResourceTestDataFactory.java
@@ -41,6 +41,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -277,6 +278,7 @@ public final class ResourceTestDataFactory {
         when(result.createStatement()).thenReturn(statement);
         when(databaseMetaData.getDatabaseProductVersion()).thenReturn(databaseMetadata.databaseVersion);
         when(databaseMetaData.getURL()).thenReturn(createJdbcUrl(databaseMetadata.databaseType));
+        when(databaseMetaData.getSearchStringEscape()).thenReturn("\\");
         when(databaseMetaData.getTables(nullable(String.class), nullable(String.class), eq("%"), any(String[].class))).thenAnswer(invocation -> {
             String[] tableTypes = invocation.getArgument(3, String[].class);
             return createResultSet("TABLE".equals(tableTypes[0]) ? createTableRows(databaseMetadata) : createViewRows(databaseMetadata));
@@ -314,32 +316,35 @@ public final class ResourceTestDataFactory {
         return result;
     }
     
-    private static List<Map<String, String>> createColumnRows(final DatabaseMetadataFixture databaseMetadata, final String objectName) {
-        List<Map<String, String>> result = new LinkedList<>();
+    private static List<Map<String, Object>> createColumnRows(final DatabaseMetadataFixture databaseMetadata, final String objectName) {
+        List<Map<String, Object>> result = new LinkedList<>();
+        String relationName = "%".equals(objectName) ? "" : unescapePattern(objectName);
         for (SchemaMetadataFixture each : databaseMetadata.schemas) {
-            appendColumnRows(result, each.tables, objectName);
-            appendColumnRows(result, each.views, objectName);
+            appendColumnRows(result, each.tables, relationName);
+            appendColumnRows(result, each.views, relationName);
         }
         return result;
     }
     
-    private static void appendColumnRows(final List<Map<String, String>> result, final List<TableMetadataFixture> objects, final String objectName) {
+    private static void appendColumnRows(final List<Map<String, Object>> result, final List<TableMetadataFixture> objects, final String relationName) {
         for (TableMetadataFixture each : objects) {
-            if (each.name.equals(objectName)) {
-                for (String column : each.columns) {
-                    result.add(Map.of("COLUMN_NAME", column));
+            if (relationName.isEmpty() || each.name.equals(relationName)) {
+                for (int i = 0; i < each.columns.size(); i++) {
+                    result.add(Map.of("TABLE_NAME", each.name, "COLUMN_NAME", each.columns.get(i), "ORDINAL_POSITION", i + 1,
+                            "DATA_TYPE", Types.VARCHAR, "TYPE_NAME", "VARCHAR", "NULLABLE", DatabaseMetaData.columnNullable));
                 }
             }
         }
     }
     
-    private static List<Map<String, String>> createIndexRows(final DatabaseMetadataFixture databaseMetadata, final String tableName) {
-        List<Map<String, String>> result = new LinkedList<>();
+    private static List<Map<String, Object>> createIndexRows(final DatabaseMetadataFixture databaseMetadata, final String tableName) {
+        List<Map<String, Object>> result = new LinkedList<>();
         for (SchemaMetadataFixture each : databaseMetadata.schemas) {
             for (TableMetadataFixture table : each.tables) {
                 if (table.name.equals(tableName)) {
                     for (String index : table.indexes) {
-                        result.add(Map.of("INDEX_NAME", index));
+                        result.add(Map.of("INDEX_NAME", index, "TYPE", DatabaseMetaData.tableIndexOther, "NON_UNIQUE", false,
+                                "ORDINAL_POSITION", 1, "COLUMN_NAME", table.columns.isEmpty() ? "" : table.columns.getFirst()));
                     }
                 }
             }
@@ -357,12 +362,39 @@ public final class ResourceTestDataFactory {
         return result;
     }
     
-    private static ResultSet createResultSet(final List<Map<String, String>> rows) throws SQLException {
+    private static String unescapePattern(final String value) {
+        StringBuilder result = new StringBuilder(value.length());
+        boolean escaped = false;
+        for (char each : value.toCharArray()) {
+            if (escaped) {
+                result.append(each);
+                escaped = false;
+            } else if ('\\' == each) {
+                escaped = true;
+            } else {
+                result.append(each);
+            }
+        }
+        return escaped ? result.append('\\').toString() : result.toString();
+    }
+    
+    private static ResultSet createResultSet(final List<? extends Map<String, ?>> rows) throws SQLException {
         ResultSet result = mock(ResultSet.class);
         AtomicInteger rowIndex = new AtomicInteger(-1);
         when(result.next()).thenAnswer(invocation -> rowIndex.incrementAndGet() < rows.size());
-        when(result.getString(anyString())).thenAnswer(invocation -> rows.get(rowIndex.get()).get(invocation.getArgument(0, String.class)));
+        when(result.getString(anyString())).thenAnswer(invocation -> {
+            Object value = rows.get(rowIndex.get()).get(invocation.getArgument(0, String.class));
+            return null == value ? null : value.toString();
+        });
+        when(result.getInt(anyString())).thenAnswer(invocation -> getNumber(rows, rowIndex.get(), invocation.getArgument(0, String.class)).intValue());
+        when(result.getShort(anyString())).thenAnswer(invocation -> getNumber(rows, rowIndex.get(), invocation.getArgument(0, String.class)).shortValue());
+        when(result.getBoolean(anyString())).thenAnswer(invocation -> Boolean.TRUE.equals(rows.get(rowIndex.get()).get(invocation.getArgument(0, String.class))));
         return result;
+    }
+    
+    private static Number getNumber(final List<? extends Map<String, ?>> rows, final int rowIndex, final String columnName) {
+        Object value = rows.get(rowIndex).get(columnName);
+        return value instanceof Number ? (Number) value : 0;
     }
     
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourcePayloadMapperTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourcePayloadMapperTest.java
@@ -22,13 +22,14 @@ import org.apache.shardingsphere.mcp.support.database.metadata.TransactionCapabi
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 import org.apache.shardingsphere.mcp.support.descriptor.ShardingSphereMCPResourceMetadata;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -64,7 +66,10 @@ class MetadataResourcePayloadMapperTest {
     @Test
     void assertMapTableDetail() {
         MCPUriVariables uriVariables = new MCPUriVariables(Map.of("database", "logic_db", "schema", "public"));
-        List<?> actual = new MetadataResourcePayloadMapper(mock(MCPMetadataQueryFacade.class), uriVariables, true)
+        MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
+        when(metadataQueryFacade.queryTableColumns("logic_db", "public", "orders")).thenReturn(createColumns("orders"));
+        when(metadataQueryFacade.queryIndexes("logic_db", "public", "orders")).thenReturn(createIndexes());
+        List<?> actual = new MetadataResourcePayloadMapper(metadataQueryFacade, uriVariables, true)
                 .map(createMetadata("table"), List.of(createTable("orders", TableType.TABLE)));
         Map<?, ?> actualTable = (Map<?, ?>) actual.getFirst();
         assertThat(actualTable.get("database"), is("logic_db"));
@@ -72,12 +77,22 @@ class MetadataResourcePayloadMapperTest {
         assertThat(actualTable.get("table"), is("orders"));
         assertThat(getNames(actualTable, "columns", "column"), is(List.of("amount", "order_id")));
         assertThat(getNames(actualTable, "indexes", "index"), is(List.of("idx_amount", "idx_order_id")));
+        Map<?, ?> firstColumn = getFirstMap(actualTable, "columns");
+        assertThat(firstColumn.get("ordinalPosition"), is(2));
+        assertThat(firstColumn.get("jdbcType"), is(Types.DECIMAL));
+        assertThat(firstColumn.get("nativeTypeName"), is("DECIMAL"));
+        assertThat(firstColumn.get("nullability"), is("nullable"));
+        Map<?, ?> firstIndex = getFirstMap(actualTable, "indexes");
+        assertThat(firstIndex.get("columns"), is(List.of("amount")));
+        assertFalse((Boolean) firstIndex.get("unique"));
     }
     
     @Test
     void assertMapViewDetail() {
         MCPUriVariables uriVariables = new MCPUriVariables(Map.of("database", "logic_db", "schema", "public"));
-        List<?> actual = new MetadataResourcePayloadMapper(mock(MCPMetadataQueryFacade.class), uriVariables, true)
+        MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
+        when(metadataQueryFacade.queryViewColumns("logic_db", "public", "active_orders")).thenReturn(createColumns("active_orders"));
+        List<?> actual = new MetadataResourcePayloadMapper(metadataQueryFacade, uriVariables, true)
                 .map(createMetadata("view"), List.of(createTable("active_orders", TableType.VIEW)));
         Map<?, ?> actualView = (Map<?, ?>) actual.getFirst();
         assertThat(actualView.get("database"), is("logic_db"));
@@ -98,11 +113,17 @@ class MetadataResourcePayloadMapperTest {
     }
     
     private ShardingSphereTable createTable(final String name, final TableType tableType) {
-        return new ShardingSphereTable(name,
-                List.of(new ShardingSphereColumn("order_id", Types.OTHER, false, false, false, true, false, true),
-                        new ShardingSphereColumn("amount", Types.OTHER, false, false, false, true, false, true)),
-                List.of(new ShardingSphereIndex("idx_order_id", List.of(), false), new ShardingSphereIndex("idx_amount", List.of(), false)),
-                List.of(), tableType);
+        return new ShardingSphereTable(name, List.of(), List.of(), List.of(), tableType);
+    }
+    
+    private List<MCPColumnMetadata> createColumns(final String relationName) {
+        return List.of(
+                new MCPColumnMetadata(relationName, "amount", 2, Types.DECIMAL, "DECIMAL", Nullability.NULLABLE),
+                new MCPColumnMetadata(relationName, "order_id", 1, Types.BIGINT, "BIGINT", Nullability.NOT_NULLABLE));
+    }
+    
+    private List<ShardingSphereIndex> createIndexes() {
+        return List.of(new ShardingSphereIndex("idx_amount", List.of("amount"), false), new ShardingSphereIndex("idx_order_id", List.of("order_id"), true));
     }
     
     private Map<?, ?> getFirstMap(final Map<?, ?> payload, final String key) {

--- a/mcp/features/broadcast/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-broadcast.yaml
+++ b/mcp/features/broadcast/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-broadcast.yaml
@@ -321,7 +321,14 @@ tools:
         distsql_artifacts:
           type: array
           description: "Generated broadcast rule DistSQL artifacts for review."
-      required: []
+      required:
+        - response_mode
+        - plan_id
+        - workflow_kind
+        - status
+        - missing_required_inputs
+        - resources_to_read
+        - next_actions
       additionalProperties: true
       examples:
         - response_mode: planning

--- a/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-encrypt.yaml
+++ b/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-encrypt.yaml
@@ -418,6 +418,14 @@ tools:
         resources_to_read:
           type: array
           description: "Typed resources the model should read when more rule or algorithm context is useful."
+      required:
+        - response_mode
+        - plan_id
+        - workflow_kind
+        - status
+        - missing_required_inputs
+        - resources_to_read
+        - next_actions
       examples:
         - response_mode: planning
           summary: Workflow plan `encrypt-rule-20260505-001` for encrypt.rule is ready for preview.

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowPlanningServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowPlanningServiceTest.java
@@ -23,13 +23,14 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.feature.encrypt.TestWorkflowSessionContext;
 import org.apache.shardingsphere.mcp.feature.encrypt.tool.model.EncryptWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmCandidate;
@@ -61,6 +62,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -111,6 +113,7 @@ class EncryptWorkflowPlanningServiceTest {
         MCPMetadataQueryFacade metadataQueryFacade = createMetadataQueryFacade();
         when(metadataQueryFacade.querySchemas(any())).thenReturn(List.of(
                 new ShardingSphereSchema("public", mock(DatabaseType.class), List.of(new ShardingSphereTable("orders", List.of(), List.of(), List.of(), TableType.TABLE)), List.of())));
+        when(metadataQueryFacade.queryTableColumns(any(), any(), any())).thenReturn(List.of());
         EncryptWorkflowPlanningService service = createService(mock(EncryptRuleInspectionService.class), mock(EncryptAlgorithmRecommendationService.class),
                 mock(EncryptAlgorithmPropertyTemplateService.class), mock(EncryptRuleDistSQLPlanningService.class));
         WorkflowContextSnapshot actual = service.plan(new TestWorkflowSessionContext(), metadataQueryFacade, createQueryFacade(), createRequest("create"));
@@ -245,7 +248,7 @@ class EncryptWorkflowPlanningServiceTest {
         request.getOptions().setCipherColumnName("name_cipher");
         MCPMetadataQueryFacade metadataQueryFacade = createMetadataQueryFacade();
         when(metadataQueryFacade.querySchemas(any())).thenReturn(List.of(new ShardingSphereSchema(
-                "public", mock(DatabaseType.class), List.of(createTableMetadata("t_user", "name")), List.of())));
+                "public", mock(DatabaseType.class), List.of(createTableMetadata("t_user")), List.of())));
         WorkflowContextSnapshot actual = createService(ruleInspectionService, createPrimaryCandidateRecommendation(), new EncryptAlgorithmPropertyTemplateService(),
                 new EncryptRuleDistSQLPlanningService()).plan(new TestWorkflowSessionContext(), metadataQueryFacade, createQueryFacade(), request);
         String actualSQL = actual.getRuleArtifacts().getFirst().getSql();
@@ -374,6 +377,9 @@ class EncryptWorkflowPlanningServiceTest {
         MCPMetadataQueryFacade result = mock(MCPMetadataQueryFacade.class);
         when(result.queryDatabase(any())).thenReturn(Optional.of(createDatabaseMetadata()));
         when(result.querySchemas(any())).thenReturn(List.of(createSchemaMetadata()));
+        when(result.queryTableColumns(any(), any(), eq("orders"))).thenReturn(List.of(
+                createColumnMetadata("orders", "phone"), createColumnMetadata("orders", "email")));
+        when(result.queryTableColumns(any(), any(), eq("t_user"))).thenReturn(List.of(createColumnMetadata("t_user", "name")));
         return result;
     }
     
@@ -386,15 +392,15 @@ class EncryptWorkflowPlanningServiceTest {
     }
     
     private ShardingSphereTable createTableMetadata() {
-        return createTableMetadata("orders", "phone");
+        return createTableMetadata("orders");
     }
     
-    private ShardingSphereTable createTableMetadata(final String tableName, final String columnName) {
-        return new ShardingSphereTable(tableName, List.of(createColumnMetadata(columnName)), List.of(), List.of(), TableType.TABLE);
+    private ShardingSphereTable createTableMetadata(final String tableName) {
+        return new ShardingSphereTable(tableName, List.of(), List.of(), List.of(), TableType.TABLE);
     }
     
-    private ShardingSphereColumn createColumnMetadata(final String columnName) {
-        return new ShardingSphereColumn(columnName, java.sql.Types.OTHER, false, false, false, true, false, true);
+    private MCPColumnMetadata createColumnMetadata(final String tableName, final String columnName) {
+        return new MCPColumnMetadata(tableName, columnName, 1, java.sql.Types.VARCHAR, "VARCHAR", Nullability.NULLABLE);
     }
     
     private EncryptWorkflowPlanningService createService(final EncryptRuleInspectionService ruleInspectionService,

--- a/mcp/features/mask/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-mask.yaml
+++ b/mcp/features/mask/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-mask.yaml
@@ -364,6 +364,14 @@ tools:
         resources_to_read:
           type: array
           description: "Typed resources the model should read when more rule or algorithm context is useful."
+      required:
+        - response_mode
+        - plan_id
+        - workflow_kind
+        - status
+        - missing_required_inputs
+        - resources_to_read
+        - next_actions
       examples:
         - response_mode: planning
           summary: Workflow plan `mask-rule-20260505-001` for mask.rule is ready for preview.

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowPlanningServiceTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowPlanningServiceTest.java
@@ -23,12 +23,13 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.feature.mask.TestWorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
@@ -62,6 +63,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -112,6 +114,7 @@ class MaskWorkflowPlanningServiceTest {
         MCPMetadataQueryFacade metadataQueryFacade = createMetadataQueryFacade();
         when(metadataQueryFacade.querySchemas(any())).thenReturn(List.of(
                 new ShardingSphereSchema("public", mock(DatabaseType.class), List.of(new ShardingSphereTable("orders", List.of(), List.of(), List.of(), TableType.TABLE)), List.of())));
+        when(metadataQueryFacade.queryTableColumns(any(), any(), any())).thenReturn(List.of());
         WorkflowContextSnapshot actual = createService(mock(MaskRuleInspectionService.class), mock(MaskAlgorithmRecommendationService.class),
                 mock(MaskAlgorithmPropertyTemplateService.class), mock(MaskRuleDistSQLPlanningService.class))
                 .plan(new TestWorkflowSessionContext(), metadataQueryFacade, createQueryFacade(), createRequest("create"));
@@ -142,7 +145,7 @@ class MaskWorkflowPlanningServiceTest {
         request.getPrimaryAlgorithmProperties().put("from-x", "1");
         MCPMetadataQueryFacade metadataQueryFacade = createMetadataQueryFacade();
         when(metadataQueryFacade.querySchemas(any())).thenReturn(List.of(
-                new ShardingSphereSchema("public", mock(DatabaseType.class), List.of(createTableMetadata("amount")), List.of())));
+                new ShardingSphereSchema("public", mock(DatabaseType.class), List.of(createTableMetadata()), List.of())));
         WorkflowContextSnapshot actual = createService(ruleInspectionService, createPrimaryCandidateRecommendation(), createEmptyPropertyTemplateService(),
                 new MaskRuleDistSQLPlanningService()).plan(new TestWorkflowSessionContext(), metadataQueryFacade, createQueryFacade(), request);
         assertThat(actual.getStatus(), is("clarifying"));
@@ -302,6 +305,8 @@ class MaskWorkflowPlanningServiceTest {
         MCPMetadataQueryFacade result = mock(MCPMetadataQueryFacade.class);
         when(result.queryDatabase(any())).thenReturn(Optional.of(createDatabaseMetadata()));
         when(result.querySchemas(any())).thenReturn(List.of(createSchemaMetadata()));
+        when(result.queryTableColumns(any(), any(), eq("orders"))).thenReturn(List.of(
+                createColumnMetadata("phone"), createColumnMetadata("amount"), createColumnMetadata("email")));
         return result;
     }
     
@@ -314,15 +319,11 @@ class MaskWorkflowPlanningServiceTest {
     }
     
     private ShardingSphereTable createTableMetadata() {
-        return createTableMetadata("phone");
+        return new ShardingSphereTable("orders", List.of(), List.of(), List.of(), TableType.TABLE);
     }
     
-    private ShardingSphereTable createTableMetadata(final String columnName) {
-        return new ShardingSphereTable("orders", List.of(createColumnMetadata(columnName)), List.of(), List.of(), TableType.TABLE);
-    }
-    
-    private ShardingSphereColumn createColumnMetadata(final String columnName) {
-        return new ShardingSphereColumn(columnName, java.sql.Types.OTHER, false, false, false, true, false, true);
+    private MCPColumnMetadata createColumnMetadata(final String columnName) {
+        return new MCPColumnMetadata("orders", columnName, 1, java.sql.Types.VARCHAR, "VARCHAR", Nullability.NULLABLE);
     }
     
     private MaskWorkflowPlanningService createService(final MaskRuleInspectionService ruleInspectionService,

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowFeatureDefinition.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowFeatureDefinition.java
@@ -60,6 +60,8 @@ public final class ShadowFeatureDefinition {
     
     public static final String ALGORITHM_PROPERTIES_FIELD = "algorithm_properties";
     
+    public static final String DEFAULT_ALGORITHM_TYPE = "SQL_HINT";
+    
     public static final String RULES_RESOURCE_URI = "shardingsphere://features/shadow/databases/{database}/rules";
     
     public static final String RULE_RESOURCE_URI = "shardingsphere://features/shadow/databases/{database}/rules/{rule}";

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProvider.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProvider.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.mcp.support.MCPFeatureRequestContext;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * Shadow algorithm completion provider.
@@ -54,8 +55,12 @@ public final class ShadowAlgorithmCompletionProvider implements MCPCompletionPro
     
     @Override
     public MCPCompletionProviderResult complete(final MCPFeatureRequestContext handlerContext, final MCPCompletionRequest request) {
-        return new MCPCompletionProviderResult(inspectionService.queryAlgorithmPlugins(handlerContext.getQueryFacade()).stream()
-                .map(this::createAlgorithmCandidate).filter(each -> !each.getValue().isEmpty()).toList());
+        Stream<MCPCompletionCandidate> candidates = inspectionService.queryAlgorithmPlugins(handlerContext.getQueryFacade()).stream()
+                .map(this::createAlgorithmCandidate).filter(each -> !each.getValue().isEmpty());
+        if (ShadowFeatureDefinition.PLAN_DEFAULT_ALGORITHM_PROMPT_NAME.equals(request.getDescriptor().getReference())) {
+            candidates = candidates.filter(each -> ShadowFeatureDefinition.DEFAULT_ALGORITHM_TYPE.equalsIgnoreCase(each.getValue()));
+        }
+        return new MCPCompletionProviderResult(candidates.toList());
     }
     
     private MCPCompletionCandidate createAlgorithmCandidate(final Map<String, Object> row) {

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowDistSQLPlanningService.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowDistSQLPlanningService.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.feature.shadow.tool.service;
 
+import org.apache.shardingsphere.mcp.feature.shadow.ShadowFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.shadow.tool.model.ShadowDefaultAlgorithmWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.shadow.tool.model.ShadowRuleWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.workflow.model.RuleArtifact;
@@ -76,7 +77,7 @@ public final class ShadowDistSQLPlanningService {
      */
     public RuleArtifact planCreateDefaultAlgorithm(final ShadowDefaultAlgorithmWorkflowRequest request) {
         return new RuleArtifact(WorkflowLifecycle.OPERATION_CREATE, String.format("CREATE DEFAULT SHADOW ALGORITHM %s",
-                WorkflowSQLUtils.createAlgorithmFragment(request.getAlgorithmType(), request.getAlgorithmProperties())));
+                createDefaultAlgorithmFragment(request)));
     }
     
     /**
@@ -87,7 +88,11 @@ public final class ShadowDistSQLPlanningService {
      */
     public RuleArtifact planAlterDefaultAlgorithm(final ShadowDefaultAlgorithmWorkflowRequest request) {
         return new RuleArtifact(WorkflowLifecycle.OPERATION_ALTER, String.format("ALTER DEFAULT SHADOW ALGORITHM %s",
-                WorkflowSQLUtils.createAlgorithmFragment(request.getAlgorithmType(), request.getAlgorithmProperties())));
+                createDefaultAlgorithmFragment(request)));
+    }
+    
+    private String createDefaultAlgorithmFragment(final ShadowDefaultAlgorithmWorkflowRequest request) {
+        return WorkflowSQLUtils.createAlgorithmFragmentWithExactType(ShadowFeatureDefinition.DEFAULT_ALGORITHM_TYPE, request.getAlgorithmProperties());
     }
     
     /**

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningService.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningService.java
@@ -132,6 +132,9 @@ public final class ShadowWorkflowPlanningService {
         if (!ensureDefaultAlgorithmPlanningContext(mergedRequest, result.getClarifiedIntent(), result)) {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_CLARIFYING, result.getStatus());
         }
+        if (!ensureDefaultAlgorithmType(mergedRequest, result)) {
+            return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
+        }
         if (!isReadyForAlgorithmArtifactPlanning(mergedRequest, result)) {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_CLARIFYING, WorkflowLifecycle.STATUS_CLARIFYING);
         }
@@ -224,6 +227,18 @@ public final class ShadowWorkflowPlanningService {
             addMissingInput(missingInputs, request.getAlgorithmType(), ShadowFeatureDefinition.ALGORITHM_TYPE_FIELD);
         }
         return ensureNoMissingInputs(missingInputs, clarifiedIntent, snapshot, "Default shadow algorithm DistSQL requires an explicit algorithm type and properties.");
+    }
+    
+    private boolean ensureDefaultAlgorithmType(final ShadowDefaultAlgorithmWorkflowRequest request, final WorkflowContextSnapshot snapshot) {
+        if (WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(request.getOperationType())
+                || ShadowFeatureDefinition.DEFAULT_ALGORITHM_TYPE.equalsIgnoreCase(request.getAlgorithmType())) {
+            return true;
+        }
+        snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.ALGORITHM_CAPABILITY_CONFLICT, "error", WorkflowLifecycle.STEP_SELECTING_ALGORITHM,
+                "Default shadow algorithm must implement the hint algorithm contract.",
+                "Use algorithm_type=SQL_HINT for the default shadow algorithm.", false, Map.of("algorithm_type", request.getAlgorithmType())));
+        snapshot.setStatus(WorkflowLifecycle.STATUS_FAILED);
+        return false;
     }
     
     private boolean ensureCleanupPlanningContext(final ShadowAlgorithmCleanupWorkflowRequest request, final ClarifiedIntent clarifiedIntent, final WorkflowContextSnapshot snapshot) {

--- a/mcp/features/shadow/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-shadow.yaml
+++ b/mcp/features/shadow/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-shadow.yaml
@@ -238,7 +238,7 @@ prompts:
         required: false
       - name: algorithm_type
         title: Algorithm Type
-        description: "Default shadow algorithm type."
+        description: "Default shadow algorithm type. ShardingSphere requires SQL_HINT for the default algorithm."
         required: false
       - name: plan_id
         title: Workflow Plan ID
@@ -589,6 +589,9 @@ tools:
         - plan_id
         - workflow_kind
         - status
+        - missing_required_inputs
+        - resources_to_read
+        - next_actions
       additionalProperties: true
       examples:
         - response_mode: planning
@@ -654,6 +657,9 @@ tools:
             - drop
         algorithm_type:
           type: string
+          enum:
+            - SQL_HINT
+          description: "Default shadow algorithm type. ShardingSphere requires SQL_HINT."
         algorithm_properties:
           type: object
           additionalProperties:
@@ -665,6 +671,8 @@ tools:
           properties:
             algorithm_type:
               type: string
+              enum:
+                - SQL_HINT
           required: []
           additionalProperties: false
         delivery_mode:

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowDescriptorContractTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowDescriptorContractTest.java
@@ -51,6 +51,16 @@ class ShadowDescriptorContractTest {
         assertCompletionTargetArguments(catalog, ShadowFeatureDefinition.PLAN_ALGORITHM_CLEANUP_PROMPT_NAME, "database", "plan_id");
     }
     
+    @SuppressWarnings("unchecked")
+    @Test
+    void assertDefaultAlgorithmTypeContract() {
+        Map<String, Object> properties = (Map<String, Object>) findTool(MCPDescriptorCatalogLoader.load(),
+                ShadowFeatureDefinition.PLAN_DEFAULT_ALGORITHM_TOOL_NAME).getInputSchema().get("properties");
+        assertThat(((Map<String, Object>) properties.get("algorithm_type")).get("enum"), is(List.of("SQL_HINT")));
+        Map<String, Object> structuredIntentProperties = (Map<String, Object>) ((Map<String, Object>) properties.get("structured_intent_evidence")).get("properties");
+        assertThat(((Map<String, Object>) structuredIntentProperties.get("algorithm_type")).get("enum"), is(List.of("SQL_HINT")));
+    }
+    
     private MCPToolDescriptor findTool(final MCPDescriptorCatalog catalog, final String toolName) {
         return catalog.getProtocolDescriptors().getToolDescriptors().stream().filter(each -> toolName.equals(each.getName())).findFirst().orElseThrow();
     }

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProviderTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProviderTest.java
@@ -85,6 +85,17 @@ class ShadowAlgorithmCompletionProviderTest {
     }
     
     @Test
+    void assertCompleteDefaultAlgorithm() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.queryWithAnyDatabase("SHOW SHADOW ALGORITHM PLUGINS")).thenReturn(List.of(Map.of("type", "VALUE_MATCH"), Map.of("type", "SQL_HINT")));
+        MCPFeatureRequestContext handlerContext = mock(MCPFeatureRequestContext.class);
+        when(handlerContext.getQueryFacade()).thenReturn(queryFacade);
+        MCPCompletionProviderResult actual = new ShadowAlgorithmCompletionProvider().complete(handlerContext,
+                createRequestContext(ShadowFeatureDefinition.PLAN_DEFAULT_ALGORITHM_PROMPT_NAME));
+        assertThat(actual.getCandidates().stream().map(MCPCompletionCandidate::getValue).toList(), is(List.of("SQL_HINT")));
+    }
+    
+    @Test
     void assertSPIRegistration() {
         assertTrue(ServiceLoader.load(MCPCompletionProvider.class).stream().anyMatch(each -> ShadowAlgorithmCompletionProvider.class.equals(each.type())));
     }

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowDistSQLPlanningServiceTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowDistSQLPlanningServiceTest.java
@@ -66,8 +66,16 @@ class ShadowDistSQLPlanningServiceTest {
         ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
         request.setAlgorithmType("SQL_HINT");
         String actual = new ShadowDistSQLPlanningService().planCreateDefaultAlgorithm(request).getSql();
-        assertThat(actual, is("CREATE DEFAULT SHADOW ALGORITHM TYPE(NAME='sql_hint')"));
+        assertThat(actual, is("CREATE DEFAULT SHADOW ALGORITHM TYPE(NAME='SQL_HINT')"));
         assertFalse(actual.contains(" FROM "));
+    }
+    
+    @Test
+    void assertPlanAlterDefaultAlgorithm() {
+        ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
+        request.setAlgorithmType("SQL_HINT");
+        assertThat(new ShadowDistSQLPlanningService().planAlterDefaultAlgorithm(request).getSql(),
+                is("ALTER DEFAULT SHADOW ALGORITHM TYPE(NAME='SQL_HINT')"));
     }
     
     @Test

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningServiceTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningServiceTest.java
@@ -109,6 +109,20 @@ class ShadowWorkflowPlanningServiceTest {
     }
     
     @Test
+    void assertRejectNonHintDefaultAlgorithm() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
+        request.setDatabase("logic_db");
+        request.setAlgorithmType("VALUE_MATCH");
+        ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
+        when(getInspectionService().queryAlgorithmPlugins(queryFacade)).thenReturn(List.of(Map.of("type", "VALUE_MATCH")));
+        WorkflowContextSnapshot actual = service.planDefaultAlgorithm(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.ALGORITHM_CAPABILITY_CONFLICT));
+        assertTrue(actual.getRuleArtifacts().isEmpty());
+    }
+    
+    @Test
     void assertPlanAlgorithmCleanup() {
         ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
         ShadowInspectionService inspectionService = getInspectionService();

--- a/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
+++ b/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
@@ -867,7 +867,14 @@ tools:
               arguments: {type: object, description: "Canonical arguments to provide to the target tool."}
               reason: {type: string, description: "Why the model should take this action."}
               required_inputs: {type: array, description: "User inputs needed before continuing."}
-      required: []
+      required:
+        - response_mode
+        - plan_id
+        - workflow_kind
+        - status
+        - missing_required_inputs
+        - resources_to_read
+        - next_actions
       additionalProperties: true
       examples:
         - response_mode: planning

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/context/RequestScopedMetadataContext.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/context/RequestScopedMetadataContext.java
@@ -19,13 +19,16 @@ package org.apache.shardingsphere.mcp.support.database.metadata.context;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseCapabilityProvider;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.MCPJdbcMetadataLoader;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -42,6 +45,12 @@ public final class RequestScopedMetadataContext {
     private final MCPJdbcMetadataLoader metadataLoader = new MCPJdbcMetadataLoader();
     
     private final Map<String, Collection<ShardingSphereSchema>> loadedSchemas = new LinkedHashMap<>(4, 1F);
+    
+    private final Map<RelationKey, List<MCPColumnMetadata>> loadedColumns = new LinkedHashMap<>(16, 1F);
+    
+    private final Map<SchemaKey, List<MCPColumnMetadata>> loadedSchemaColumns = new LinkedHashMap<>(4, 1F);
+    
+    private final Map<RelationKey, List<ShardingSphereIndex>> loadedIndexes = new LinkedHashMap<>(16, 1F);
     
     /**
      * Load schema metadata lazily within the current request.
@@ -62,6 +71,90 @@ public final class RequestScopedMetadataContext {
         Collection<ShardingSphereSchema> result = metadataLoader.load(databaseName, runtimeDatabaseConfig, databaseProfile.get());
         loadedSchemas.put(databaseName, result);
         return Optional.of(result);
+    }
+    
+    /**
+     * Load columns for one relation lazily within the current request.
+     *
+     * @param databaseName database name
+     * @param schemaName schema name
+     * @param relationName table or view name
+     * @return column metadata
+     */
+    public Optional<List<MCPColumnMetadata>> loadColumns(final String databaseName, final String schemaName, final String relationName) {
+        RelationKey key = new RelationKey(databaseName, schemaName, relationName);
+        List<MCPColumnMetadata> loadedMetadata = loadedColumns.get(key);
+        if (null != loadedMetadata) {
+            return Optional.of(loadedMetadata);
+        }
+        Optional<RuntimeDatabaseBinding> binding = findRuntimeDatabaseBinding(databaseName);
+        if (binding.isEmpty()) {
+            return Optional.empty();
+        }
+        List<MCPColumnMetadata> result = metadataLoader.loadColumns(
+                databaseName, binding.get().configuration(), binding.get().profile(), schemaName, relationName);
+        loadedColumns.put(key, result);
+        return Optional.of(result);
+    }
+    
+    /**
+     * Load all columns in one schema lazily within the current request.
+     *
+     * @param databaseName database name
+     * @param schemaName schema name
+     * @return column metadata
+     */
+    public Optional<List<MCPColumnMetadata>> loadSchemaColumns(final String databaseName, final String schemaName) {
+        SchemaKey key = new SchemaKey(databaseName, schemaName);
+        List<MCPColumnMetadata> loadedMetadata = loadedSchemaColumns.get(key);
+        if (null != loadedMetadata) {
+            return Optional.of(loadedMetadata);
+        }
+        Optional<RuntimeDatabaseBinding> binding = findRuntimeDatabaseBinding(databaseName);
+        if (binding.isEmpty()) {
+            return Optional.empty();
+        }
+        List<MCPColumnMetadata> result = metadataLoader.loadSchemaColumns(databaseName, binding.get().configuration(), binding.get().profile(), schemaName);
+        loadedSchemaColumns.put(key, result);
+        return Optional.of(result);
+    }
+    
+    /**
+     * Load indexes for one table lazily within the current request.
+     *
+     * @param databaseName database name
+     * @param schemaName schema name
+     * @param tableName table name
+     * @return index metadata
+     */
+    public Optional<List<ShardingSphereIndex>> loadIndexes(final String databaseName, final String schemaName, final String tableName) {
+        RelationKey key = new RelationKey(databaseName, schemaName, tableName);
+        List<ShardingSphereIndex> loadedMetadata = loadedIndexes.get(key);
+        if (null != loadedMetadata) {
+            return Optional.of(loadedMetadata);
+        }
+        Optional<RuntimeDatabaseBinding> binding = findRuntimeDatabaseBinding(databaseName);
+        if (binding.isEmpty()) {
+            return Optional.empty();
+        }
+        List<ShardingSphereIndex> result = metadataLoader.loadIndexes(databaseName, binding.get().configuration(), binding.get().profile(), schemaName, tableName);
+        loadedIndexes.put(key, result);
+        return Optional.of(result);
+    }
+    
+    private Optional<RuntimeDatabaseBinding> findRuntimeDatabaseBinding(final String databaseName) {
+        RuntimeDatabaseConfiguration configuration = runtimeDatabases.get(databaseName);
+        Optional<RuntimeDatabaseProfile> profile = databaseCapabilityProvider.findDatabaseProfile(databaseName);
+        return null == configuration || profile.isEmpty() ? Optional.empty() : Optional.of(new RuntimeDatabaseBinding(configuration, profile.get()));
+    }
+    
+    private record SchemaKey(String databaseName, String schemaName) {
+    }
+    
+    private record RelationKey(String databaseName, String schemaName, String relationName) {
+    }
+    
+    private record RuntimeDatabaseBinding(RuntimeDatabaseConfiguration configuration, RuntimeDatabaseProfile profile) {
     }
     
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoader.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoader.java
@@ -189,10 +189,21 @@ public final class MCPJdbcMetadataLoader {
     
     private List<MCPColumnMetadata> loadColumnMetadata(final Connection connection, final DatabaseMetaData databaseMetaData, final RuntimeDatabaseProfile databaseProfile,
                                                        final String schemaName, final String relationNamePattern) throws SQLException {
-        List<MCPColumnMetadata> result = new LinkedList<>();
         DialectSchemaSemantics schemaSemantics = MCPDatabaseDialect.of(databaseProfile.getDatabaseType()).getDefaultSchemaSemantics();
         String catalogName = DialectSchemaSemantics.DATABASE_AS_SCHEMA == schemaSemantics ? resolveCatalogName(connection, schemaName) : null;
         String schemaNamePattern = DialectSchemaSemantics.NATIVE_SCHEMA == schemaSemantics ? escapePattern(databaseMetaData, schemaName) : null;
+        List<MCPColumnMetadata> result = queryColumnMetadata(databaseMetaData, catalogName, schemaNamePattern, relationNamePattern);
+        if (result.isEmpty() && null != catalogName) {
+            result = queryColumnMetadata(databaseMetaData, null, schemaNamePattern, relationNamePattern);
+        }
+        result.sort(Comparator.comparing(MCPColumnMetadata::getRelationName)
+                .thenComparingInt(MCPColumnMetadata::getOrdinalPosition).thenComparing(MCPColumnMetadata::getName));
+        return result;
+    }
+    
+    private List<MCPColumnMetadata> queryColumnMetadata(final DatabaseMetaData databaseMetaData, final String catalogName,
+                                                        final String schemaNamePattern, final String relationNamePattern) throws SQLException {
+        List<MCPColumnMetadata> result = new LinkedList<>();
         try (ResultSet columns = databaseMetaData.getColumns(catalogName, schemaNamePattern, relationNamePattern, "%")) {
             while (columns.next()) {
                 String columnName = Objects.toString(columns.getString("COLUMN_NAME"), "").trim();
@@ -204,8 +215,6 @@ public final class MCPJdbcMetadataLoader {
                 }
             }
         }
-        result.sort(Comparator.comparing(MCPColumnMetadata::getRelationName)
-                .thenComparingInt(MCPColumnMetadata::getOrdinalPosition).thenComparing(MCPColumnMetadata::getName));
         return result;
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoader.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoader.java
@@ -23,30 +23,29 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.loader.ty
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaSemantics;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseDialect;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.sql.Types;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * MCP JDBC metadata loader.
@@ -65,6 +64,66 @@ public final class MCPJdbcMetadataLoader {
     public Collection<ShardingSphereSchema> load(final String databaseName, final RuntimeDatabaseConfiguration runtimeDatabaseConfig, final RuntimeDatabaseProfile databaseProfile) {
         try (Connection connection = runtimeDatabaseConfig.openConnection(databaseName)) {
             return loadSchemas(databaseName, databaseProfile, connection, connection.getMetaData());
+        } catch (final SQLException ex) {
+            throw RuntimeDatabaseConnectionException.connectionFailed(databaseName, ex);
+        }
+    }
+    
+    /**
+     * Load columns for one relation.
+     *
+     * @param databaseName database name
+     * @param runtimeDatabaseConfig runtime database configuration
+     * @param databaseProfile runtime database profile
+     * @param schemaName schema name
+     * @param relationName table or view name
+     * @return column metadata
+     * @throws RuntimeDatabaseConnectionException when metadata loading fails
+     */
+    public List<MCPColumnMetadata> loadColumns(final String databaseName, final RuntimeDatabaseConfiguration runtimeDatabaseConfig,
+                                               final RuntimeDatabaseProfile databaseProfile, final String schemaName, final String relationName) {
+        try (Connection connection = runtimeDatabaseConfig.openConnection(databaseName)) {
+            DatabaseMetaData databaseMetaData = connection.getMetaData();
+            return loadColumnMetadata(connection, databaseMetaData, databaseProfile, schemaName, escapePattern(databaseMetaData, relationName));
+        } catch (final SQLException ex) {
+            throw RuntimeDatabaseConnectionException.connectionFailed(databaseName, ex);
+        }
+    }
+    
+    /**
+     * Load all columns in one schema.
+     *
+     * @param databaseName database name
+     * @param runtimeDatabaseConfig runtime database configuration
+     * @param databaseProfile runtime database profile
+     * @param schemaName schema name
+     * @return column metadata
+     * @throws RuntimeDatabaseConnectionException when metadata loading fails
+     */
+    public List<MCPColumnMetadata> loadSchemaColumns(final String databaseName, final RuntimeDatabaseConfiguration runtimeDatabaseConfig,
+                                                     final RuntimeDatabaseProfile databaseProfile, final String schemaName) {
+        try (Connection connection = runtimeDatabaseConfig.openConnection(databaseName)) {
+            return loadColumnMetadata(connection, connection.getMetaData(), databaseProfile, schemaName, "%");
+        } catch (final SQLException ex) {
+            throw RuntimeDatabaseConnectionException.connectionFailed(databaseName, ex);
+        }
+    }
+    
+    /**
+     * Load indexes for one table.
+     *
+     * @param databaseName database name
+     * @param runtimeDatabaseConfig runtime database configuration
+     * @param databaseProfile runtime database profile
+     * @param schemaName schema name
+     * @param tableName table name
+     * @return index metadata
+     * @throws RuntimeDatabaseConnectionException when metadata loading fails
+     */
+    public List<ShardingSphereIndex> loadIndexes(final String databaseName, final RuntimeDatabaseConfiguration runtimeDatabaseConfig,
+                                                 final RuntimeDatabaseProfile databaseProfile, final String schemaName, final String tableName) {
+        try (Connection connection = runtimeDatabaseConfig.openConnection(databaseName)) {
+            return loadIndexMetadata(connection, connection.getMetaData(), databaseProfile, schemaName, tableName);
         } catch (final SQLException ex) {
             throw RuntimeDatabaseConnectionException.connectionFailed(databaseName, ex);
         }
@@ -95,14 +154,7 @@ public final class MCPJdbcMetadataLoader {
                 if (tableName.isEmpty()) {
                     continue;
                 }
-                TableMetadataAccumulator tableMetadata = accumulator.getSchemaAccumulator(
-                        normalizeSchemaName(databaseName, defaultSchemaSemantics, schemaName)).getTableAccumulator(tableName, TableType.TABLE);
-                for (String each : loadColumns(databaseMetaData, catalogName, schemaName, tableName)) {
-                    tableMetadata.addColumn(each);
-                }
-                for (String each : loadIndexes(databaseMetaData, catalogName, schemaName, tableName)) {
-                    tableMetadata.addIndex(each);
-                }
+                accumulator.getSchemaAccumulator(normalizeSchemaName(databaseName, defaultSchemaSemantics, schemaName)).addRelation(tableName, TableType.TABLE);
             }
         }
     }
@@ -120,11 +172,7 @@ public final class MCPJdbcMetadataLoader {
                 if (viewName.isEmpty()) {
                     continue;
                 }
-                TableMetadataAccumulator viewMetadata = accumulator.getSchemaAccumulator(
-                        normalizeSchemaName(databaseName, defaultSchemaSemantics, schemaName)).getTableAccumulator(viewName, TableType.VIEW);
-                for (String each : loadColumns(databaseMetaData, catalogName, schemaName, viewName)) {
-                    viewMetadata.addColumn(each);
-                }
+                accumulator.getSchemaAccumulator(normalizeSchemaName(databaseName, defaultSchemaSemantics, schemaName)).addRelation(viewName, TableType.VIEW);
             }
         }
     }
@@ -139,36 +187,68 @@ public final class MCPJdbcMetadataLoader {
         }
     }
     
-    private List<String> loadColumns(final DatabaseMetaData databaseMetaData, final String catalogName, final String schemaName, final String objectName) throws SQLException {
-        List<String> result = new LinkedList<>();
-        try (ResultSet columns = databaseMetaData.getColumns(getPattern(catalogName), getPattern(schemaName), objectName, "%")) {
+    private List<MCPColumnMetadata> loadColumnMetadata(final Connection connection, final DatabaseMetaData databaseMetaData, final RuntimeDatabaseProfile databaseProfile,
+                                                       final String schemaName, final String relationNamePattern) throws SQLException {
+        List<MCPColumnMetadata> result = new LinkedList<>();
+        DialectSchemaSemantics schemaSemantics = MCPDatabaseDialect.of(databaseProfile.getDatabaseType()).getDefaultSchemaSemantics();
+        String catalogName = DialectSchemaSemantics.DATABASE_AS_SCHEMA == schemaSemantics ? resolveCatalogName(connection, schemaName) : null;
+        String schemaNamePattern = DialectSchemaSemantics.NATIVE_SCHEMA == schemaSemantics ? escapePattern(databaseMetaData, schemaName) : null;
+        try (ResultSet columns = databaseMetaData.getColumns(catalogName, schemaNamePattern, relationNamePattern, "%")) {
             while (columns.next()) {
                 String columnName = Objects.toString(columns.getString("COLUMN_NAME"), "").trim();
                 if (!columnName.isEmpty()) {
-                    result.add(columnName);
+                    result.add(new MCPColumnMetadata(
+                            Objects.toString(columns.getString("TABLE_NAME"), "").trim(), columnName, columns.getInt("ORDINAL_POSITION"),
+                            columns.getInt("DATA_TYPE"), Objects.toString(columns.getString("TYPE_NAME"), "").trim(),
+                            Nullability.fromJdbcValue(columns.getInt("NULLABLE"))));
                 }
             }
         }
+        result.sort(Comparator.comparing(MCPColumnMetadata::getRelationName)
+                .thenComparingInt(MCPColumnMetadata::getOrdinalPosition).thenComparing(MCPColumnMetadata::getName));
         return result;
     }
     
-    private List<String> loadIndexes(final DatabaseMetaData databaseMetaData, final String catalogName, final String schemaName, final String tableName) throws SQLException {
-        List<String> result = new LinkedList<>();
-        Set<String> loadedIndexNames = new LinkedHashSet<>();
-        try (ResultSet indexes = databaseMetaData.getIndexInfo(getPattern(catalogName), getPattern(schemaName), tableName, false, false)) {
+    private List<ShardingSphereIndex> loadIndexMetadata(final Connection connection, final DatabaseMetaData databaseMetaData, final RuntimeDatabaseProfile databaseProfile,
+                                                        final String schemaName, final String tableName) throws SQLException {
+        Map<String, IndexMetadataAccumulator> result = new LinkedHashMap<>(16, 1F);
+        DialectSchemaSemantics schemaSemantics = MCPDatabaseDialect.of(databaseProfile.getDatabaseType()).getDefaultSchemaSemantics();
+        String catalogName = DialectSchemaSemantics.DATABASE_AS_SCHEMA == schemaSemantics ? resolveCatalogName(connection, schemaName) : null;
+        String jdbcSchemaName = DialectSchemaSemantics.NATIVE_SCHEMA == schemaSemantics ? trimToNull(schemaName) : null;
+        try (ResultSet indexes = databaseMetaData.getIndexInfo(catalogName, jdbcSchemaName, tableName, false, false)) {
             while (indexes.next()) {
                 String indexName = Objects.toString(indexes.getString("INDEX_NAME"), "").trim();
-                if (!indexName.isEmpty() && loadedIndexNames.add(indexName)) {
-                    result.add(indexName);
+                if (indexName.isEmpty() || DatabaseMetaData.tableIndexStatistic == indexes.getShort("TYPE")) {
+                    continue;
                 }
+                boolean unique = !indexes.getBoolean("NON_UNIQUE");
+                IndexMetadataAccumulator accumulator = result.computeIfAbsent(indexName, ignored -> new IndexMetadataAccumulator(unique));
+                accumulator.addColumn(indexes.getInt("ORDINAL_POSITION"), Objects.toString(indexes.getString("COLUMN_NAME"), "").trim());
             }
         } catch (final SQLFeatureNotSupportedException ignored) {
-            return result;
+            return Collections.emptyList();
         }
-        return result;
+        return result.entrySet().stream().map(each -> each.getValue().build(each.getKey())).toList();
     }
     
-    private String getPattern(final String value) {
+    private String resolveCatalogName(final Connection connection, final String schemaName) throws SQLException {
+        String result = trimToNull(connection.getCatalog());
+        return null == result ? trimToNull(schemaName) : result;
+    }
+    
+    private String escapePattern(final DatabaseMetaData databaseMetaData, final String value) throws SQLException {
+        String result = Objects.toString(value, "").trim();
+        if (result.isEmpty()) {
+            return null;
+        }
+        String escape = Objects.toString(databaseMetaData.getSearchStringEscape(), "");
+        if (escape.isEmpty()) {
+            return result;
+        }
+        return result.replace(escape, escape + escape).replace("%", escape + "%").replace("_", escape + "_");
+    }
+    
+    private String trimToNull(final String value) {
         String result = Objects.toString(value, "").trim();
         return result.isEmpty() ? null : result;
     }
@@ -213,17 +293,12 @@ public final class MCPJdbcMetadataLoader {
         
         private final DatabaseType protocolType;
         
-        private final Map<String, TableMetadataAccumulator> tableAccumulators = new LinkedHashMap<>(16, 1F);
+        private final Map<String, ShardingSphereTable> relations = new LinkedHashMap<>(16, 1F);
         
         private final Map<String, ShardingSphereSequence> sequences = new LinkedHashMap<>(16, 1F);
         
-        private TableMetadataAccumulator getTableAccumulator(final String name, final TableType type) {
-            TableMetadataAccumulator result = tableAccumulators.get(name);
-            if (null == result) {
-                result = new TableMetadataAccumulator(name, type);
-                tableAccumulators.put(name, result);
-            }
-            return result;
+        private void addRelation(final String name, final TableType type) {
+            relations.putIfAbsent(name, new ShardingSphereTable(name, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), type));
         }
         
         private void addSequence(final String sequence) {
@@ -231,36 +306,25 @@ public final class MCPJdbcMetadataLoader {
         }
         
         private ShardingSphereSchema build() {
-            List<ShardingSphereTable> tables = new LinkedList<>();
-            for (TableMetadataAccumulator each : tableAccumulators.values()) {
-                tables.add(each.build());
-            }
-            return new ShardingSphereSchema(schema, protocolType, tables, Collections.emptyList(), sequences.values());
+            return new ShardingSphereSchema(schema, protocolType, relations.values(), Collections.emptyList(), sequences.values());
         }
     }
     
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-    private static final class TableMetadataAccumulator {
+    private static final class IndexMetadataAccumulator {
         
-        private final String name;
+        private final boolean unique;
         
-        private final TableType type;
+        private final Map<Integer, String> columns = new LinkedHashMap<>(4, 1F);
         
-        private final Map<String, ShardingSphereColumn> columns = new LinkedHashMap<>(16, 1F);
-        
-        private final Map<String, ShardingSphereIndex> indexes = new LinkedHashMap<>(16, 1F);
-        
-        private void addColumn(final String column) {
-            columns.putIfAbsent(column, new ShardingSphereColumn(column, Types.OTHER, false, false, false, true, false, true));
+        private void addColumn(final int ordinalPosition, final String columnName) {
+            if (!columnName.isEmpty()) {
+                columns.putIfAbsent(ordinalPosition, columnName);
+            }
         }
         
-        private void addIndex(final String index) {
-            indexes.putIfAbsent(index, new ShardingSphereIndex(index, Collections.emptyList(), false));
-        }
-        
-        private ShardingSphereTable build() {
-            Collection<ShardingSphereIndex> actualIndexes = TableType.TABLE == type ? new LinkedList<>(indexes.values()) : Collections.emptyList();
-            return new ShardingSphereTable(name, new LinkedList<>(columns.values()), actualIndexes, Collections.emptyList(), type);
+        private ShardingSphereIndex build(final String name) {
+            return new ShardingSphereIndex(name, columns.entrySet().stream().sorted(Entry.comparingByKey()).map(Entry::getValue).toList(), unique);
         }
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/model/MCPColumnMetadata.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/model/MCPColumnMetadata.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.database.metadata.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.sql.DatabaseMetaData;
+
+/**
+ * MCP column metadata.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class MCPColumnMetadata {
+    
+    private final String relationName;
+    
+    private final String name;
+    
+    private final int ordinalPosition;
+    
+    private final int jdbcType;
+    
+    private final String nativeTypeName;
+    
+    private final Nullability nullability;
+    
+    /**
+     * JDBC column nullability.
+     */
+    @Getter
+    @RequiredArgsConstructor
+    public enum Nullability {
+        
+        NULLABLE("nullable"),
+        
+        NOT_NULLABLE("not_nullable"),
+        
+        UNKNOWN("unknown");
+        
+        private final String value;
+        
+        /**
+         * Create nullability from JDBC metadata value.
+         *
+         * @param jdbcValue JDBC metadata value
+         * @return nullability
+         */
+        public static Nullability fromJdbcValue(final int jdbcValue) {
+            if (DatabaseMetaData.columnNullable == jdbcValue) {
+                return NULLABLE;
+            }
+            if (DatabaseMetaData.columnNoNulls == jdbcValue) {
+                return NOT_NULLABLE;
+            }
+            return UNKNOWN;
+        }
+        
+    }
+}

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/query/MetadataQueryService.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/query/MetadataQueryService.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.mcp.support.database.metadata.query;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
@@ -31,6 +30,7 @@ import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseCapa
 import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPMetadataObjectType;
 import org.apache.shardingsphere.mcp.support.database.metadata.context.RequestScopedMetadataContext;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 
 import java.util.Collection;
@@ -103,15 +103,17 @@ public final class MetadataQueryService implements MCPMetadataQueryFacade {
     }
     
     @Override
-    public List<ShardingSphereColumn> queryTableColumns(final String databaseName, final String schemaName, final String tableName) {
+    public List<MCPColumnMetadata> queryTableColumns(final String databaseName, final String schemaName, final String tableName) {
         if (!isSupportedMetadataObjectType(databaseName, SupportedMCPMetadataObjectType.COLUMN)) {
             return Collections.emptyList();
         }
-        return queryTable(databaseName, schemaName, tableName).map(optional -> sortColumns(optional.getAllColumns())).orElse(Collections.emptyList());
+        return queryTable(databaseName, schemaName, tableName).isEmpty()
+                ? Collections.emptyList()
+                : metadataContext.loadColumns(databaseName, schemaName, tableName).map(this::sortColumns).orElse(Collections.emptyList());
     }
     
     @Override
-    public Optional<ShardingSphereColumn> queryTableColumn(final String databaseName, final String schemaName, final String tableName, final String columnName) {
+    public Optional<MCPColumnMetadata> queryTableColumn(final String databaseName, final String schemaName, final String tableName, final String columnName) {
         if (!isSupportedMetadataObjectType(databaseName, SupportedMCPMetadataObjectType.COLUMN)) {
             return Optional.empty();
         }
@@ -119,30 +121,43 @@ public final class MetadataQueryService implements MCPMetadataQueryFacade {
     }
     
     @Override
-    public List<ShardingSphereColumn> queryViewColumns(final String databaseName, final String schemaName, final String viewName) {
+    public List<MCPColumnMetadata> queryViewColumns(final String databaseName, final String schemaName, final String viewName) {
         if (!isSupportedMetadataObjectType(databaseName, SupportedMCPMetadataObjectType.COLUMN)) {
             return Collections.emptyList();
         }
-        return queryView(databaseName, schemaName, viewName).map(optional -> sortColumns(optional.getAllColumns())).orElse(Collections.emptyList());
+        return queryView(databaseName, schemaName, viewName).isEmpty()
+                ? Collections.emptyList()
+                : metadataContext.loadColumns(databaseName, schemaName, viewName).map(this::sortColumns).orElse(Collections.emptyList());
     }
     
     @Override
-    public Optional<ShardingSphereColumn> queryViewColumn(final String databaseName, final String schemaName, final String viewName, final String columnName) {
+    public Optional<MCPColumnMetadata> queryViewColumn(final String databaseName, final String schemaName, final String viewName, final String columnName) {
         if (!isSupportedMetadataObjectType(databaseName, SupportedMCPMetadataObjectType.COLUMN)) {
             return Optional.empty();
         }
         return findColumn(queryViewColumns(databaseName, schemaName, viewName), columnName);
     }
     
-    private List<ShardingSphereColumn> sortColumns(final Collection<ShardingSphereColumn> columns) {
-        return columns.stream().sorted(Comparator.comparing(ShardingSphereColumn::getName)).toList();
+    @Override
+    public List<MCPColumnMetadata> querySchemaColumns(final String databaseName, final String schemaName) {
+        if (!isSupportedMetadataObjectType(databaseName, SupportedMCPMetadataObjectType.COLUMN) || querySchema(databaseName, schemaName).isEmpty()) {
+            return Collections.emptyList();
+        }
+        return metadataContext.loadSchemaColumns(databaseName, schemaName).map(this::sortColumns).orElse(Collections.emptyList());
+    }
+    
+    private List<MCPColumnMetadata> sortColumns(final Collection<MCPColumnMetadata> columns) {
+        return columns.stream().sorted(Comparator.comparing(MCPColumnMetadata::getRelationName)
+                .thenComparingInt(MCPColumnMetadata::getOrdinalPosition).thenComparing(MCPColumnMetadata::getName)).toList();
     }
     
     @Override
     public List<ShardingSphereIndex> queryIndexes(final String databaseName, final String schemaName, final String tableName) {
         ShardingSpherePreconditions.checkState(isSupportedMetadataObjectType(databaseName, SupportedMCPMetadataObjectType.INDEX),
                 () -> new MCPUnsupportedException("Index resources are not supported for the current database."));
-        return queryTable(databaseName, schemaName, tableName).map(optional -> sortIndexes(optional.getAllIndexes())).orElse(Collections.emptyList());
+        return queryTable(databaseName, schemaName, tableName).isEmpty()
+                ? Collections.emptyList()
+                : metadataContext.loadIndexes(databaseName, schemaName, tableName).map(this::sortIndexes).orElse(Collections.emptyList());
     }
     
     @Override
@@ -182,7 +197,7 @@ public final class MetadataQueryService implements MCPMetadataQueryFacade {
         return tables.stream().filter(each -> tableName.equals(each.getName())).findFirst();
     }
     
-    private Optional<ShardingSphereColumn> findColumn(final Collection<ShardingSphereColumn> columns, final String columnName) {
+    private Optional<MCPColumnMetadata> findColumn(final Collection<MCPColumnMetadata> columns, final String columnName) {
         return columns.stream().filter(each -> columnName.equals(each.getName())).findFirst();
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/query/MetadataQueryService.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/query/MetadataQueryService.java
@@ -148,7 +148,7 @@ public final class MetadataQueryService implements MCPMetadataQueryFacade {
     
     private List<MCPColumnMetadata> sortColumns(final Collection<MCPColumnMetadata> columns) {
         return columns.stream().sorted(Comparator.comparing(MCPColumnMetadata::getRelationName)
-                .thenComparingInt(MCPColumnMetadata::getOrdinalPosition).thenComparing(MCPColumnMetadata::getName)).toList();
+                .thenComparing(MCPColumnMetadata::getName)).toList();
     }
     
     @Override

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/spi/MCPMetadataQueryFacade.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/spi/MCPMetadataQueryFacade.java
@@ -17,13 +17,13 @@
 
 package org.apache.shardingsphere.mcp.support.database.spi;
 
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPMetadataObjectType;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
 
 import java.util.List;
 import java.util.Optional;
@@ -111,7 +111,7 @@ public interface MCPMetadataQueryFacade {
      * @param tableName table name
      * @return column metadata list
      */
-    List<ShardingSphereColumn> queryTableColumns(String databaseName, String schemaName, String tableName);
+    List<MCPColumnMetadata> queryTableColumns(String databaseName, String schemaName, String tableName);
     
     /**
      * Query one table column.
@@ -122,7 +122,7 @@ public interface MCPMetadataQueryFacade {
      * @param columnName column name
      * @return column metadata
      */
-    Optional<ShardingSphereColumn> queryTableColumn(String databaseName, String schemaName, String tableName, String columnName);
+    Optional<MCPColumnMetadata> queryTableColumn(String databaseName, String schemaName, String tableName, String columnName);
     
     /**
      * Query view columns.
@@ -132,7 +132,7 @@ public interface MCPMetadataQueryFacade {
      * @param viewName view name
      * @return column metadata list
      */
-    List<ShardingSphereColumn> queryViewColumns(String databaseName, String schemaName, String viewName);
+    List<MCPColumnMetadata> queryViewColumns(String databaseName, String schemaName, String viewName);
     
     /**
      * Query one view column.
@@ -143,7 +143,16 @@ public interface MCPMetadataQueryFacade {
      * @param columnName column name
      * @return column metadata
      */
-    Optional<ShardingSphereColumn> queryViewColumn(String databaseName, String schemaName, String viewName, String columnName);
+    Optional<MCPColumnMetadata> queryViewColumn(String databaseName, String schemaName, String viewName, String columnName);
+    
+    /**
+     * Query all table and view columns in a schema.
+     *
+     * @param databaseName database name
+     * @param schemaName schema name
+     * @return column metadata list
+     */
+    List<MCPColumnMetadata> querySchemaColumns(String databaseName, String schemaName);
     
     /**
      * Query table indexes.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtils.java
@@ -44,6 +44,10 @@ public final class MCPToolDescriptorValidationUtils {
             "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
             "distsql_artifacts", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
     
+    private static final Collection<String> REQUIRED_WORKFLOW_PLAN_SCHEMA_FIELDS = List.of(
+            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs",
+            MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
+    
     private static final Collection<String> REQUIRED_WORKFLOW_PLAN_META_FIELDS = List.of(
             "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/artifact-categories", "org.apache.shardingsphere/side-effect-scope",
             "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
@@ -55,6 +59,7 @@ public final class MCPToolDescriptorValidationUtils {
      */
     public static void validateRequiredWorkflowPlanOutputFields(final MCPToolDescriptor descriptor) {
         validateRequiredOutputFields(descriptor, REQUIRED_WORKFLOW_PLAN_OUTPUT_FIELDS);
+        validateRequiredWorkflowPlanSchemaFields(descriptor);
     }
     
     /**
@@ -67,6 +72,17 @@ public final class MCPToolDescriptorValidationUtils {
         Collection<String> requiredFields = new LinkedList<>(REQUIRED_WORKFLOW_PLAN_OUTPUT_FIELDS);
         requiredFields.addAll(additionalFields);
         validateRequiredOutputFields(descriptor, requiredFields);
+        validateRequiredWorkflowPlanSchemaFields(descriptor);
+    }
+    
+    private static void validateRequiredWorkflowPlanSchemaFields(final MCPToolDescriptor descriptor) {
+        Object required = descriptor.getOutputSchema().get("required");
+        ShardingSpherePreconditions.checkState(required instanceof Collection,
+                () -> new IllegalStateException(String.format("Tool `%s` outputSchema must declare required workflow fields.", descriptor.getName())));
+        for (String each : REQUIRED_WORKFLOW_PLAN_SCHEMA_FIELDS) {
+            ShardingSpherePreconditions.checkState(((Collection<?>) required).contains(each),
+                    () -> new IllegalStateException(String.format("Tool `%s` outputSchema must require `%s`.", descriptor.getName(), each)));
+        }
     }
     
     /**

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningContextValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningContextValidator.java
@@ -19,10 +19,10 @@ package org.apache.shardingsphere.mcp.support.workflow.service;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.mcp.support.database.exception.DatabaseCapabilityNotFoundException;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.model.ClarifiedIntent;
@@ -113,16 +113,24 @@ public final class WorkflowPlanningContextValidator {
         if (schemas.isEmpty()) {
             schemas = metadataQueryFacade.querySchemas(databaseName);
         }
-        Optional<ShardingSphereTable> table = findTable(schemas, request, queryFacade, databaseName);
+        Optional<ShardingSphereSchema> schema = findSchema(schemas, request, queryFacade, databaseName);
+        Optional<ShardingSphereTable> table = findTable(schema, request, queryFacade, databaseName);
         if (!ensureTableExists(table, request, snapshot)) {
             snapshot.setStatus(WorkflowLifecycle.STATUS_FAILED);
             return false;
         }
-        if (!ensureColumnExists(table.orElseThrow(), request, snapshot, queryFacade, databaseName)) {
+        if (!ensureColumnExists(metadataQueryFacade.queryTableColumns(databaseName, schema.orElseThrow().getName(), table.orElseThrow().getName()),
+                request, snapshot, queryFacade, databaseName)) {
             snapshot.setStatus(WorkflowLifecycle.STATUS_FAILED);
             return false;
         }
         return true;
+    }
+    
+    private Optional<ShardingSphereSchema> findSchema(final Collection<ShardingSphereSchema> schemas, final WorkflowRequest request,
+                                                      final MCPFeatureQueryFacade queryFacade, final String databaseName) {
+        return schemas.stream().filter(each -> matchesMetadataIdentifier(
+                queryFacade, databaseName, IdentifierScope.SCHEMA, request.getSchema(), each.getName())).findFirst();
     }
     
     private boolean ensureIdentifiers(final String fieldName, final Collection<String> identifiers, final WorkflowContextSnapshot snapshot, final String issueStage, final boolean allowEmpty) {
@@ -226,13 +234,12 @@ public final class WorkflowPlanningContextValidator {
         return schema;
     }
     
-    private Optional<ShardingSphereTable> findTable(final Collection<ShardingSphereSchema> schemas, final WorkflowRequest request,
+    private Optional<ShardingSphereTable> findTable(final Optional<ShardingSphereSchema> schema, final WorkflowRequest request,
                                                     final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return schemas.stream().filter(each -> matchesMetadataIdentifier(queryFacade, databaseName, IdentifierScope.SCHEMA, request.getSchema(), each.getName())).findFirst()
-                .flatMap(schema -> schema.getAllTables().stream()
-                        .filter(each -> TableType.TABLE == each.getType()
-                                && matchesMetadataIdentifier(queryFacade, databaseName, IdentifierScope.TABLE, request.getTable(), each.getName()))
-                        .findFirst());
+        return schema.flatMap(optional -> optional.getAllTables().stream()
+                .filter(each -> TableType.TABLE == each.getType()
+                        && matchesMetadataIdentifier(queryFacade, databaseName, IdentifierScope.TABLE, request.getTable(), each.getName()))
+                .findFirst());
     }
     
     private boolean matchesMetadataIdentifier(final MCPFeatureQueryFacade queryFacade, final String databaseName, final IdentifierScope identifierScope,
@@ -251,9 +258,9 @@ public final class WorkflowPlanningContextValidator {
         return false;
     }
     
-    private boolean ensureColumnExists(final ShardingSphereTable table, final WorkflowRequest request, final WorkflowContextSnapshot snapshot,
+    private boolean ensureColumnExists(final Collection<MCPColumnMetadata> columns, final WorkflowRequest request, final WorkflowContextSnapshot snapshot,
                                        final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        for (ShardingSphereColumn each : table.getAllColumns()) {
+        for (MCPColumnMetadata each : columns) {
             if (matchesMetadataIdentifier(queryFacade, databaseName, IdentifierScope.COLUMN, request.getColumn(), each.getName())) {
                 return true;
             }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtils.java
@@ -175,13 +175,28 @@ public final class WorkflowSQLUtils {
      */
     public static String createAlgorithmFragment(final String algorithmType, final Map<String, String> properties) {
         String actualType = trimToEmpty(algorithmType).toLowerCase(Locale.ENGLISH);
-        if (actualType.isEmpty()) {
+        return createAlgorithmFragmentWithType(actualType, properties);
+    }
+    
+    /**
+     * Create an algorithm fragment for DistSQL while preserving the algorithm type case.
+     *
+     * @param algorithmType algorithm type
+     * @param properties algorithm properties
+     * @return DistSQL algorithm fragment
+     */
+    public static String createAlgorithmFragmentWithExactType(final String algorithmType, final Map<String, String> properties) {
+        return createAlgorithmFragmentWithType(trimToEmpty(algorithmType), properties);
+    }
+    
+    private static String createAlgorithmFragmentWithType(final String algorithmType, final Map<String, String> properties) {
+        if (algorithmType.isEmpty()) {
             return "";
         }
         Properties actualProperties = WorkflowAlgorithmUtils.createProperties(properties);
         return actualProperties.isEmpty()
-                ? String.format("TYPE(NAME='%s')", escapeLiteral(actualType))
-                : String.format("TYPE(NAME='%s', PROPERTIES(%s))", escapeLiteral(actualType), createPropertiesFragment(actualProperties));
+                ? String.format("TYPE(NAME='%s')", escapeLiteral(algorithmType))
+                : String.format("TYPE(NAME='%s', PROPERTIES(%s))", escapeLiteral(algorithmType), createPropertiesFragment(actualProperties));
     }
     
     private static String createPropertiesFragment(final Properties props) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/context/RequestScopedMetadataContextTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/context/RequestScopedMetadataContextTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.database.metadata.context;
+
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
+import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseCapabilityProvider;
+import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.MCPJdbcMetadataLoader;
+import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
+import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+import java.sql.Types;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class RequestScopedMetadataContextTest {
+    
+    @Test
+    void assertLoadColumnsOncePerRelation() {
+        RuntimeDatabaseConfiguration configuration = mock(RuntimeDatabaseConfiguration.class);
+        RuntimeDatabaseProfile profile = mock(RuntimeDatabaseProfile.class);
+        MCPDatabaseCapabilityProvider capabilityProvider = createCapabilityProvider(profile);
+        List<MCPColumnMetadata> expected = List.of(new MCPColumnMetadata("orders", "order_id", 1, Types.BIGINT, "BIGINT", Nullability.NOT_NULLABLE));
+        try (
+                MockedConstruction<MCPJdbcMetadataLoader> mockedLoader = mockConstruction(MCPJdbcMetadataLoader.class,
+                        (mock, context) -> when(mock.loadColumns("logic_db", configuration, profile, "public", "orders")).thenReturn(expected))) {
+            RequestScopedMetadataContext context = new RequestScopedMetadataContext(Map.of("logic_db", configuration), capabilityProvider);
+            assertThat(context.loadColumns("logic_db", "public", "orders").orElseThrow().stream().map(MCPColumnMetadata::getName).toList(), is(List.of("order_id")));
+            assertThat(context.loadColumns("logic_db", "public", "orders").orElseThrow().stream().map(MCPColumnMetadata::getName).toList(), is(List.of("order_id")));
+            verify(mockedLoader.constructed().getFirst()).loadColumns("logic_db", configuration, profile, "public", "orders");
+        }
+    }
+    
+    @Test
+    void assertLoadColumnsWithoutRuntimeBinding() {
+        try (MockedConstruction<MCPJdbcMetadataLoader> mockedLoader = mockConstruction(MCPJdbcMetadataLoader.class)) {
+            RequestScopedMetadataContext context = new RequestScopedMetadataContext(Map.of(), createCapabilityProvider());
+            assertTrue(context.loadColumns("logic_db", "public", "orders").isEmpty());
+            verifyNoInteractions(mockedLoader.constructed().getFirst());
+        }
+    }
+    
+    @Test
+    void assertLoadSchemaColumnsOncePerSchema() {
+        RuntimeDatabaseConfiguration configuration = mock(RuntimeDatabaseConfiguration.class);
+        RuntimeDatabaseProfile profile = mock(RuntimeDatabaseProfile.class);
+        MCPDatabaseCapabilityProvider capabilityProvider = createCapabilityProvider(profile);
+        List<MCPColumnMetadata> expected = List.of(new MCPColumnMetadata("orders", "order_id", 1, Types.BIGINT, "BIGINT", Nullability.NOT_NULLABLE));
+        try (
+                MockedConstruction<MCPJdbcMetadataLoader> mockedLoader = mockConstruction(MCPJdbcMetadataLoader.class,
+                        (mock, context) -> when(mock.loadSchemaColumns("logic_db", configuration, profile, "public")).thenReturn(expected))) {
+            RequestScopedMetadataContext context = new RequestScopedMetadataContext(Map.of("logic_db", configuration), capabilityProvider);
+            assertThat(context.loadSchemaColumns("logic_db", "public").orElseThrow().stream().map(MCPColumnMetadata::getName).toList(), is(List.of("order_id")));
+            assertThat(context.loadSchemaColumns("logic_db", "public").orElseThrow().stream().map(MCPColumnMetadata::getName).toList(), is(List.of("order_id")));
+            verify(mockedLoader.constructed().getFirst()).loadSchemaColumns("logic_db", configuration, profile, "public");
+        }
+    }
+    
+    @Test
+    void assertLoadSchemaColumnsWithoutRuntimeBinding() {
+        try (MockedConstruction<MCPJdbcMetadataLoader> mockedLoader = mockConstruction(MCPJdbcMetadataLoader.class)) {
+            RequestScopedMetadataContext context = new RequestScopedMetadataContext(Map.of(), createCapabilityProvider());
+            assertTrue(context.loadSchemaColumns("logic_db", "public").isEmpty());
+            verifyNoInteractions(mockedLoader.constructed().getFirst());
+        }
+    }
+    
+    @Test
+    void assertLoadIndexesOncePerTable() {
+        RuntimeDatabaseConfiguration configuration = mock(RuntimeDatabaseConfiguration.class);
+        RuntimeDatabaseProfile profile = mock(RuntimeDatabaseProfile.class);
+        MCPDatabaseCapabilityProvider capabilityProvider = createCapabilityProvider(profile);
+        List<ShardingSphereIndex> expected = List.of(new ShardingSphereIndex("orders_idx", List.of("order_id"), true));
+        try (
+                MockedConstruction<MCPJdbcMetadataLoader> mockedLoader = mockConstruction(MCPJdbcMetadataLoader.class,
+                        (mock, context) -> when(mock.loadIndexes("logic_db", configuration, profile, "public", "orders")).thenReturn(expected))) {
+            RequestScopedMetadataContext context = new RequestScopedMetadataContext(Map.of("logic_db", configuration), capabilityProvider);
+            assertThat(context.loadIndexes("logic_db", "public", "orders").orElseThrow().stream().map(ShardingSphereIndex::getName).toList(), is(List.of("orders_idx")));
+            assertThat(context.loadIndexes("logic_db", "public", "orders").orElseThrow().stream().map(ShardingSphereIndex::getName).toList(), is(List.of("orders_idx")));
+            verify(mockedLoader.constructed().getFirst()).loadIndexes("logic_db", configuration, profile, "public", "orders");
+        }
+    }
+    
+    @Test
+    void assertLoadIndexesWithoutRuntimeBinding() {
+        try (MockedConstruction<MCPJdbcMetadataLoader> mockedLoader = mockConstruction(MCPJdbcMetadataLoader.class)) {
+            RequestScopedMetadataContext context = new RequestScopedMetadataContext(Map.of(), createCapabilityProvider());
+            assertTrue(context.loadIndexes("logic_db", "public", "orders").isEmpty());
+            verifyNoInteractions(mockedLoader.constructed().getFirst());
+        }
+    }
+    
+    private MCPDatabaseCapabilityProvider createCapabilityProvider() {
+        return mock(MCPDatabaseCapabilityProvider.class);
+    }
+    
+    private MCPDatabaseCapabilityProvider createCapabilityProvider(final RuntimeDatabaseProfile profile) {
+        MCPDatabaseCapabilityProvider result = mock(MCPDatabaseCapabilityProvider.class);
+        when(result.findDatabaseProfile("logic_db")).thenReturn(Optional.of(profile));
+        return result;
+    }
+}

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/AbstractMCPJdbcMetadataLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/AbstractMCPJdbcMetadataLoaderTest.java
@@ -30,13 +30,13 @@ import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoa
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPMetadataObjectType;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
 import org.apache.shardingsphere.mcp.support.fixture.SupportDatabaseTypeFactoryMocker;
 import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.MockedStatic;
@@ -59,6 +59,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -104,6 +105,53 @@ abstract class AbstractMCPJdbcMetadataLoaderTest {
                 result.put(entry.getKey(), metadataLoader.load(entry.getKey(), entry.getValue(), databaseProfiles.get(entry.getKey())));
             }
             return new LoadedMetadataCatalog(result);
+        }
+    }
+    
+    protected List<MCPColumnMetadata> loadColumns(final RuntimeDatabaseConfiguration runtimeDatabaseConfig, final String schemaName, final String relationName) {
+        return loadMetadataDetail(runtimeDatabaseConfig, Map.of(),
+                (loader, profile) -> loader.loadColumns("logic_db", runtimeDatabaseConfig, profile, schemaName, relationName));
+    }
+    
+    protected List<MCPColumnMetadata> loadColumns(final RuntimeDatabaseConfiguration runtimeDatabaseConfig, final String schemaName, final String relationName,
+                                                  final Map<String, DialectSchemaSemantics> schemaSemantics) {
+        return loadMetadataDetail(runtimeDatabaseConfig, schemaSemantics,
+                (loader, profile) -> loader.loadColumns("logic_db", runtimeDatabaseConfig, profile, schemaName, relationName));
+    }
+    
+    protected List<MCPColumnMetadata> loadSchemaColumns(final RuntimeDatabaseConfiguration runtimeDatabaseConfig, final String schemaName) {
+        return loadMetadataDetail(runtimeDatabaseConfig, Map.of(),
+                (loader, profile) -> loader.loadSchemaColumns("logic_db", runtimeDatabaseConfig, profile, schemaName));
+    }
+    
+    protected List<MCPColumnMetadata> loadSchemaColumns(final RuntimeDatabaseConfiguration runtimeDatabaseConfig, final String schemaName,
+                                                        final Map<String, DialectSchemaSemantics> schemaSemantics) {
+        return loadMetadataDetail(runtimeDatabaseConfig, schemaSemantics,
+                (loader, profile) -> loader.loadSchemaColumns("logic_db", runtimeDatabaseConfig, profile, schemaName));
+    }
+    
+    protected List<ShardingSphereIndex> loadIndexes(final RuntimeDatabaseConfiguration runtimeDatabaseConfig, final String schemaName, final String tableName) {
+        return loadMetadataDetail(runtimeDatabaseConfig, Map.of(),
+                (loader, profile) -> loader.loadIndexes("logic_db", runtimeDatabaseConfig, profile, schemaName, tableName));
+    }
+    
+    protected List<ShardingSphereIndex> loadIndexes(final RuntimeDatabaseConfiguration runtimeDatabaseConfig, final String schemaName, final String tableName,
+                                                    final Map<String, DialectSchemaSemantics> schemaSemantics) {
+        return loadMetadataDetail(runtimeDatabaseConfig, schemaSemantics,
+                (loader, profile) -> loader.loadIndexes("logic_db", runtimeDatabaseConfig, profile, schemaName, tableName));
+    }
+    
+    private <T> T loadMetadataDetail(final RuntimeDatabaseConfiguration runtimeDatabaseConfig,
+                                     final Map<String, DialectSchemaSemantics> schemaSemantics,
+                                     final BiFunction<MCPJdbcMetadataLoader, RuntimeDatabaseProfile, T> operation) {
+        try (
+                MockedStatic<DatabaseTypeFactory> ignored = SupportDatabaseTypeFactoryMocker.mockByConnectionMetadata();
+                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class, CALLS_REAL_METHODS);
+                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
+            Map<String, RuntimeDatabaseConfiguration> runtimeDatabases = Map.of("logic_db", runtimeDatabaseConfig);
+            RuntimeDatabaseProfile databaseProfile = new MCPJdbcDatabaseProfileLoader().load(runtimeDatabases).get("logic_db");
+            mockDatabaseTypedSPI(List.of(databaseProfile), List.of("PostgreSQL"), Map.of(), schemaSemantics, typedSPILoader, databaseTypedSPILoader);
+            return operation.apply(new MCPJdbcMetadataLoader(), databaseProfile);
         }
     }
     
@@ -153,8 +201,6 @@ abstract class AbstractMCPJdbcMetadataLoaderTest {
                 Arguments.of("table orders", SupportedMCPMetadataObjectType.TABLE, "orders"),
                 Arguments.of("table order_items", SupportedMCPMetadataObjectType.TABLE, "order_items"),
                 Arguments.of("view active_orders", SupportedMCPMetadataObjectType.VIEW, "active_orders"),
-                Arguments.of("column status", SupportedMCPMetadataObjectType.COLUMN, "status"),
-                Arguments.of("index idx_orders_status", SupportedMCPMetadataObjectType.INDEX, "idx_orders_status"),
                 Arguments.of("sequence order_seq", SupportedMCPMetadataObjectType.SEQUENCE, "order_seq"));
     }
     
@@ -318,24 +364,40 @@ abstract class AbstractMCPJdbcMetadataLoaderTest {
         return result;
     }
     
-    protected ResultSet mockSingleRowResultSet(final Map<String, String> values) throws SQLException {
+    protected ResultSet mockSingleRowResultSet(final Map<String, ?> values) throws SQLException {
         ResultSet result = mock(ResultSet.class);
         when(result.next()).thenReturn(true, false);
-        for (Entry<String, String> entry : values.entrySet()) {
-            when(result.getString(entry.getKey())).thenReturn(entry.getValue());
+        for (Entry<String, ?> entry : values.entrySet()) {
+            when(result.getString(entry.getKey())).thenReturn(null == entry.getValue() ? null : entry.getValue().toString());
         }
         return result;
     }
     
-    protected ResultSet mockMultiRowResultSet(final List<Map<String, String>> values) throws SQLException {
+    protected ResultSet mockMultiRowResultSet(final List<? extends Map<String, ?>> values) throws SQLException {
         ResultSet result = mock(ResultSet.class);
         AtomicInteger rowIndex = new AtomicInteger(-1);
         when(result.next()).thenAnswer(invocation -> rowIndex.incrementAndGet() < values.size());
         when(result.getString(anyString())).thenAnswer(invocation -> {
             int currentRowIndex = rowIndex.get();
-            return 0 <= currentRowIndex && currentRowIndex < values.size() ? values.get(currentRowIndex).get(invocation.getArgument(0)) : null;
+            Object value = 0 <= currentRowIndex && currentRowIndex < values.size() ? values.get(currentRowIndex).get(invocation.getArgument(0)) : null;
+            return null == value ? null : value.toString();
+        });
+        when(result.getInt(anyString())).thenAnswer(invocation -> getNumber(values, rowIndex.get(), invocation.getArgument(0)).intValue());
+        when(result.getShort(anyString())).thenAnswer(invocation -> getNumber(values, rowIndex.get(), invocation.getArgument(0)).shortValue());
+        when(result.getBoolean(anyString())).thenAnswer(invocation -> {
+            Object value = getValue(values, rowIndex.get(), invocation.getArgument(0));
+            return value instanceof Boolean ? value : Boolean.parseBoolean(String.valueOf(value));
         });
         return result;
+    }
+    
+    private Number getNumber(final List<? extends Map<String, ?>> values, final int rowIndex, final String columnName) {
+        Object value = getValue(values, rowIndex, columnName);
+        return value instanceof Number ? (Number) value : 0;
+    }
+    
+    private Object getValue(final List<? extends Map<String, ?>> values, final int rowIndex, final String columnName) {
+        return 0 <= rowIndex && rowIndex < values.size() ? values.get(rowIndex).get(columnName) : null;
     }
     
     protected String getMetadataJdbcUrl(final String databaseType) {
@@ -364,28 +426,6 @@ abstract class AbstractMCPJdbcMetadataLoaderTest {
                 result++;
             }
             if (SupportedMCPMetadataObjectType.VIEW == objectType && TableType.VIEW == each.getType() && objectName.equals(each.getName())) {
-                result++;
-            }
-            result += countColumnMetadata(each.getAllColumns(), objectType, objectName);
-            result += countIndexMetadata(each.getAllIndexes(), objectType, objectName);
-        }
-        return result;
-    }
-    
-    private int countColumnMetadata(final Collection<ShardingSphereColumn> columns, final SupportedMCPMetadataObjectType objectType, final String objectName) {
-        int result = 0;
-        for (ShardingSphereColumn each : columns) {
-            if (SupportedMCPMetadataObjectType.COLUMN == objectType && objectName.equals(each.getName())) {
-                result++;
-            }
-        }
-        return result;
-    }
-    
-    private int countIndexMetadata(final Collection<ShardingSphereIndex> indexes, final SupportedMCPMetadataObjectType objectType, final String objectName) {
-        int result = 0;
-        for (ShardingSphereIndex each : indexes) {
-            if (SupportedMCPMetadataObjectType.INDEX == objectType && objectName.equals(each.getName())) {
                 result++;
             }
         }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoaderSchemaFilteringTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoaderSchemaFilteringTest.java
@@ -52,7 +52,7 @@ class MCPJdbcMetadataLoaderSchemaFilteringTest extends AbstractMCPJdbcMetadataLo
             assertThat(schemas.size(), is(1));
             assertThat(schemas.iterator().next().getName(), is("logic_db"));
             assertTrue(containsMetadata(schemas, SupportedMCPMetadataObjectType.TABLE, "orders"));
-            assertTrue(containsMetadata(schemas, SupportedMCPMetadataObjectType.COLUMN, "order_id"));
+            assertFalse(containsMetadata(schemas, SupportedMCPMetadataObjectType.COLUMN, "order_id"));
         }
     }
     
@@ -108,7 +108,7 @@ class MCPJdbcMetadataLoaderSchemaFilteringTest extends AbstractMCPJdbcMetadataLo
         Collection<ShardingSphereSchema> actual = loadWithDatabaseAsSchema(Map.of("logic_db", runtimeDatabaseConfiguration)).findMetadata("logic_db").orElseThrow();
         assertThat(actual.iterator().next().getName(), is("logic_db"));
         assertTrue(containsMetadata(actual, SupportedMCPMetadataObjectType.TABLE, "orders"));
-        assertTrue(containsMetadata(actual, SupportedMCPMetadataObjectType.INDEX, "idx_orders_status"));
+        assertFalse(containsMetadata(actual, SupportedMCPMetadataObjectType.INDEX, "idx_orders_status"));
     }
     
     @Test
@@ -134,24 +134,23 @@ class MCPJdbcMetadataLoaderSchemaFilteringTest extends AbstractMCPJdbcMetadataLo
     }
     
     @Test
-    void assertLoadWithoutEmptyColumnName() throws SQLException {
+    void assertLoadCatalogWithoutEagerColumns() throws SQLException {
         Connection connection = createConnectionWithMetadata(
                 List.of(Map.of("TABLE_SCHEM", "PUBLIC", "TABLE_NAME", "orders")), List.of(), Map.of("orders", List.of("", "order_id")), Map.of(), List.of());
         RuntimeDatabaseConfiguration runtimeDatabaseConfiguration = createMockRuntimeDatabaseConfiguration(connection);
         Collection<ShardingSphereSchema> actual = load(Map.of("logic_db", runtimeDatabaseConfiguration)).findMetadata("logic_db").orElseThrow();
-        assertTrue(containsMetadata(actual, SupportedMCPMetadataObjectType.COLUMN, "order_id"));
+        assertFalse(containsMetadata(actual, SupportedMCPMetadataObjectType.COLUMN, "order_id"));
         assertFalse(containsMetadata(actual, SupportedMCPMetadataObjectType.COLUMN, ""));
     }
     
     @Test
-    void assertLoadWithoutEmptyOrDuplicateIndexName() throws SQLException {
+    void assertLoadCatalogWithoutEagerIndexes() throws SQLException {
         Connection connection = createConnectionWithMetadata(
                 List.of(Map.of("TABLE_SCHEM", "PUBLIC", "TABLE_NAME", "orders")), List.of(), Map.of("orders", List.of("order_id")),
                 Map.of("orders", List.of("", "idx_orders_status", "idx_orders_status")), List.of());
         RuntimeDatabaseConfiguration runtimeDatabaseConfiguration = createMockRuntimeDatabaseConfiguration(connection);
         Collection<ShardingSphereSchema> actual = load(Map.of("logic_db", runtimeDatabaseConfiguration)).findMetadata("logic_db").orElseThrow();
-        assertTrue(containsMetadata(actual, SupportedMCPMetadataObjectType.INDEX, "idx_orders_status"));
-        assertThat(countMetadata(actual, SupportedMCPMetadataObjectType.INDEX, "idx_orders_status"), is(1));
+        assertFalse(containsMetadata(actual, SupportedMCPMetadataObjectType.INDEX, "idx_orders_status"));
     }
     
     @Test

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoaderTest.java
@@ -122,6 +122,23 @@ class MCPJdbcMetadataLoaderTest extends AbstractMCPJdbcMetadataLoaderTest {
     }
     
     @Test
+    void assertLoadColumnsWithLogicalCatalogFallback() throws SQLException {
+        Connection connection = createMetadataDetailConnection("MySQL");
+        DatabaseMetaData databaseMetaData = connection.getMetaData();
+        when(connection.getCatalog()).thenReturn("logic_db");
+        when(databaseMetaData.getSearchStringEscape()).thenReturn("\\");
+        ResultSet emptyColumns = mockMultiRowResultSet(List.of());
+        ResultSet fallbackColumns = mockMultiRowResultSet(List.of(
+                Map.of("TABLE_NAME", "orders", "COLUMN_NAME", "order_id", "ORDINAL_POSITION", 1,
+                        "DATA_TYPE", Types.BIGINT, "TYPE_NAME", "BIGINT", "NULLABLE", DatabaseMetaData.columnNoNulls)));
+        when(databaseMetaData.getColumns(eq("logic_db"), isNull(), eq("orders"), eq("%"))).thenReturn(emptyColumns);
+        when(databaseMetaData.getColumns(isNull(), isNull(), eq("orders"), eq("%"))).thenReturn(fallbackColumns);
+        List<MCPColumnMetadata> actual = loadColumns(createMockRuntimeDatabaseConfiguration(connection), "logic_db", "orders",
+                Map.of("MySQL", DialectSchemaSemantics.DATABASE_AS_SCHEMA));
+        assertThat(actual.stream().map(MCPColumnMetadata::getName).toList(), is(List.of("order_id")));
+    }
+    
+    @Test
     void assertLoadSchemaColumnsInOneQuery() throws SQLException {
         Connection connection = createMetadataDetailConnection();
         DatabaseMetaData databaseMetaData = connection.getMetaData();

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoaderTest.java
@@ -17,27 +17,34 @@
 
 package org.apache.shardingsphere.mcp.support.database.metadata.jdbc;
 
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaSemantics;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPMetadataObjectType;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Types;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MCPJdbcMetadataLoaderTest extends AbstractMCPJdbcMetadataLoaderTest {
@@ -77,14 +84,126 @@ class MCPJdbcMetadataLoaderTest extends AbstractMCPJdbcMetadataLoaderTest {
     }
     
     @Test
-    void assertLoadWithoutIndexMetadataSupport() throws SQLException {
-        Connection connection = createStandardPostgreSQLMetadataConnection();
+    void assertLoadColumns() throws SQLException {
+        Connection connection = createMetadataDetailConnection();
         DatabaseMetaData databaseMetaData = connection.getMetaData();
-        when(databaseMetaData.getIndexInfo(isNull(), nullable(String.class), anyString(), eq(false), eq(false)))
+        when(databaseMetaData.getSearchStringEscape()).thenReturn("\\");
+        ResultSet columns = mockMultiRowResultSet(List.of(
+                Map.of("TABLE_NAME", "order_%\\archive", "COLUMN_NAME", "status", "ORDINAL_POSITION", 2,
+                        "DATA_TYPE", Types.VARCHAR, "TYPE_NAME", "varchar", "NULLABLE", DatabaseMetaData.columnNullable),
+                Map.of("TABLE_NAME", "order_%\\archive", "COLUMN_NAME", "order_id", "ORDINAL_POSITION", 1,
+                        "DATA_TYPE", Types.BIGINT, "TYPE_NAME", "int8", "NULLABLE", DatabaseMetaData.columnNoNulls),
+                Map.of("TABLE_NAME", "order_%\\archive", "COLUMN_NAME", "", "ORDINAL_POSITION", 3,
+                        "DATA_TYPE", Types.OTHER, "TYPE_NAME", "", "NULLABLE", DatabaseMetaData.columnNullableUnknown)));
+        when(databaseMetaData.getColumns(isNull(), eq("PUBLIC"), eq("order\\_\\%\\\\archive"), eq("%"))).thenReturn(columns);
+        List<MCPColumnMetadata> actual = loadColumns(createMockRuntimeDatabaseConfiguration(connection), "PUBLIC", "order_%\\archive");
+        assertThat(actual.size(), is(2));
+        assertThat(actual.getFirst().getName(), is("order_id"));
+        assertThat(actual.getFirst().getOrdinalPosition(), is(1));
+        assertThat(actual.getFirst().getJdbcType(), is(Types.BIGINT));
+        assertThat(actual.getFirst().getNativeTypeName(), is("int8"));
+        assertThat(actual.getFirst().getNullability(), is(Nullability.NOT_NULLABLE));
+        assertThat(actual.get(1).getNullability(), is(Nullability.NULLABLE));
+    }
+    
+    @Test
+    void assertLoadColumnsWithDatabaseAsSchema() throws SQLException {
+        Connection connection = createMetadataDetailConnection("MySQL");
+        DatabaseMetaData databaseMetaData = connection.getMetaData();
+        when(connection.getCatalog()).thenReturn("orders");
+        when(databaseMetaData.getSearchStringEscape()).thenReturn("\\");
+        ResultSet columns = mockMultiRowResultSet(List.of(
+                Map.of("TABLE_NAME", "orders", "COLUMN_NAME", "order_id", "ORDINAL_POSITION", 1,
+                        "DATA_TYPE", Types.BIGINT, "TYPE_NAME", "BIGINT", "NULLABLE", DatabaseMetaData.columnNoNulls)));
+        when(databaseMetaData.getColumns(eq("orders"), isNull(), eq("orders"), eq("%"))).thenReturn(columns);
+        List<MCPColumnMetadata> actual = loadColumns(createMockRuntimeDatabaseConfiguration(connection), "logic_db", "orders",
+                Map.of("MySQL", DialectSchemaSemantics.DATABASE_AS_SCHEMA));
+        assertThat(actual.stream().map(MCPColumnMetadata::getName).toList(), is(List.of("order_id")));
+    }
+    
+    @Test
+    void assertLoadSchemaColumnsInOneQuery() throws SQLException {
+        Connection connection = createMetadataDetailConnection();
+        DatabaseMetaData databaseMetaData = connection.getMetaData();
+        when(databaseMetaData.getSearchStringEscape()).thenReturn("\\");
+        ResultSet columns = mockMultiRowResultSet(List.of(
+                Map.of("TABLE_NAME", "orders", "COLUMN_NAME", "order_id", "ORDINAL_POSITION", 1,
+                        "DATA_TYPE", Types.BIGINT, "TYPE_NAME", "int8", "NULLABLE", DatabaseMetaData.columnNoNulls),
+                Map.of("TABLE_NAME", "active_orders", "COLUMN_NAME", "status", "ORDINAL_POSITION", 2,
+                        "DATA_TYPE", Types.VARCHAR, "TYPE_NAME", "varchar", "NULLABLE", DatabaseMetaData.columnNullableUnknown)));
+        when(databaseMetaData.getColumns(isNull(), eq("PUBLIC"), eq("%"), eq("%"))).thenReturn(columns);
+        List<MCPColumnMetadata> actual = loadSchemaColumns(createMockRuntimeDatabaseConfiguration(connection), "PUBLIC");
+        assertThat(actual.stream().map(MCPColumnMetadata::getRelationName).toList(), is(List.of("active_orders", "orders")));
+        assertThat(actual.getFirst().getNullability(), is(Nullability.UNKNOWN));
+        verify(databaseMetaData).getColumns(isNull(), eq("PUBLIC"), eq("%"), eq("%"));
+    }
+    
+    @Test
+    void assertLoadSchemaColumnsWithDatabaseAsSchema() throws SQLException {
+        Connection connection = createMetadataDetailConnection("MySQL");
+        DatabaseMetaData databaseMetaData = connection.getMetaData();
+        when(connection.getCatalog()).thenReturn("orders");
+        ResultSet columns = mockMultiRowResultSet(List.of(
+                Map.of("TABLE_NAME", "orders", "COLUMN_NAME", "order_id", "ORDINAL_POSITION", 1,
+                        "DATA_TYPE", Types.BIGINT, "TYPE_NAME", "BIGINT", "NULLABLE", DatabaseMetaData.columnNoNulls)));
+        when(databaseMetaData.getColumns(eq("orders"), isNull(), eq("%"), eq("%"))).thenReturn(columns);
+        List<MCPColumnMetadata> actual = loadSchemaColumns(createMockRuntimeDatabaseConfiguration(connection), "logic_db",
+                Map.of("MySQL", DialectSchemaSemantics.DATABASE_AS_SCHEMA));
+        assertThat(actual.stream().map(MCPColumnMetadata::getName).toList(), is(List.of("order_id")));
+    }
+    
+    @Test
+    void assertLoadIndexes() throws SQLException {
+        Connection connection = createMetadataDetailConnection();
+        DatabaseMetaData databaseMetaData = connection.getMetaData();
+        ResultSet indexes = mockMultiRowResultSet(List.of(
+                Map.of("INDEX_NAME", "idx_orders", "TYPE", DatabaseMetaData.tableIndexOther, "NON_UNIQUE", false, "ORDINAL_POSITION", 2, "COLUMN_NAME", "status"),
+                Map.of("INDEX_NAME", "statistics", "TYPE", DatabaseMetaData.tableIndexStatistic, "NON_UNIQUE", true, "ORDINAL_POSITION", 0, "COLUMN_NAME", ""),
+                Map.of("INDEX_NAME", "", "TYPE", DatabaseMetaData.tableIndexOther, "NON_UNIQUE", true, "ORDINAL_POSITION", 1, "COLUMN_NAME", "ignored"),
+                Map.of("INDEX_NAME", "idx_orders", "TYPE", DatabaseMetaData.tableIndexOther, "NON_UNIQUE", false, "ORDINAL_POSITION", 1, "COLUMN_NAME", "tenant_id"),
+                Map.of("INDEX_NAME", "idx_status", "TYPE", DatabaseMetaData.tableIndexOther, "NON_UNIQUE", true, "ORDINAL_POSITION", 1, "COLUMN_NAME", "status")));
+        when(databaseMetaData.getIndexInfo(isNull(), eq("PUBLIC"), eq("orders"), eq(false), eq(false))).thenReturn(indexes);
+        List<ShardingSphereIndex> actual = loadIndexes(createMockRuntimeDatabaseConfiguration(connection), "PUBLIC", "orders");
+        assertThat(actual.size(), is(2));
+        assertThat(actual.getFirst().getName(), is("idx_orders"));
+        assertThat(actual.getFirst().getColumns(), is(List.of("tenant_id", "status")));
+        assertTrue(actual.getFirst().isUnique());
+        assertThat(actual.get(1).getName(), is("idx_status"));
+        assertFalse(actual.get(1).isUnique());
+    }
+    
+    @Test
+    void assertLoadIndexesWithDatabaseAsSchema() throws SQLException {
+        Connection connection = createMetadataDetailConnection("MySQL");
+        DatabaseMetaData databaseMetaData = connection.getMetaData();
+        when(connection.getCatalog()).thenReturn("orders");
+        ResultSet indexes = mockMultiRowResultSet(List.of(
+                Map.of("INDEX_NAME", "PRIMARY", "TYPE", DatabaseMetaData.tableIndexOther, "NON_UNIQUE", false,
+                        "ORDINAL_POSITION", 1, "COLUMN_NAME", "order_id")));
+        when(databaseMetaData.getIndexInfo(eq("orders"), isNull(), eq("orders"), eq(false), eq(false))).thenReturn(indexes);
+        List<ShardingSphereIndex> actual = loadIndexes(createMockRuntimeDatabaseConfiguration(connection), "logic_db", "orders",
+                Map.of("MySQL", DialectSchemaSemantics.DATABASE_AS_SCHEMA));
+        assertThat(actual.stream().map(ShardingSphereIndex::getName).toList(), is(List.of("PRIMARY")));
+    }
+    
+    @Test
+    void assertLoadIndexesWithoutMetadataSupport() throws SQLException {
+        Connection connection = createMetadataDetailConnection();
+        when(connection.getMetaData().getIndexInfo(isNull(), eq("PUBLIC"), eq("orders"), eq(false), eq(false)))
                 .thenThrow(new SQLFeatureNotSupportedException("unsupported"));
-        LoadedMetadataCatalog actual = load(Map.of("logic_db", createMockRuntimeDatabaseConfiguration(connection)));
-        Collection<ShardingSphereSchema> schemas = actual.findMetadata("logic_db").orElseThrow();
-        assertTrue(containsMetadata(schemas, SupportedMCPMetadataObjectType.TABLE, "orders"));
-        assertFalse(containsMetadata(schemas, SupportedMCPMetadataObjectType.INDEX, "idx_orders_status"));
+        assertTrue(loadIndexes(createMockRuntimeDatabaseConfiguration(connection), "PUBLIC", "orders").isEmpty());
+    }
+    
+    private Connection createMetadataDetailConnection() throws SQLException {
+        return createMetadataDetailConnection("PostgreSQL");
+    }
+    
+    private Connection createMetadataDetailConnection(final String databaseType) throws SQLException {
+        Connection result = mock(Connection.class);
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        when(result.getMetaData()).thenReturn(databaseMetaData);
+        when(databaseMetaData.getDatabaseProductVersion()).thenReturn("16.2");
+        when(databaseMetaData.getURL()).thenReturn(getMetadataJdbcUrl(databaseType));
+        return result;
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/model/MCPColumnMetadataTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/model/MCPColumnMetadataTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.database.metadata.model;
+
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.sql.DatabaseMetaData;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MCPColumnMetadataTest {
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("nullabilityArguments")
+    void assertNullability(final String name, final int jdbcValue, final Nullability expected, final String expectedValue) {
+        Nullability actual = Nullability.fromJdbcValue(jdbcValue);
+        assertThat(actual, is(expected));
+        assertThat(actual.getValue(), is(expectedValue));
+    }
+    
+    private static Stream<Arguments> nullabilityArguments() {
+        return Stream.of(
+                Arguments.of("nullable", DatabaseMetaData.columnNullable, Nullability.NULLABLE, "nullable"),
+                Arguments.of("not nullable", DatabaseMetaData.columnNoNulls, Nullability.NOT_NULLABLE, "not_nullable"),
+                Arguments.of("unknown", DatabaseMetaData.columnNullableUnknown, Nullability.UNKNOWN, "unknown"),
+                Arguments.of("unrecognized", Integer.MIN_VALUE, Nullability.UNKNOWN, "unknown"));
+    }
+}

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/query/DatabaseTestDataFactory.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/query/DatabaseTestDataFactory.java
@@ -28,6 +28,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -48,7 +49,7 @@ final class DatabaseTestDataFactory {
         return List.of(
                 new DatabaseFixture("logic_db", "MySQL", "", List.of(
                         new SchemaFixture("public", List.of(
-                                new TableFixture("orders", List.of("order_id"), List.of("order_idx")),
+                                new TableFixture("orders", List.of("order_id", "amount"), List.of("order_idx")),
                                 new TableFixture("order_items", List.of("item_id"), List.of())),
                                 List.of(new TableFixture("orders_view", List.of("order_id"), List.of())), List.of()))),
                 new DatabaseFixture("runtime_db", "PostgreSQL", "", List.of(
@@ -83,6 +84,7 @@ final class DatabaseTestDataFactory {
         when(result.createStatement()).thenReturn(statement);
         when(databaseMetaData.getDatabaseProductVersion()).thenReturn(databaseMetadata.databaseVersion);
         when(databaseMetaData.getURL()).thenReturn(SupportDatabaseTypeFactoryMocker.createJdbcUrl(databaseMetadata.databaseType));
+        when(databaseMetaData.getSearchStringEscape()).thenReturn("\\");
         when(databaseMetaData.getTables(nullable(String.class), nullable(String.class), eq("%"), any(String[].class))).thenAnswer(invocation -> {
             String[] tableTypes = invocation.getArgument(3, String[].class);
             return createResultSet("TABLE".equals(tableTypes[0]) ? createTableRows(databaseMetadata) : createViewRows(databaseMetadata));
@@ -96,8 +98,8 @@ final class DatabaseTestDataFactory {
         return result;
     }
     
-    private static List<Map<String, String>> createTableRows(final DatabaseFixture databaseMetadata) {
-        List<Map<String, String>> result = new LinkedList<>();
+    private static List<Map<String, Object>> createTableRows(final DatabaseFixture databaseMetadata) {
+        List<Map<String, Object>> result = new LinkedList<>();
         for (SchemaFixture each : databaseMetadata.schemas) {
             for (TableFixture table : each.tables) {
                 result.add(Map.of("TABLE_SCHEM", each.schema, "TABLE_CAT", "", "TABLE_NAME", table.name));
@@ -106,8 +108,8 @@ final class DatabaseTestDataFactory {
         return result;
     }
     
-    private static List<Map<String, String>> createViewRows(final DatabaseFixture databaseMetadata) {
-        List<Map<String, String>> result = new LinkedList<>();
+    private static List<Map<String, Object>> createViewRows(final DatabaseFixture databaseMetadata) {
+        List<Map<String, Object>> result = new LinkedList<>();
         for (SchemaFixture each : databaseMetadata.schemas) {
             for (TableFixture view : each.views) {
                 result.add(Map.of("TABLE_SCHEM", each.schema, "TABLE_CAT", "", "TABLE_NAME", view.name));
@@ -116,20 +118,21 @@ final class DatabaseTestDataFactory {
         return result;
     }
     
-    private static List<Map<String, String>> createColumnRows(final DatabaseFixture databaseMetadata, final String objectName) {
-        List<Map<String, String>> result = new LinkedList<>();
+    private static List<Map<String, Object>> createColumnRows(final DatabaseFixture databaseMetadata, final String objectName) {
+        List<Map<String, Object>> result = new LinkedList<>();
+        String relationName = "%".equals(objectName) ? "" : unescapePattern(objectName);
         for (SchemaFixture each : databaseMetadata.schemas) {
             for (TableFixture table : each.tables) {
-                if (table.name.equals(objectName)) {
-                    for (String column : table.columns) {
-                        result.add(Map.of("COLUMN_NAME", column));
+                if (relationName.isEmpty() || table.name.equals(relationName)) {
+                    for (int i = 0; i < table.columns.size(); i++) {
+                        result.add(createColumnRow(table.name, table.columns.get(i), i + 1));
                     }
                 }
             }
             for (TableFixture view : each.views) {
-                if (view.name.equals(objectName)) {
-                    for (String column : view.columns) {
-                        result.add(Map.of("COLUMN_NAME", column));
+                if (relationName.isEmpty() || view.name.equals(relationName)) {
+                    for (int i = 0; i < view.columns.size(); i++) {
+                        result.add(createColumnRow(view.name, view.columns.get(i), i + 1));
                     }
                 }
             }
@@ -137,13 +140,35 @@ final class DatabaseTestDataFactory {
         return result;
     }
     
-    private static List<Map<String, String>> createIndexRows(final DatabaseFixture databaseMetadata, final String tableName) {
-        List<Map<String, String>> result = new LinkedList<>();
+    private static String unescapePattern(final String value) {
+        StringBuilder result = new StringBuilder(value.length());
+        boolean escaped = false;
+        for (char each : value.toCharArray()) {
+            if (escaped) {
+                result.append(each);
+                escaped = false;
+            } else if ('\\' == each) {
+                escaped = true;
+            } else {
+                result.append(each);
+            }
+        }
+        return escaped ? result.append('\\').toString() : result.toString();
+    }
+    
+    private static Map<String, Object> createColumnRow(final String relationName, final String columnName, final int ordinalPosition) {
+        return Map.of("TABLE_NAME", relationName, "COLUMN_NAME", columnName, "ORDINAL_POSITION", ordinalPosition,
+                "DATA_TYPE", Types.INTEGER, "TYPE_NAME", "INT", "NULLABLE", DatabaseMetaData.columnNullable);
+    }
+    
+    private static List<Map<String, Object>> createIndexRows(final DatabaseFixture databaseMetadata, final String tableName) {
+        List<Map<String, Object>> result = new LinkedList<>();
         for (SchemaFixture each : databaseMetadata.schemas) {
             for (TableFixture table : each.tables) {
                 if (table.name.equals(tableName)) {
                     for (String index : table.indexes) {
-                        result.add(Map.of("INDEX_NAME", index));
+                        result.add(Map.of("INDEX_NAME", index, "TYPE", DatabaseMetaData.tableIndexOther, "NON_UNIQUE", false,
+                                "ORDINAL_POSITION", 1, "COLUMN_NAME", table.columns.isEmpty() ? "" : table.columns.getFirst()));
                     }
                 }
             }
@@ -151,8 +176,8 @@ final class DatabaseTestDataFactory {
         return result;
     }
     
-    private static List<Map<String, String>> createSequenceRows(final DatabaseFixture databaseMetadata) {
-        List<Map<String, String>> result = new LinkedList<>();
+    private static List<Map<String, Object>> createSequenceRows(final DatabaseFixture databaseMetadata) {
+        List<Map<String, Object>> result = new LinkedList<>();
         for (SchemaFixture each : databaseMetadata.schemas) {
             for (String sequence : each.sequences) {
                 result.add(Map.of("SEQUENCE_SCHEMA", each.schema, "SEQUENCE_NAME", sequence));
@@ -161,12 +186,23 @@ final class DatabaseTestDataFactory {
         return result;
     }
     
-    private static ResultSet createResultSet(final List<Map<String, String>> rows) throws SQLException {
+    private static ResultSet createResultSet(final List<Map<String, Object>> rows) throws SQLException {
         ResultSet result = mock(ResultSet.class);
         AtomicInteger rowIndex = new AtomicInteger(-1);
         when(result.next()).thenAnswer(invocation -> rowIndex.incrementAndGet() < rows.size());
-        when(result.getString(anyString())).thenAnswer(invocation -> rows.get(rowIndex.get()).get(invocation.getArgument(0, String.class)));
+        when(result.getString(anyString())).thenAnswer(invocation -> {
+            Object value = rows.get(rowIndex.get()).get(invocation.getArgument(0, String.class));
+            return null == value ? null : value.toString();
+        });
+        when(result.getInt(anyString())).thenAnswer(invocation -> getNumber(rows, rowIndex.get(), invocation.getArgument(0, String.class)).intValue());
+        when(result.getShort(anyString())).thenAnswer(invocation -> getNumber(rows, rowIndex.get(), invocation.getArgument(0, String.class)).shortValue());
+        when(result.getBoolean(anyString())).thenAnswer(invocation -> Boolean.TRUE.equals(rows.get(rowIndex.get()).get(invocation.getArgument(0, String.class))));
         return result;
+    }
+    
+    private static Number getNumber(final List<Map<String, Object>> rows, final int rowIndex, final String columnLabel) {
+        Object value = rows.get(rowIndex).get(columnLabel);
+        return value instanceof Number ? (Number) value : 0;
     }
     
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/query/MetadataQueryServiceTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/query/MetadataQueryServiceTest.java
@@ -26,7 +26,6 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.syste
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSequence;
@@ -38,6 +37,7 @@ import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPMet
 import org.apache.shardingsphere.mcp.support.database.metadata.context.RequestScopedMetadataContext;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
 import org.apache.shardingsphere.mcp.support.fixture.SupportDatabaseTypeFactoryMocker;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +50,7 @@ import org.mockito.MockedStatic;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.sql.Types;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -166,7 +167,7 @@ class MetadataQueryServiceTest {
         assertThat(actual.size(), is(2));
         assertThat(actual.get(0).getName(), is("order_items"));
         assertThat(actual.get(1).getName(), is("orders"));
-        assertThat(actual.get(1).getAllColumns().size(), is(1));
+        assertTrue(actual.get(1).getAllColumns().isEmpty());
     }
     
     @Test
@@ -179,8 +180,8 @@ class MetadataQueryServiceTest {
         Optional<ShardingSphereTable> actual = metadataQueryService.queryTable("logic_db", "public", "orders");
         assertTrue(actual.isPresent());
         assertThat(actual.get().getName(), is("orders"));
-        assertThat(actual.get().getAllColumns().size(), is(1));
-        assertThat(actual.get().getAllIndexes().size(), is(1));
+        assertTrue(actual.get().getAllColumns().isEmpty());
+        assertTrue(actual.get().getAllIndexes().isEmpty());
     }
     
     @Test
@@ -190,9 +191,9 @@ class MetadataQueryServiceTest {
     
     @Test
     void assertQueryTableColumns() {
-        List<ShardingSphereColumn> actual = metadataQueryService.queryTableColumns("logic_db", "public", "orders");
-        assertThat(actual.size(), is(1));
-        assertThat(actual.get(0).getName(), is("order_id"));
+        List<MCPColumnMetadata> actual = metadataQueryService.queryTableColumns("logic_db", "public", "orders");
+        assertThat(actual.stream().map(MCPColumnMetadata::getName).toList(), is(List.of("order_id", "amount")));
+        assertThat(actual.get(0).getJdbcType(), is(Types.INTEGER));
     }
     
     @Test
@@ -201,8 +202,13 @@ class MetadataQueryServiceTest {
     }
     
     @Test
+    void assertQueryTableColumnsWithMissingTable() {
+        assertTrue(metadataQueryService.queryTableColumns("logic_db", "public", "missing_table").isEmpty());
+    }
+    
+    @Test
     void assertQueryTableColumn() {
-        Optional<ShardingSphereColumn> actual = metadataQueryService.queryTableColumn("logic_db", "public", "orders", "order_id");
+        Optional<MCPColumnMetadata> actual = metadataQueryService.queryTableColumn("logic_db", "public", "orders", "order_id");
         assertTrue(actual.isPresent());
         assertThat(actual.get().getName(), is("order_id"));
     }
@@ -217,7 +223,7 @@ class MetadataQueryServiceTest {
         List<ShardingSphereTable> actual = metadataQueryService.queryViews("logic_db", "public");
         assertThat(actual.size(), is(1));
         assertThat(actual.get(0).getName(), is("orders_view"));
-        assertThat(actual.get(0).getAllColumns().size(), is(1));
+        assertTrue(actual.get(0).getAllColumns().isEmpty());
     }
     
     @Test
@@ -230,7 +236,7 @@ class MetadataQueryServiceTest {
         Optional<ShardingSphereTable> actual = metadataQueryService.queryView("logic_db", "public", "orders_view");
         assertTrue(actual.isPresent());
         assertThat(actual.get().getName(), is("orders_view"));
-        assertThat(actual.get().getAllColumns().size(), is(1));
+        assertTrue(actual.get().getAllColumns().isEmpty());
     }
     
     @Test
@@ -240,7 +246,7 @@ class MetadataQueryServiceTest {
     
     @Test
     void assertQueryViewColumns() {
-        List<ShardingSphereColumn> actual = metadataQueryService.queryViewColumns("logic_db", "public", "orders_view");
+        List<MCPColumnMetadata> actual = metadataQueryService.queryViewColumns("logic_db", "public", "orders_view");
         assertThat(actual.size(), is(1));
         assertThat(actual.get(0).getName(), is("order_id"));
     }
@@ -251,8 +257,13 @@ class MetadataQueryServiceTest {
     }
     
     @Test
+    void assertQueryViewColumnsWithMissingView() {
+        assertTrue(metadataQueryService.queryViewColumns("logic_db", "public", "missing_view").isEmpty());
+    }
+    
+    @Test
     void assertQueryViewColumn() {
-        Optional<ShardingSphereColumn> actual = metadataQueryService.queryViewColumn("logic_db", "public", "orders_view", "order_id");
+        Optional<MCPColumnMetadata> actual = metadataQueryService.queryViewColumn("logic_db", "public", "orders_view", "order_id");
         assertTrue(actual.isPresent());
         assertThat(actual.get().getName(), is("order_id"));
     }
@@ -260,6 +271,23 @@ class MetadataQueryServiceTest {
     @Test
     void assertQueryViewColumnWithUnsupportedDatabase() {
         assertFalse(metadataQueryService.queryViewColumn("unknown_db", "public", "orders_view", "order_id").isPresent());
+    }
+    
+    @Test
+    void assertQuerySchemaColumns() {
+        List<MCPColumnMetadata> actual = metadataQueryService.querySchemaColumns("logic_db", "public");
+        assertThat(actual.stream().map(each -> each.getRelationName() + "." + each.getName()).toList(),
+                is(List.of("order_items.item_id", "orders.order_id", "orders.amount", "orders_view.order_id")));
+    }
+    
+    @Test
+    void assertQuerySchemaColumnsWithMissingSchema() {
+        assertTrue(metadataQueryService.querySchemaColumns("logic_db", "missing_schema").isEmpty());
+    }
+    
+    @Test
+    void assertQuerySchemaColumnsWithUnsupportedDatabase() {
+        assertTrue(metadataQueryService.querySchemaColumns("unknown_db", "public").isEmpty());
     }
     
     @Test
@@ -272,6 +300,11 @@ class MetadataQueryServiceTest {
     @Test
     void assertQueryIndexesWithoutIndexMetadata() {
         assertTrue(metadataQueryService.queryIndexes("warehouse", "warehouse", "facts").isEmpty());
+    }
+    
+    @Test
+    void assertQueryIndexesWithMissingTable() {
+        assertTrue(metadataQueryService.queryIndexes("logic_db", "public", "missing_table").isEmpty());
     }
     
     @Test

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/query/MetadataQueryServiceTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/query/MetadataQueryServiceTest.java
@@ -192,8 +192,8 @@ class MetadataQueryServiceTest {
     @Test
     void assertQueryTableColumns() {
         List<MCPColumnMetadata> actual = metadataQueryService.queryTableColumns("logic_db", "public", "orders");
-        assertThat(actual.stream().map(MCPColumnMetadata::getName).toList(), is(List.of("order_id", "amount")));
-        assertThat(actual.get(0).getJdbcType(), is(Types.INTEGER));
+        assertThat(actual.stream().map(MCPColumnMetadata::getName).toList(), is(List.of("amount", "order_id")));
+        assertThat(actual.get(1).getJdbcType(), is(Types.INTEGER));
     }
     
     @Test
@@ -277,7 +277,7 @@ class MetadataQueryServiceTest {
     void assertQuerySchemaColumns() {
         List<MCPColumnMetadata> actual = metadataQueryService.querySchemaColumns("logic_db", "public");
         assertThat(actual.stream().map(each -> each.getRelationName() + "." + each.getName()).toList(),
-                is(List.of("order_items.item_id", "orders.order_id", "orders.amount", "orders_view.order_id")));
+                is(List.of("order_items.item_id", "orders.amount", "orders.order_id", "orders_view.order_id")));
     }
     
     @Test

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
@@ -385,7 +385,11 @@ class MCPDescriptorCatalogValidatorTest {
             properties.put(each, Map.of("type", "object", "description", "Workflow plan field."));
         }
         properties.put(MCPPayloadFieldNames.NEXT_ACTIONS, createNextActionsSchema());
-        return createOutputSchema(properties, List.of(Map.of("response_mode", "planning")));
+        Map<String, Object> result = new LinkedHashMap<>(createOutputSchema(properties, List.of(Map.of("response_mode", "planning"))));
+        result.put("required", List.of(
+                "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs",
+                MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS));
+        return result;
     }
     
     private Map<String, Object> createPlanningToolMeta(final String workflowKind) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtilsTest.java
@@ -43,6 +43,10 @@ class MCPToolDescriptorValidationUtilsTest {
             "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
             "distsql_artifacts", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
     
+    private static final Collection<String> REQUIRED_WORKFLOW_PLAN_SCHEMA_FIELDS = List.of(
+            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs",
+            MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
+    
     private static final Collection<String> WORKFLOW_PLAN_META_FIELDS = List.of(
             "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/artifact-categories", "org.apache.shardingsphere/side-effect-scope",
             "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
@@ -59,6 +63,15 @@ class MCPToolDescriptorValidationUtilsTest {
         IllegalStateException actual = assertThrows(IllegalStateException.class,
                 () -> MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(descriptor, List.of("secret_reference_summary")));
         assertThat(actual.getMessage(), is("Tool `fixture_tool` outputSchema must declare `secret_reference_summary`."));
+    }
+    
+    @Test
+    void assertValidateRequiredWorkflowPlanOutputFieldsRejectsOptionalContractField() {
+        MCPToolDescriptor descriptor = createDescriptor(WORKFLOW_PLAN_OUTPUT_FIELDS, REQUIRED_WORKFLOW_PLAN_SCHEMA_FIELDS.stream()
+                .filter(each -> !MCPPayloadFieldNames.NEXT_ACTIONS.equals(each)).toList(), createWorkflowPlanMeta());
+        IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(descriptor));
+        assertThat(actual.getMessage(), is("Tool `fixture_tool` outputSchema must require `next_actions`."));
     }
     
     @Test
@@ -117,8 +130,12 @@ class MCPToolDescriptorValidationUtilsTest {
     }
     
     private MCPToolDescriptor createDescriptor(final Collection<String> outputFields, final Map<String, Object> meta) {
+        return createDescriptor(outputFields, REQUIRED_WORKFLOW_PLAN_SCHEMA_FIELDS, meta);
+    }
+    
+    private MCPToolDescriptor createDescriptor(final Collection<String> outputFields, final Collection<String> requiredFields, final Map<String, Object> meta) {
         return new MCPToolDescriptor("fixture_tool", "Fixture Tool", "Fixture tool.", Map.of(),
-                Map.of("type", "object", "properties", createOutputProperties(outputFields)), createAnnotations(), meta);
+                Map.of("type", "object", "properties", createOutputProperties(outputFields), "required", requiredFields), createAnnotations(), meta);
     }
     
     private MCPToolDescriptor createDescriptor(final Map<String, Object> inputSchema, final Map<String, Object> outputSchema) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningContextValidatorTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningContextValidatorTest.java
@@ -23,11 +23,12 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.mcp.support.database.exception.DatabaseCapabilityNotFoundException;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.model.ClarifiedIntent;
@@ -121,6 +122,7 @@ class WorkflowPlanningContextValidatorTest {
         MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
         when(metadataQueryFacade.queryDatabase("logic_db")).thenReturn(Optional.of(createDatabaseMetadata()));
         when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata()));
+        when(metadataQueryFacade.queryTableColumns("logic_db", "public", "orders")).thenReturn(List.of(createColumnMetadata()));
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         mockIdentifierComparison(queryFacade);
         ClarifiedIntent clarifiedIntent = new ClarifiedIntent();
@@ -197,10 +199,10 @@ class WorkflowPlanningContextValidatorTest {
     }
     
     private ShardingSphereTable createTableMetadata() {
-        return new ShardingSphereTable("orders", List.of(createColumnMetadata()), List.of(), List.of(), TableType.TABLE);
+        return new ShardingSphereTable("orders", List.of(), List.of(), List.of(), TableType.TABLE);
     }
     
-    private ShardingSphereColumn createColumnMetadata() {
-        return new ShardingSphereColumn("phone", java.sql.Types.OTHER, false, false, false, true, false, true);
+    private MCPColumnMetadata createColumnMetadata() {
+        return new MCPColumnMetadata("orders", "phone", 1, java.sql.Types.VARCHAR, "VARCHAR", Nullability.NULLABLE);
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningSupportTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningSupportTest.java
@@ -23,10 +23,11 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata;
+import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPColumnMetadata.Nullability;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyRequirement;
@@ -109,7 +110,8 @@ class WorkflowPlanningSupportTest {
         WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
         MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
         when(metadataQueryFacade.queryDatabase("logic_db")).thenReturn(Optional.of(createDatabaseMetadata()));
-        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders-detail", "Phone Number")));
+        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders-detail")));
+        when(metadataQueryFacade.queryTableColumns("logic_db", "public", "orders-detail")).thenReturn(List.of(createColumnMetadata("orders-detail", "Phone Number")));
         boolean actual = planningSupport.ensurePlanningContext(metadataQueryFacade, mock(MCPFeatureQueryFacade.class), request, clarifiedIntent, snapshot);
         assertTrue(actual);
         assertThat(request.getDatabase(), is("`logic_db`"));
@@ -128,7 +130,8 @@ class WorkflowPlanningSupportTest {
         WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
         MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
         when(metadataQueryFacade.queryDatabase("logic_db")).thenReturn(Optional.of(createDatabaseMetadata()));
-        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders", "phone")));
+        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders")));
+        when(metadataQueryFacade.queryTableColumns("logic_db", "public", "orders")).thenReturn(List.of(createColumnMetadata("orders", "phone")));
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "orders", "orders")).thenReturn(true);
         when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.SCHEMA, "public", "public")).thenReturn(true);
@@ -152,7 +155,8 @@ class WorkflowPlanningSupportTest {
         WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
         MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
         when(metadataQueryFacade.queryDatabase("logic_db")).thenReturn(Optional.of(createDatabaseMetadata()));
-        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders", "phone")));
+        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders")));
+        when(metadataQueryFacade.queryTableColumns("logic_db", "public", "orders")).thenReturn(List.of(createColumnMetadata("orders", "phone")));
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.SCHEMA, "Public", "public")).thenReturn(true);
         when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "Orders", "orders")).thenReturn(true);
@@ -173,7 +177,7 @@ class WorkflowPlanningSupportTest {
         WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
         MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
         when(metadataQueryFacade.queryDatabase("logic_db")).thenReturn(Optional.of(createDatabaseMetadata()));
-        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders", "phone")));
+        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders")));
         boolean actual = planningSupport.ensurePlanningContext(metadataQueryFacade, mock(MCPFeatureQueryFacade.class), request, clarifiedIntent, snapshot);
         assertFalse(actual);
         assertThat(snapshot.getIssues().getFirst().getCode(), is(WorkflowIssueCode.TABLE_NOT_FOUND));
@@ -189,7 +193,7 @@ class WorkflowPlanningSupportTest {
         WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
         MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
         when(metadataQueryFacade.queryDatabase("logic_db")).thenReturn(Optional.of(createDatabaseMetadata()));
-        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders-detail", "phone")));
+        when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(createSchemaMetadata("public", "orders-detail")));
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.SCHEMA, "public", "public")).thenReturn(true);
         boolean actual = planningSupport.ensurePlanningContext(metadataQueryFacade, queryFacade, request, new ClarifiedIntent(), snapshot);
@@ -208,8 +212,8 @@ class WorkflowPlanningSupportTest {
         MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
         when(metadataQueryFacade.queryDatabase("logic_db")).thenReturn(Optional.of(createDatabaseMetadata()));
         when(metadataQueryFacade.querySchemas("logic_db")).thenReturn(List.of(
-                createSchemaMetadata("quoted_schema", "Orders", "Phone"),
-                createSchemaMetadata("other_schema", "customers", "id")));
+                createSchemaMetadata("quoted_schema", "Orders"),
+                createSchemaMetadata("other_schema", "customers")));
         boolean actual = planningSupport.ensurePlanningContext(metadataQueryFacade, mock(MCPFeatureQueryFacade.class), request, clarifiedIntent, snapshot);
         assertFalse(actual);
         assertThat(snapshot.getStatus(), is("clarifying"));
@@ -360,15 +364,15 @@ class WorkflowPlanningSupportTest {
         return new RuntimeDatabaseProfile("logic_db", "FixtureDB", "1.0", TransactionCapability.LOCAL_WITH_SAVEPOINT, IdentifierCasePolicyFactory.newInsensitivePolicySet());
     }
     
-    private ShardingSphereSchema createSchemaMetadata(final String schemaName, final String tableName, final String columnName) {
-        return new ShardingSphereSchema(schemaName, mock(DatabaseType.class), List.of(createTableMetadata(tableName, columnName)), List.of());
+    private ShardingSphereSchema createSchemaMetadata(final String schemaName, final String tableName) {
+        return new ShardingSphereSchema(schemaName, mock(DatabaseType.class), List.of(createTableMetadata(tableName)), List.of());
     }
     
-    private ShardingSphereTable createTableMetadata(final String tableName, final String columnName) {
-        return new ShardingSphereTable(tableName, List.of(createColumnMetadata(columnName)), List.of(), List.of(), TableType.TABLE);
+    private ShardingSphereTable createTableMetadata(final String tableName) {
+        return new ShardingSphereTable(tableName, List.of(), List.of(), List.of(), TableType.TABLE);
     }
     
-    private ShardingSphereColumn createColumnMetadata(final String columnName) {
-        return new ShardingSphereColumn(columnName, java.sql.Types.OTHER, false, false, false, true, false, true);
+    private MCPColumnMetadata createColumnMetadata(final String tableName, final String columnName) {
+        return new MCPColumnMetadata(tableName, columnName, 1, java.sql.Types.VARCHAR, "VARCHAR", Nullability.NULLABLE);
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtilsTest.java
@@ -261,6 +261,12 @@ class WorkflowSQLUtilsTest {
         assertThat(actualFragment, is(""));
     }
     
+    @Test
+    void assertCreateAlgorithmFragmentWithExactTypePreservesCase() {
+        String actualFragment = WorkflowSQLUtils.createAlgorithmFragmentWithExactType(" SQL_HINT ", Map.of());
+        assertThat(actualFragment, is("TYPE(NAME='SQL_HINT')"));
+    }
+    
     private static Stream<Arguments> getDistSQLKeywordCases() {
         return Stream.of(
                 Arguments.of("quote if keyword", "if", "`if`"),

--- a/mcp/support/src/test/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-test-planning.yaml
+++ b/mcp/support/src/test/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-test-planning.yaml
@@ -171,6 +171,14 @@ tools:
               reason:
                 type: string
                 description: "Why the model should take this action."
+      required:
+        - response_mode
+        - plan_id
+        - workflow_kind
+        - status
+        - missing_required_inputs
+        - resources_to_read
+        - next_actions
       examples:
         - response_mode: planning
           summary: Workflow plan `encrypt-rule-20260505-001` for encrypt.rule is ready for preview.

--- a/test/e2e/mcp/pom.xml
+++ b/test/e2e/mcp/pom.xml
@@ -96,6 +96,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
             <scope>test</scope>

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPActionExecutorTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPActionExecutorTest.java
@@ -243,6 +243,11 @@ class LLMMCPActionExecutorTest {
         }
         
         @Override
+        public void sendRawNotification(final String method, final Map<String, Object> params) {
+            throw new UnsupportedOperationException("Raw JSON-RPC notification is not supported.");
+        }
+        
+        @Override
         public void close() {
         }
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -292,7 +293,12 @@ abstract class AbstractProductionMySQLRuntimeE2ETest extends AbstractTransportPa
     }
     
     protected McpSyncClient createElicitationClient(final RuntimeTransport transport, final List<McpSchema.ElicitRequest> elicitationRequests) throws IOException {
-        return ProductionMCPClientTransportFactory.createElicitationClient(createClientTransport(transport), elicitationRequests, this::createElicitationResult);
+        return createElicitationClient(transport, elicitationRequests, this::createElicitationResult);
+    }
+    
+    protected McpSyncClient createElicitationClient(final RuntimeTransport transport, final List<McpSchema.ElicitRequest> elicitationRequests,
+                                                    final BiFunction<List<McpSchema.ElicitRequest>, McpSchema.ElicitRequest, McpSchema.ElicitResult> handler) throws IOException {
+        return ProductionMCPClientTransportFactory.createElicitationClient(createClientTransport(transport), elicitationRequests, handler);
     }
     
     private McpClientTransport createClientTransport(final RuntimeTransport transport) throws IOException {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionPostgreSQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionPostgreSQLRuntimeE2ETest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
+
+import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
+import org.apache.shardingsphere.test.e2e.mcp.env.MCPE2ECondition;
+import org.apache.shardingsphere.test.e2e.mcp.support.runtime.PostgreSQLRuntimeTestSupport;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.provider.Arguments;
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractProductionPostgreSQLRuntimeE2ETest extends AbstractTransportParameterizedProductionRuntimeE2ETest {
+    
+    protected static final String LOGICAL_DATABASE_NAME = "postgres_db";
+    
+    private GenericContainer<?> container;
+    
+    @AfterAll
+    void tearDownContainer() {
+        if (null != container) {
+            container.stop();
+            container = null;
+        }
+    }
+    
+    @Override
+    protected void prepareRuntimeFixture() throws IOException {
+        Assumptions.assumeTrue(PostgreSQLRuntimeTestSupport.isDockerAvailable(), "Docker is required for the PostgreSQL-backed production runtime E2E test.");
+        if (null != container) {
+            return;
+        }
+        GenericContainer<?> result = PostgreSQLRuntimeTestSupport.createContainer();
+        boolean success = false;
+        try {
+            result.start();
+            PostgreSQLRuntimeTestSupport.initializeDatabase(result);
+            container = result;
+            success = true;
+        } catch (final SQLException ex) {
+            throw new IOException("Failed to initialize PostgreSQL runtime fixture.", ex);
+        } finally {
+            if (!success) {
+                result.stop();
+            }
+        }
+    }
+    
+    @Override
+    protected Map<String, RuntimeDatabaseConfiguration> getRuntimeDatabases() {
+        return PostgreSQLRuntimeTestSupport.createRuntimeDatabases(container, LOGICAL_DATABASE_NAME);
+    }
+    
+    protected static Map<String, Object> createExecuteUpdateArguments(final String schema, final String sql) {
+        return Map.of("database", LOGICAL_DATABASE_NAME, "schema", schema, "sql", sql, "execution_mode", "execute");
+    }
+    
+    protected static boolean isEnabled() {
+        return MCPE2ECondition.isDockerEnabled();
+    }
+    
+    protected static Stream<Arguments> dualTransports() {
+        return ProductionRuntimeTransportCases.transports();
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
@@ -51,9 +51,25 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
     
     private static final String READWRITE_SPLITTING_PLAN_TOOL_NAME = "database_gateway_plan_readwrite_splitting_rule";
     
+    private static final String READWRITE_SPLITTING_STATUS_PLAN_TOOL_NAME = "database_gateway_plan_readwrite_splitting_status";
+    
     private static final String SHADOW_PLAN_TOOL_NAME = "database_gateway_plan_shadow_rule";
     
+    private static final String DEFAULT_SHADOW_ALGORITHM_PLAN_TOOL_NAME = "database_gateway_plan_default_shadow_algorithm";
+    
+    private static final String SHADOW_ALGORITHM_CLEANUP_PLAN_TOOL_NAME = "database_gateway_plan_shadow_algorithm_cleanup";
+    
     private static final String SHARDING_PLAN_TOOL_NAME = "database_gateway_plan_sharding_table_rule";
+    
+    private static final String SHARDING_TABLE_REFERENCE_PLAN_TOOL_NAME = "database_gateway_plan_sharding_table_reference_rule";
+    
+    private static final String SHARDING_DEFAULT_STRATEGY_PLAN_TOOL_NAME = "database_gateway_plan_sharding_default_strategy";
+    
+    private static final String SHARDING_KEY_GENERATOR_PLAN_TOOL_NAME = "database_gateway_plan_sharding_key_generator";
+    
+    private static final String SHARDING_KEY_GENERATE_STRATEGY_PLAN_TOOL_NAME = "database_gateway_plan_sharding_key_generate_strategy";
+    
+    private static final String SHARDING_COMPONENT_CLEANUP_PLAN_TOOL_NAME = "database_gateway_plan_sharding_rule_component_cleanup";
     
     private static final String BROADCAST_RULES_RESOURCE_URI = "shardingsphere://features/broadcast/databases/%s/rules";
     
@@ -76,12 +92,9 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
     void assertPlanManualApplyAndValidateFeatureWorkflowThroughProxy(final String scenarioName, final FeatureWorkflowScenario scenario) throws IOException, InterruptedException {
         try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
             assertThat(interactionClient.listTools().stream().map(each -> String.valueOf(each.get("name"))).toList(), hasItem(scenario.toolName()));
-            Map<String, Object> actualPlanResponse = interactionClient.call(scenario.toolName(), createPlanArguments(scenario));
-            assertThat(String.valueOf(actualPlanResponse.get("status")), is("planned"));
+            Map<String, Object> actualPlanResponse = planWorkflow(interactionClient, scenario.toolName(), createPlanArguments(scenario));
             assertThat(String.valueOf(actualPlanResponse.get("current_step")), is("review"));
             assertTrue(String.valueOf(getObjectListOrEmpty(actualPlanResponse.get("distsql_artifacts"))).contains(scenario.expectedDistSQLToken()));
-            assertNoForbiddenArtifacts(actualPlanResponse);
-            assertModelFacingPayloadContract(actualPlanResponse);
             String planId = String.valueOf(actualPlanResponse.get("plan_id"));
             Map<String, Object> actualManualApplyResponse = interactionClient.call(APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "manual-only"));
             assertThat(String.valueOf(actualManualApplyResponse.get("status")), is("awaiting-manual-execution"));
@@ -127,12 +140,31 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
             assertThat(String.valueOf(actualRule.get("write_storage_unit_name")), is("ds_0"));
             assertTrue(String.valueOf(actualRule.get("read_storage_unit_names")).contains("ds_1"));
             assertThat(String.valueOf(actualRule.get("transactional_read_query_strategy")).toUpperCase(Locale.ENGLISH), is("DYNAMIC"));
+            Map<String, Object> actualStatusPlan = planWorkflow(interactionClient, READWRITE_SPLITTING_STATUS_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "rule", "readwrite_ds", "storage_unit", "ds_1", "target_status", "disable"));
+            assertTrue(String.valueOf(getObjectListOrEmpty(actualStatusPlan.get("distsql_artifacts"))).contains("DISABLE"));
+            Map<String, Object> actualManualApply = interactionClient.call(APPLY_TOOL_NAME,
+                    Map.of("plan_id", String.valueOf(actualStatusPlan.get("plan_id")), "execution_mode", "manual-only"));
+            assertManualApply(actualManualApply);
+            Map<String, Object> actualStatus = findItemByField(getPayloadItems(interactionClient.readResource(
+                    String.format("shardingsphere://features/readwrite-splitting/databases/%s/rules/readwrite_ds/status", getLogicalDatabaseName()))),
+                    "storage_unit", "ds_1");
+            assertThat(String.valueOf(actualStatus.get("status")).toUpperCase(Locale.ENGLISH), is("ENABLED"));
         }
     }
     
     @Test
     void assertShadowWorkflowCanBeAppliedAndValidatedThroughProxy() throws IOException, InterruptedException {
         try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            applyAndValidateWorkflow(interactionClient, DEFAULT_SHADOW_ALGORITHM_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "algorithm_type", "SQL_HINT"));
+            assertFalse(getPayloadItems(interactionClient.readResource(
+                    String.format("shardingsphere://features/shadow/databases/%s/default-algorithm", getLogicalDatabaseName()))).isEmpty());
+            applyAndValidateWorkflow(interactionClient, SHADOW_ALGORITHM_CLEANUP_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "algorithm_name", "fixture_unused_algorithm"));
+            assertFalse(getPayloadItems(interactionClient.readResource(
+                    String.format("shardingsphere://features/shadow/databases/%s/algorithms", getLogicalDatabaseName())))
+                    .stream().anyMatch(each -> "fixture_unused_algorithm".equalsIgnoreCase(String.valueOf(each.get("shadow_algorithm_name")))));
             planApplyAndValidateWorkflow(interactionClient, SHADOW_PLAN_TOOL_NAME,
                     Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "rule", "shadow_rule", "source_storage_unit", "ds_0",
                             "shadow_storage_unit", "ds_shadow", "table", "orders", "algorithm_type", "VALUE_MATCH",
@@ -143,6 +175,11 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
             assertThat(String.valueOf(actualRule.get("shadow_name")), is("ds_shadow"));
             assertThat(String.valueOf(actualRule.get("shadow_table")), is("orders"));
             assertThat(String.valueOf(actualRule.get("algorithm_type")).toUpperCase(Locale.ENGLISH), is("VALUE_MATCH"));
+            Map<String, Object> actualDropPlan = planWorkflow(interactionClient, SHADOW_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "drop", "rule", "shadow_rule"));
+            assertTrue(String.valueOf(getObjectListOrEmpty(actualDropPlan.get("distsql_artifacts"))).contains("DROP SHADOW RULE"));
+            assertManualApply(interactionClient.call(APPLY_TOOL_NAME,
+                    Map.of("plan_id", String.valueOf(actualDropPlan.get("plan_id")), "execution_mode", "manual-only")));
         }
     }
     
@@ -150,13 +187,56 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
     void assertShardingWorkflowCanBeAppliedAndValidatedThroughProxy() throws IOException, InterruptedException {
         try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
             planApplyAndValidateWorkflow(interactionClient, SHARDING_PLAN_TOOL_NAME,
-                    Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "table", "orders", "column", "order_id",
-                            "data_nodes", "ds_0.orders", "strategy_type", "standard", "algorithm_type", "INLINE",
-                            "algorithm_properties", Map.of("algorithm-expression", "orders")));
+                    createShardingTableRuleArguments("orders"));
+            applyAndValidateWorkflow(interactionClient, SHARDING_PLAN_TOOL_NAME, createShardingTableRuleArguments("order_items"));
+            applyAndValidateWorkflow(interactionClient, SHARDING_TABLE_REFERENCE_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "rule", "order_reference",
+                            "reference_tables", "orders,order_items"));
+            applyAndValidateWorkflow(interactionClient, SHARDING_DEFAULT_STRATEGY_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "default_strategy_type", "DATABASE", "strategy_type", "none"));
+            applyAndValidateWorkflow(interactionClient, SHARDING_KEY_GENERATOR_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "key_generator", "snowflake_generator",
+                            "key_generator_type", "SNOWFLAKE", "key_generator_properties", Map.of("worker-id", "1")));
+            applyAndValidateWorkflow(interactionClient, SHARDING_KEY_GENERATE_STRATEGY_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "key_generate_strategy", "order_key_strategy",
+                            "table", "orders", "column", "order_id", "key_generator", "snowflake_generator"));
+            applyAndValidateWorkflow(interactionClient, SHARDING_KEY_GENERATOR_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "key_generator", "unused_generator",
+                            "key_generator_type", "SNOWFLAKE", "key_generator_properties", Map.of("worker-id", "2")));
             List<Map<String, Object>> actualRules = getPayloadItems(interactionClient.readResource(
                     String.format(SHARDING_TABLE_RULES_RESOURCE_URI, getLogicalDatabaseName())));
             assertThat(actualRules.stream().map(each -> String.valueOf(each.get("table"))).toList(), hasItem("orders"));
+            assertFalse(getPayloadItems(interactionClient.readResource(String.format(
+                    "shardingsphere://features/sharding/databases/%s/table-reference-rules", getLogicalDatabaseName()))).isEmpty());
+            assertFalse(getPayloadItems(interactionClient.readResource(String.format(
+                    "shardingsphere://features/sharding/databases/%s/default-strategy", getLogicalDatabaseName()))).isEmpty());
+            assertFalse(getPayloadItems(interactionClient.readResource(String.format(
+                    "shardingsphere://features/sharding/databases/%s/key-generators", getLogicalDatabaseName()))).isEmpty());
+            assertFalse(getPayloadItems(interactionClient.readResource(String.format(
+                    "shardingsphere://features/sharding/databases/%s/key-generate-strategies", getLogicalDatabaseName()))).isEmpty());
+            List<Map<String, Object>> unusedKeyGenerators = getPayloadItems(interactionClient.readResource(String.format(
+                    "shardingsphere://features/sharding/databases/%s/unused-key-generators", getLogicalDatabaseName())));
+            assertThat(findItemByField(unusedKeyGenerators, "name", "unused_generator").get("name"), is("unused_generator"));
+            applyAndValidateWorkflow(interactionClient, SHARDING_COMPONENT_CLEANUP_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "component_type", "key-generator", "component_name", "unused_generator"));
+            assertFalse(getPayloadItems(interactionClient.readResource(String.format(
+                    "shardingsphere://features/sharding/databases/%s/unused-key-generators", getLogicalDatabaseName())))
+                    .stream().anyMatch(each -> "unused_generator".equalsIgnoreCase(String.valueOf(each.get("name")))));
+            applyAndValidateWorkflow(interactionClient, SHARDING_KEY_GENERATE_STRATEGY_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "drop", "key_generate_strategy", "order_key_strategy"));
+            applyAndValidateWorkflow(interactionClient, SHARDING_TABLE_REFERENCE_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "drop", "rule", "order_reference"));
+            applyAndValidateWorkflow(interactionClient, SHARDING_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "drop", "table", "order_items"));
+            applyAndValidateWorkflow(interactionClient, SHARDING_PLAN_TOOL_NAME,
+                    Map.of("database", getLogicalDatabaseName(), "operation_type", "drop", "table", "orders"));
         }
+    }
+    
+    private Map<String, Object> createShardingTableRuleArguments(final String tableName) {
+        return Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "table", tableName, "column", "order_id",
+                "data_nodes", "ds_0." + tableName, "strategy_type", "standard", "algorithm_type", "INLINE",
+                "algorithm_properties", Map.of("algorithm-expression", tableName));
     }
     
     private static Stream<Arguments> featureWorkflowScenarios() {
@@ -202,16 +282,33 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
     
     private void planApplyAndValidateWorkflow(final MCPInteractionClient interactionClient, final String toolName,
                                               final Map<String, Object> arguments) throws IOException, InterruptedException {
-        Map<String, Object> actualPlanResponse = interactionClient.call(toolName, arguments);
-        assertThat(String.valueOf(actualPlanResponse.get("status")), is("planned"));
-        assertNoForbiddenArtifacts(actualPlanResponse);
-        assertModelFacingPayloadContract(actualPlanResponse);
+        applyAndValidateWorkflow(interactionClient, toolName, arguments);
+        assertDuplicateCreateFails(interactionClient, toolName, arguments);
+    }
+    
+    private void applyAndValidateWorkflow(final MCPInteractionClient interactionClient, final String toolName,
+                                          final Map<String, Object> arguments) throws IOException, InterruptedException {
+        Map<String, Object> actualPlanResponse = planWorkflow(interactionClient, toolName, arguments);
         String planId = String.valueOf(actualPlanResponse.get("plan_id"));
         Map<String, Object> actualApplyResponse = applyReviewedWorkflow(interactionClient, planId);
         assertApplyCompleted(actualApplyResponse);
         assertThat(getStringListOrEmpty(actualApplyResponse.get("executed_distsql")).size(), is(1));
         assertValidationPassed(interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId)));
-        assertDuplicateCreateFails(interactionClient, toolName, arguments);
+    }
+    
+    private Map<String, Object> planWorkflow(final MCPInteractionClient interactionClient, final String toolName,
+                                             final Map<String, Object> arguments) throws IOException, InterruptedException {
+        Map<String, Object> result = interactionClient.call(toolName, arguments);
+        assertThat(String.valueOf(result.get("status")), is("planned"));
+        assertNoForbiddenArtifacts(result);
+        assertModelFacingPayloadContract(result);
+        return result;
+    }
+    
+    private void assertManualApply(final Map<String, Object> actual) {
+        assertThat(String.valueOf(actual.get("status")), is("awaiting-manual-execution"));
+        assertTrue(getStringListOrEmpty(actual.get("executed_distsql")).isEmpty());
+        assertModelFacingPayloadContract(actual);
     }
     
     private void assertDuplicateCreateFails(final MCPInteractionClient interactionClient, final String toolName,

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLReadOnlySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLReadOnlySQLRuntimeE2ETest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionPa
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPPayloadAssertions;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPInteractionClient;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -39,6 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIf("isEnabled")
 class ProductionMySQLReadOnlySQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2ETest {
+    
+    private static final long SLOW_ELICITATION_MILLIS = 11_000L;
     
     @Override
     protected boolean useSharedRuntimeFixture() {
@@ -166,6 +169,32 @@ class ProductionMySQLReadOnlySQLRuntimeE2ETest extends AbstractProductionMySQLRu
             Map<String, Object> primaryProperties = MCPInteractionPayloads.getRequiredObject(maskedPropertyPreview, "primary");
             assertThat(String.valueOf(primaryProperties.get("from-x")), is("1"));
             assertThat(String.valueOf(primaryProperties.get("to-y")), is("3"));
+            assertElicitationRequest(actualElicitationRequests);
+        }
+    }
+    
+    @Test
+    void assertElicitationCanExceedSdkDefaultRequestTimeout() throws IOException {
+        useTransport(RuntimeTransport.STDIO);
+        List<McpSchema.ElicitRequest> actualElicitationRequests = new CopyOnWriteArrayList<>();
+        try (McpSyncClient client = createElicitationClient(RuntimeTransport.STDIO, actualElicitationRequests, (requests, request) -> {
+            try {
+                Thread.sleep(SLOW_ELICITATION_MILLIS);
+            } catch (final InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(ex);
+            }
+            return createElicitationResult(requests, request);
+        })) {
+            client.initialize();
+            McpSchema.CallToolResult actual = client.callTool(new McpSchema.CallToolRequest(MASK_PLAN_TOOL_NAME, Map.of(
+                    "database", LOGICAL_DATABASE_NAME,
+                    "schema", LOGICAL_DATABASE_NAME,
+                    "table", "orders",
+                    "column", "status",
+                    "operation_type", "create",
+                    "algorithm_type", "MASK_FROM_X_TO_Y")));
+            assertThat(String.valueOf(MCPInteractionPayloads.getRequiredObjectValue(actual.structuredContent(), "structuredContent").get("status")), is("planned"));
             assertElicitationRequest(actualElicitationRequests);
         }
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionPostgreSQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionPostgreSQLRuntimeE2ETest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
+
+import org.apache.shardingsphere.test.e2e.mcp.support.runtime.RuntimeTransport;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionPayloads;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPPayloadAssertions;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPInteractionClient;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.sql.Types;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIf("isEnabled")
+class ProductionPostgreSQLRuntimeE2ETest extends AbstractProductionPostgreSQLRuntimeE2ETest {
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("dualTransports")
+    void assertPostgreSQLRuntimeContract(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            assertMetadata(interactionClient);
+            assertQueries(interactionClient);
+            assertTransactionRollback(interactionClient);
+        }
+    }
+    
+    private void assertMetadata(final MCPInteractionClient interactionClient) throws IOException, InterruptedException {
+        Map<String, Object> capabilities = interactionClient.readResource("shardingsphere://databases/postgres_db/capabilities");
+        assertThat(String.valueOf(capabilities.get("databaseType")), is("PostgreSQL"));
+        MCPPayloadAssertions.assertItemValues(interactionClient.readResource("shardingsphere://databases/postgres_db/schemas"), "schema", List.of("public", "tenant"));
+        MCPPayloadAssertions.assertSingleItemValue(interactionClient.readResource(
+                "shardingsphere://databases/postgres_db/schemas/public/tables"), "table", "orders");
+        MCPPayloadAssertions.assertSingleItemValue(interactionClient.readResource(
+                "shardingsphere://databases/postgres_db/schemas/tenant/tables"), "table", "orders");
+        MCPPayloadAssertions.assertSingleItemValue(interactionClient.readResource(
+                "shardingsphere://databases/postgres_db/schemas/public/views"), "view", "active_orders");
+        Map<String, Object> publicOrders = getPayloadItems(interactionClient.readResource(
+                "shardingsphere://databases/postgres_db/schemas/public/tables/orders")).getFirst();
+        assertThat(getNestedNames(publicOrders, "columns", "column"), is(List.of("order_id", "status", "tenant_code")));
+        Map<String, Object> statusColumn = findNested(publicOrders, "columns", "column", "status");
+        assertThat(statusColumn.get("ordinalPosition"), is(2));
+        assertThat(statusColumn.get("jdbcType"), is(Types.VARCHAR));
+        assertThat(statusColumn.get("nativeTypeName"), is("varchar"));
+        assertThat(statusColumn.get("nullability"), is("nullable"));
+        Map<String, Object> tenantColumn = findNested(publicOrders, "columns", "column", "tenant_code");
+        assertThat(tenantColumn.get("nullability"), is("not_nullable"));
+        Map<String, Object> compositeIndex = findNested(publicOrders, "indexes", "index", "idx_orders_tenant_order");
+        assertThat(compositeIndex.get("columns"), is(List.of("tenant_code", "order_id")));
+        assertTrue((Boolean) compositeIndex.get("unique"));
+        assertThat(getNestedNames(getPayloadItems(interactionClient.readResource(
+                "shardingsphere://databases/postgres_db/schemas/tenant/tables/orders")).getFirst(), "columns", "column"),
+                is(List.of("order_id", "tenant_note")));
+        assertThat(getNestedNames(getPayloadItems(interactionClient.readResource(
+                "shardingsphere://databases/postgres_db/schemas/public/views/active_orders")).getFirst(), "columns", "column"),
+                is(List.of("order_id", "status")));
+    }
+    
+    private void assertQueries(final MCPInteractionClient interactionClient) throws IOException, InterruptedException {
+        Map<String, Object> query = interactionClient.call("database_gateway_execute_query",
+                Map.of("database", LOGICAL_DATABASE_NAME, "schema", "public", "sql", "SELECT status FROM public.orders WHERE order_id = 1", "max_rows", 1));
+        assertThat(String.valueOf(query.get("result_kind")), is("result_set"));
+        assertTrue(String.valueOf(query.get("row_objects")).contains("NEW"));
+        Map<String, Object> tenantQuery = interactionClient.call("database_gateway_execute_query",
+                Map.of("database", LOGICAL_DATABASE_NAME, "schema", "tenant", "sql", "SELECT tenant_note FROM tenant.orders WHERE order_id = 1", "max_rows", 1));
+        assertTrue(String.valueOf(tenantQuery.get("row_objects")).contains("tenant-schema"));
+        Map<String, Object> explain = interactionClient.call("database_gateway_execute_explain_query",
+                Map.of("database", LOGICAL_DATABASE_NAME, "schema", "public", "sql", "SELECT * FROM public.orders WHERE order_id = 1",
+                        "explain_sql", "EXPLAIN SELECT * FROM public.orders WHERE order_id = 1", "max_rows", 10));
+        assertThat(String.valueOf(explain.get("statement_type")), is("EXPLAIN"));
+        assertFalse(((List<?>) explain.get("rows")).isEmpty());
+    }
+    
+    private void assertTransactionRollback(final MCPInteractionClient interactionClient) throws IOException, InterruptedException {
+        assertThat(interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("public", "BEGIN")).get("message"), is("Transaction started."));
+        interactionClient.call("database_gateway_execute_update",
+                createExecuteUpdateArguments("public", "UPDATE public.orders SET status = 'PENDING' WHERE order_id = 1"));
+        assertThat(interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("public", "ROLLBACK")).get("message"), is("Transaction rolled back."));
+        Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                Map.of("database", LOGICAL_DATABASE_NAME, "schema", "public", "sql", "SELECT status FROM public.orders WHERE order_id = 1", "max_rows", 1));
+        assertTrue(String.valueOf(actual.get("row_objects")).contains("NEW"));
+    }
+    
+    private Map<String, Object> findNested(final Map<String, Object> payload, final String collectionName, final String fieldName, final String expectedValue) {
+        return ((List<?>) payload.get(collectionName)).stream().map(each -> MCPInteractionPayloads.getRequiredObjectValue(each, collectionName))
+                .filter(each -> expectedValue.equals(each.get(fieldName))).findFirst().orElseThrow();
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionRuntimeTransportSmokeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionRuntimeTransportSmokeE2ETest.java
@@ -43,6 +43,10 @@ class ProductionRuntimeTransportSmokeE2ETest extends AbstractProductionMySQLRunt
     void assertTransportLifecycleWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
         useTransport(transport);
         try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            interactionClient.sendRawNotification("notifications/cancelled", Map.of("requestId", "unknown-request", "reason", "race tolerance"));
+            assertThat(getObjectOrEmpty(interactionClient.sendRawRequest("ping-1", "ping", Map.of()).get("result")), is(Map.of()));
+            interactionClient.sendRawNotification("notifications/cancelled", Map.of("requestId", "ping-1", "reason", "request already completed"));
+            assertThat(getObjectOrEmpty(interactionClient.sendRawRequest("ping-2", "ping", Map.of()).get("result")), is(Map.of()));
             assertOfficialToolNames(interactionClient.listTools().stream().map(each -> String.valueOf(each.get("name"))).toList());
             MCPPayloadAssertions.assertSingleItemValue(interactionClient.readResource("shardingsphere://databases"), "database", LOGICAL_DATABASE_NAME);
             Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/FeatureWorkflowContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/FeatureWorkflowContractE2ETest.java
@@ -47,6 +47,9 @@ class FeatureWorkflowContractE2ETest extends AbstractSharedHttpProgrammaticRunti
             "create table", "alter table", "drop table", "create index", "drop index", "migrate", "migration", "backfill", "data probe", "physical metadata",
             "register storage unit", "alter storage unit", "unregister storage unit");
     
+    private static final List<String> REQUIRED_WORKFLOW_OUTPUT_FIELDS = List.of(
+            "response_mode", "plan_id", "workflow_kind", "status", "missing_required_inputs", "resources_to_read", "next_actions");
+    
     private static boolean isEnabled() {
         return MCPE2ECondition.isDockerEnabled();
     }
@@ -72,16 +75,42 @@ class FeatureWorkflowContractE2ETest extends AbstractSharedHttpProgrammaticRunti
                         "shardingsphere://features/readwrite-splitting/databases/{database}/rules",
                         Map.of("database", "logic_db", "operation_type", "create", "rule", "readwrite_ds", "write_storage_unit", "write_ds",
                                 "read_storage_units", "read_ds_0", "transactional_read_query_strategy", "DYNAMIC"))),
+                Arguments.of("readwrite-splitting status", new FeatureWorkflowScenario("database_gateway_plan_readwrite_splitting_status",
+                        "shardingsphere://features/readwrite-splitting/databases/{database}/rules",
+                        Map.of("database", "logic_db", "rule", "readwrite_ds", "storage_unit", "read_ds_0", "target_status", "disable"))),
                 Arguments.of("shadow", new FeatureWorkflowScenario("database_gateway_plan_shadow_rule", "shardingsphere://features/shadow/databases/{database}/rules",
                         Map.of("database", "logic_db", "operation_type", "create", "rule", "shadow_rule", "source_storage_unit", "demo_ds",
                                 "shadow_storage_unit", "demo_ds_shadow", "table", "orders", "algorithm_type", "VALUE_MATCH",
                                 "algorithm_properties", Map.of("operation", "insert", "column", "user_id", "value", "1")))),
+                Arguments.of("shadow default algorithm", new FeatureWorkflowScenario("database_gateway_plan_default_shadow_algorithm",
+                        "shardingsphere://features/shadow/databases/{database}/rules",
+                        Map.of("database", "logic_db", "operation_type", "create", "algorithm_type", "SQL_HINT"))),
+                Arguments.of("shadow algorithm cleanup", new FeatureWorkflowScenario("database_gateway_plan_shadow_algorithm_cleanup",
+                        "shardingsphere://features/shadow/databases/{database}/rules",
+                        Map.of("database", "logic_db", "algorithm_name", "unused_algorithm"))),
                 Arguments.of("sharding", new FeatureWorkflowScenario("database_gateway_plan_sharding_table_rule",
                         "shardingsphere://features/sharding/databases/{database}/table-rules",
                         Map.of("database", "logic_db", "operation_type", "create", "table", "t_order", "column", "order_id",
                                 "data_nodes", "ds_${0..1}.t_order_${0..1}", "strategy_type", "standard", "algorithm_type", "INLINE",
                                 "algorithm_properties", Map.of("algorithm-expression", "t_order_${order_id % 2}"), "key_generate_column", "id",
-                                "key_generator_type", "SNOWFLAKE"))));
+                                "key_generator_type", "SNOWFLAKE"))),
+                Arguments.of("sharding table reference", new FeatureWorkflowScenario("database_gateway_plan_sharding_table_reference_rule",
+                        "shardingsphere://features/sharding/databases/{database}/table-reference-rules",
+                        Map.of("database", "logic_db", "operation_type", "create", "rule", "order_reference", "reference_tables", "t_order,t_order_item"))),
+                Arguments.of("sharding default strategy", new FeatureWorkflowScenario("database_gateway_plan_sharding_default_strategy",
+                        "shardingsphere://features/sharding/databases/{database}/default-strategy",
+                        Map.of("database", "logic_db", "operation_type", "create", "default_strategy_type", "DATABASE", "strategy_type", "none"))),
+                Arguments.of("sharding key generator", new FeatureWorkflowScenario("database_gateway_plan_sharding_key_generator",
+                        "shardingsphere://features/sharding/databases/{database}/key-generators",
+                        Map.of("database", "logic_db", "operation_type", "create", "key_generator", "snowflake_generator",
+                                "key_generator_type", "SNOWFLAKE", "key_generator_properties", Map.of("worker-id", "1")))),
+                Arguments.of("sharding key generate strategy", new FeatureWorkflowScenario("database_gateway_plan_sharding_key_generate_strategy",
+                        "shardingsphere://features/sharding/databases/{database}/key-generate-strategies",
+                        Map.of("database", "logic_db", "operation_type", "create", "key_generate_strategy", "order_key_strategy",
+                                "table", "t_order", "column", "id", "key_generator", "snowflake_generator"))),
+                Arguments.of("sharding component cleanup", new FeatureWorkflowScenario("database_gateway_plan_sharding_rule_component_cleanup",
+                        "shardingsphere://features/sharding/databases/{database}/unused-algorithms",
+                        Map.of("database", "logic_db", "component_type", "algorithm", "component_name", "unused_algorithm"))));
     }
     
     private void assertFeatureDiscovery(final HttpClient httpClient, final String sessionId, final FeatureWorkflowScenario scenario) throws IOException, InterruptedException {
@@ -107,6 +136,8 @@ class FeatureWorkflowContractE2ETest extends AbstractSharedHttpProgrammaticRunti
         for (String each : scenario.planArguments().keySet()) {
             assertTrue(actualProperties.containsKey(each), each);
         }
+        Map<String, Object> actualOutputSchema = MCPInteractionPayloads.getRequiredObject(actualTool, "outputSchema");
+        assertThat(((List<?>) actualOutputSchema.get("required")).stream().map(String::valueOf).toList(), is(REQUIRED_WORKFLOW_OUTPUT_FIELDS));
     }
     
     private Map<String, Object> findByKey(final List<Map<String, Object>> values, final String key, final String expectedValue) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/runtime/PostgreSQLRuntimeTestSupport.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/runtime/PostgreSQLRuntimeTestSupport.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.support.runtime;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
+import org.apache.shardingsphere.test.e2e.env.runtime.EnvironmentPropertiesLoader;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * E2E-local PostgreSQL-backed runtime test support.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PostgreSQLRuntimeTestSupport {
+    
+    private static final Duration JDBC_READY_TIMEOUT = Duration.ofSeconds(90L);
+    
+    private static final String DATABASE_NAME = "orders";
+    
+    private static final String USERNAME = "mcp";
+    
+    private static final String PASSWORD = "mcp";
+    
+    /**
+     * Create one PostgreSQL runtime container.
+     *
+     * @return PostgreSQL runtime container
+     * @throws IllegalStateException when the configured image is empty
+     */
+    public static GenericContainer<?> createContainer() {
+        String image = EnvironmentPropertiesLoader.loadProperties().getProperty("mcp.e2e.postgresql.image", "").trim();
+        if (image.isEmpty()) {
+            throw new IllegalStateException("MCP E2E PostgreSQL image property `mcp.e2e.postgresql.image` is required.");
+        }
+        return new GenericContainer<>(DockerImageName.parse(image))
+                .withEnv("POSTGRES_DB", DATABASE_NAME)
+                .withEnv("POSTGRES_USER", USERNAME)
+                .withEnv("POSTGRES_PASSWORD", PASSWORD)
+                .withExposedPorts(5432)
+                .waitingFor(Wait.forListeningPort())
+                .withStartupTimeout(Duration.ofMinutes(2L));
+    }
+    
+    /**
+     * Check whether Docker is available for Testcontainers-backed tests.
+     *
+     * @return whether Docker is available
+     */
+    public static boolean isDockerAvailable() {
+        try {
+            return DockerClientFactory.instance().isDockerAvailable();
+        } catch (final IllegalStateException ignored) {
+            return false;
+        }
+    }
+    
+    /**
+     * Create runtime databases for the PostgreSQL-backed runtime.
+     *
+     * @param container running container
+     * @param logicalDatabase logical database name
+     * @return runtime databases
+     */
+    public static Map<String, RuntimeDatabaseConfiguration> createRuntimeDatabases(final GenericContainer<?> container, final String logicalDatabase) {
+        return Map.of(logicalDatabase, new RuntimeDatabaseConfiguration(createJdbcUrl(container), USERNAME, PASSWORD, "org.postgresql.Driver"));
+    }
+    
+    /**
+     * Initialize PostgreSQL schemas that exercise native schema metadata.
+     *
+     * @param container running container
+     * @throws SQLException SQL exception
+     */
+    public static void initializeDatabase(final GenericContainer<?> container) throws SQLException {
+        try (
+                Connection connection = getConnection(container);
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE SCHEMA IF NOT EXISTS tenant");
+            statement.execute("CREATE TABLE IF NOT EXISTS public.orders (order_id INTEGER PRIMARY KEY, status VARCHAR(32), tenant_code VARCHAR(16) NOT NULL)");
+            statement.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_orders_tenant_order ON public.orders (tenant_code, order_id)");
+            statement.execute("INSERT INTO public.orders (order_id, status, tenant_code) VALUES (1, 'NEW', 'tenant-a') ON CONFLICT (order_id) "
+                    + "DO UPDATE SET status = EXCLUDED.status, tenant_code = EXCLUDED.tenant_code");
+            statement.execute("CREATE OR REPLACE VIEW public.active_orders AS SELECT order_id, status FROM public.orders WHERE status <> 'DONE'");
+            statement.execute("CREATE TABLE IF NOT EXISTS tenant.orders (order_id INTEGER PRIMARY KEY, tenant_note VARCHAR(32) NOT NULL)");
+            statement.execute("INSERT INTO tenant.orders (order_id, tenant_note) VALUES (1, 'tenant-schema') ON CONFLICT (order_id) "
+                    + "DO UPDATE SET tenant_note = EXCLUDED.tenant_note");
+        }
+    }
+    
+    private static Connection getConnection(final GenericContainer<?> container) throws SQLException {
+        String jdbcUrl = createJdbcUrl(container);
+        try {
+            return new ReadinessProbe(JDBC_READY_TIMEOUT.toMillis(), 250L, 1000L).waitUntilReady(
+                    () -> getConnectionIfReady(jdbcUrl),
+                    (cause, attemptCount, elapsedMillis) -> new SQLException(String.format(
+                            "PostgreSQL JDBC connection did not become ready after %d attempt(s), elapsedMillis=%d.", attemptCount, elapsedMillis), cause));
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new SQLException("Interrupted while waiting for PostgreSQL JDBC readiness.", ex);
+        }
+    }
+    
+    private static ReadinessProbe.ReadinessResult<Connection> getConnectionIfReady(final String jdbcUrl) {
+        try {
+            return ReadinessProbe.ReadinessResult.ready(DriverManager.getConnection(jdbcUrl, USERNAME, PASSWORD));
+        } catch (final SQLException ex) {
+            return ReadinessProbe.ReadinessResult.retry(ex);
+        }
+    }
+    
+    private static String createJdbcUrl(final GenericContainer<?> container) {
+        return String.format("jdbc:postgresql://%s:%d/%s", container.getHost(), container.getMappedPort(5432), DATABASE_NAME);
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/AbstractMCPInteractionClient.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/AbstractMCPInteractionClient.java
@@ -58,6 +58,12 @@ abstract class AbstractMCPInteractionClient implements MCPInteractionClient {
     }
     
     @Override
+    public final void sendRawNotification(final String method, final Map<String, Object> params) throws IOException, InterruptedException {
+        ensureOpened();
+        sendNotification(method, params);
+    }
+    
+    @Override
     public final Map<String, Object> listPrompts() throws IOException, InterruptedException {
         return getObjectListResultOrError(sendInitializedRequest("prompts-list-1", "prompts/list", Map.of()), "prompts");
     }
@@ -88,6 +94,8 @@ abstract class AbstractMCPInteractionClient implements MCPInteractionClient {
     protected abstract void ensureOpened();
     
     protected abstract Map<String, Object> sendRequest(String requestId, String method, Map<String, Object> params) throws IOException, InterruptedException;
+    
+    protected abstract void sendNotification(String method, Map<String, Object> params) throws IOException, InterruptedException;
     
     private Map<String, Object> sendInitializedRequest(final String requestId, final String method, final Map<String, Object> params) throws IOException, InterruptedException {
         ensureOpened();

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/AbstractMCPInteractionClientTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/AbstractMCPInteractionClientTest.java
@@ -85,6 +85,15 @@ class AbstractMCPInteractionClientTest {
     }
     
     @Test
+    void assertSendRawNotification() throws IOException, InterruptedException {
+        FakeMCPInteractionClient client = new FakeMCPInteractionClient(Map.of());
+        client.sendRawNotification("notifications/cancelled", Map.of("requestId", "id", "reason", "not needed"));
+        assertThat(client.method, is("notifications/cancelled"));
+        assertThat(client.params, is(Map.of("requestId", "id", "reason", "not needed")));
+        assertThat(client.openCount, is(1));
+    }
+    
+    @Test
     void assertListPrompts() throws IOException, InterruptedException {
         FakeMCPInteractionClient client = new FakeMCPInteractionClient(Map.of("result", Map.of("prompts", List.of(Map.of("name", "inspect_metadata")))));
         assertThat(client.listPrompts(), is(Map.of("prompts", List.of(Map.of("name", "inspect_metadata")))));
@@ -166,6 +175,12 @@ class AbstractMCPInteractionClientTest {
             this.method = method;
             this.params = params;
             return response;
+        }
+        
+        @Override
+        protected void sendNotification(final String method, final Map<String, Object> params) {
+            this.method = method;
+            this.params = params;
         }
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/AbstractProcessMCPStdioInteractionClient.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/AbstractProcessMCPStdioInteractionClient.java
@@ -125,7 +125,7 @@ abstract class AbstractProcessMCPStdioInteractionClient extends AbstractMCPInter
         if (!MCPInteractionProtocolSupport.PROTOCOL_VERSION.equals(initializeResult.get("protocolVersion"))) {
             throw createRuntimeFailureException("Unexpected STDIO MCP protocol version: " + initializeResult + ".");
         }
-        notifyServer("notifications/initialized", Map.of());
+        sendNotification("notifications/initialized", Map.of());
     }
     
     private Thread startStdErrorCollector(final Process process, final List<String> stdErrorMessages) {
@@ -145,7 +145,8 @@ abstract class AbstractProcessMCPStdioInteractionClient extends AbstractMCPInter
         }
     }
     
-    private void notifyServer(final String method, final Map<String, Object> params) throws IOException {
+    @Override
+    protected final void sendNotification(final String method, final Map<String, Object> params) throws IOException {
         writeJsonRpcMessage(MCPInteractionProtocolSupport.createJsonRpcNotification(method, params));
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPHttpInteractionClient.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPHttpInteractionClient.java
@@ -70,7 +70,7 @@ public final class MCPHttpInteractionClient extends AbstractMCPInteractionClient
         sessionId = response.headers().firstValue("MCP-Session-Id")
                 .orElseThrow(() -> new IllegalStateException("MCP initialize response does not contain MCP-Session-Id header."));
         actualProtocolVersion = response.headers().firstValue("MCP-Protocol-Version").orElse(MCPInteractionProtocolSupport.PROTOCOL_VERSION);
-        sendInitializedNotification();
+        sendNotification("notifications/initialized", Map.of());
     }
     
     @Override
@@ -106,6 +106,20 @@ public final class MCPHttpInteractionClient extends AbstractMCPInteractionClient
         return MCPInteractionPayloads.parseJsonPayload(sendPostRequest(requestId, method, params).body());
     }
     
+    @Override
+    protected void sendNotification(final String method, final Map<String, Object> params) throws IOException, InterruptedException {
+        HttpRequest request = createSessionRequestBuilder()
+                .POST(HttpRequest.BodyPublishers.ofString(MCPInteractionProtocolSupport.createJsonRpcNotificationBody(method, params)))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (202 != response.statusCode()) {
+            throw new IllegalStateException("MCP notification failed with status " + response.statusCode() + ".");
+        }
+        if (!response.body().isEmpty()) {
+            throw new IllegalStateException("MCP notification response body must be empty.");
+        }
+    }
+    
     private HttpRequest.Builder createSessionRequestBuilder() {
         return MCPHttpTransportTestSupport.createSessionRequestBuilder(endpointUri, sessionId, actualProtocolVersion);
     }
@@ -119,16 +133,6 @@ public final class MCPHttpInteractionClient extends AbstractMCPInteractionClient
             throw new IllegalStateException("MCP request failed with status " + response.statusCode() + ".");
         }
         return response;
-    }
-    
-    private void sendInitializedNotification() throws IOException, InterruptedException {
-        HttpRequest request = createSessionRequestBuilder()
-                .POST(HttpRequest.BodyPublishers.ofString(MCPInteractionProtocolSupport.createJsonRpcNotificationBody("notifications/initialized", Map.of())))
-                .build();
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        if (202 != response.statusCode()) {
-            throw new IllegalStateException("Failed to notify initialized MCP session.");
-        }
     }
     
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPHttpInteractionClientTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPHttpInteractionClientTest.java
@@ -90,6 +90,15 @@ class MCPHttpInteractionClientTest {
     }
     
     @Test
+    void assertOpenWithInvalidNotificationResponse() {
+        FakeHttpClient httpClient = new FakeHttpClient();
+        httpClient.addResponse(200, Map.of("MCP-Session-Id", List.of("session")), "{\"result\":{}}");
+        httpClient.addResponse(202, Map.of(), "{}");
+        IllegalStateException actual = assertThrows(IllegalStateException.class, () -> new MCPHttpInteractionClient(ENDPOINT_URI, httpClient).open());
+        assertThat(actual.getMessage(), is("MCP notification response body must be empty."));
+    }
+    
+    @Test
     void assertGetInitializePayloadBeforeOpen() {
         assertThat(new MCPHttpInteractionClient(ENDPOINT_URI, new FakeHttpClient()).getInitializePayload(), is(Map.of()));
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPInteractionClient.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPInteractionClient.java
@@ -135,6 +135,16 @@ public interface MCPInteractionClient extends AutoCloseable {
      */
     Map<String, Object> sendRawRequest(String requestId, String method, Map<String, Object> params) throws IOException, InterruptedException;
     
+    /**
+     * Send raw JSON-RPC notification.
+     *
+     * @param method method name
+     * @param params notification params
+     * @throws IOException IO exception
+     * @throws InterruptedException interrupted exception
+     */
+    void sendRawNotification(String method, Map<String, Object> params) throws IOException, InterruptedException;
+    
     @Override
     void close() throws IOException, InterruptedException;
 }

--- a/test/e2e/mcp/src/test/resources/env/e2e-env.properties
+++ b/test/e2e/mcp/src/test/resources/env/e2e-env.properties
@@ -22,6 +22,7 @@ e2e.run.type=
 
 mcp.e2e.container.image=
 mcp.e2e.mysql.image=mysql:8.0.36
+mcp.e2e.postgresql.image=postgres:16.4
 mcp.e2e.mysql.ready-timeout-seconds=90
 mcp.distribution.home=
 

--- a/test/e2e/mcp/src/test/resources/proxy/workflow/database-logic-db.yaml
+++ b/test/e2e/mcp/src/test/resources/proxy/workflow/database-logic-db.yaml
@@ -56,3 +56,7 @@ rules:
 - !SINGLE
   tables:
     - "*.*"
+- !SHADOW
+  shadowAlgorithms:
+    fixture_unused_algorithm:
+      type: SQL_HINT


### PR DESCRIPTION
- load rich JDBC metadata lazily with request-scoped caching
- enforce workflow schemas and fixed protocol transport behavior
- extend PostgreSQL and feature workflow E2E coverage
