### PR TITLE
Fix unparseable multi-table DROP TABLE in Oracle parser example

### DIFF
--- a/examples/shardingsphere-parser-example/src/main/java/org/apache/shardingsphere/example/parser/oracle/statement/OracleParserStatementExample.java
+++ b/examples/shardingsphere-parser-example/src/main/java/org/apache/shardingsphere/example/parser/oracle/statement/OracleParserStatementExample.java
@@ -38,7 +38,7 @@ public final class OracleParserStatementExample {
     
     private static final String DDL_CREATE_SQL = "CREATE TABLE table2 (id BIGINT(20) PRIMARY KEY, name VARCHAR(20), age INT(2))";
     
-    private static final String DDL_DROP_SQL = "DROP TABLE table1, table2;";
+    private static final String DDL_DROP_SQL = "DROP TABLE table1;";
     
     private static final String DDL_ALTER_SQL = "ALTER TABLE table1 DROP age;";
 


### PR DESCRIPTION
Fixes #39150.

Changes proposed in this pull request:
  - Change the Oracle example's `DDL_DROP_SQL` from `DROP TABLE table1, table2;` to `DROP TABLE table1;`.
  - The comma-separated multi-table form is MySQL syntax; Oracle's `dropTable` grammar (`DROP TABLE tableName (CASCADE CONSTRAINTS)? (PURGE)?`) accepts a single table only, so under the Oracle dialect the statement failed to parse and `OracleParserStatementExample.main()` threw before reaching the DROP and ALTER demos.
  - After the change, the example parses and visits all statements (SELECT, INSERT, UPDATE, DELETE, CREATE TABLE, DROP TABLE, ALTER TABLE) without exception; single-table DROP is the valid Oracle form and still demonstrates the DROP TABLE statement type.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version.
