### PR TITLE
Add etcd repository dependency to example generator pom template

### DIFF
--- a/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/pom.ftl
+++ b/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/pom.ftl
@@ -114,6 +114,13 @@
             <version>${r'${project.version}'}</version>
         </dependency>
     </#if>
+    <#if mode=="cluster-etcd">
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-cluster-mode-repository-etcd</artifactId>
+            <version>${r'${project.version}'}</version>
+        </dependency>
+    </#if>
     <#if mode?contains("standalone") && repository == "JDBC">
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>

--- a/examples/shardingsphere-jdbc-example-generator/src/test/java/PomTemplateTest.java
+++ b/examples/shardingsphere-jdbc-example-generator/src/test/java/PomTemplateTest.java
@@ -71,7 +71,23 @@ public final class PomTemplateTest {
         assertThat(content, containsString("shardingsphere-sharding-core"));
         assertThat(content, containsString("shardingsphere-broadcast-core"));
     }
-    
+
+    @Test
+    public void assertClusterZookeeperRepositoryDependency() throws IOException, TemplateException {
+        Map<String, Object> dataModel = createBaseDataModel();
+        dataModel.put("mode", "cluster-zookeeper");
+        String content = renderPomTemplate(dataModel);
+        assertThat(content, containsString("shardingsphere-cluster-mode-repository-zookeeper"));
+    }
+
+    @Test
+    public void assertClusterEtcdRepositoryDependency() throws IOException, TemplateException {
+        Map<String, Object> dataModel = createBaseDataModel();
+        dataModel.put("mode", "cluster-etcd");
+        String content = renderPomTemplate(dataModel);
+        assertThat(content, containsString("shardingsphere-cluster-mode-repository-etcd"));
+    }
+
     private Map<String, Object> createBaseDataModel() {
         Map<String, Object> result = new HashMap<>(6, 1F);
         result.put("mode", "standalone");


### PR DESCRIPTION
Fixes #39148.

Changes proposed in this pull request:
  - Add a `<#if mode=="cluster-etcd">` block to `template/pom.ftl` that adds the `shardingsphere-cluster-mode-repository-etcd` dependency, mirroring the existing `cluster-zookeeper` block.
  - Without it, a generated `cluster-etcd` example has no repository provider on the classpath and fails at runtime with `ServiceProviderNotFoundException`, even though `cluster-etcd` is a supported mode (`YamlExampleConfigurationSupportedValue.MODES`, `config.yaml`, `template/resources/yaml/mode/cluster-etcd.ftl`).
  - Uses the existing internal module `shardingsphere-cluster-mode-repository-etcd` (`mode/type/cluster/repository/provider/etcd`) — no new third-party dependency.
  - Extend `PomTemplateTest` with etcd and zookeeper cluster-mode assertions verifying the rendered pom contains the matching repository provider.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally (compile + apache-rat + `PomTemplateTest`; the examples project is a standalone build without spotless/checkstyle).
- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the Release Notes of the current development version.
