### PR TITLE
Fix broadcast data node lookup ignoring table name case

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,6 +55,7 @@
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
 1. SQL Federation: Fix SQL Federation pagination binding for long LIMIT parameters - [#39237](https://github.com/apache/shardingsphere/pull/39237)
+1. Broadcast: Fix case-sensitive table name lookup in broadcast data node rule attribute - [#39153](https://github.com/apache/shardingsphere/pull/39153)
 
 ### Enhancements
 

--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/rule/attribute/BroadcastDataNodeRuleAttribute.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/rule/attribute/BroadcastDataNodeRuleAttribute.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.broadcast.rule.attribute;
 
+import com.cedarsoftware.util.CaseInsensitiveMap;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.rule.attribute.datanode.DataNodeRuleAttribute;
 
@@ -37,7 +38,10 @@ public final class BroadcastDataNodeRuleAttribute implements DataNodeRuleAttribu
     
     public BroadcastDataNodeRuleAttribute(final Collection<String> dataSourceNames, final Collection<String> tables) {
         this.tables = tables;
-        tableDataNodes = tables.stream().collect(Collectors.toMap(String::toLowerCase, each -> generateDataNodes(each, dataSourceNames)));
+        tableDataNodes = new CaseInsensitiveMap<>(tables.size(), 1F);
+        for (String each : tables) {
+            tableDataNodes.put(each, generateDataNodes(each, dataSourceNames));
+        }
     }
     
     private Collection<DataNode> generateDataNodes(final String logicTable, final Collection<String> dataSourceNames) {
@@ -51,12 +55,12 @@ public final class BroadcastDataNodeRuleAttribute implements DataNodeRuleAttribu
     
     @Override
     public Collection<DataNode> getDataNodesByTableName(final String tableName) {
-        return tableDataNodes.getOrDefault(tableName.toLowerCase(), Collections.emptyList());
+        return tableDataNodes.getOrDefault(tableName, Collections.emptyList());
     }
     
     @Override
     public Optional<String> findFirstActualTable(final String logicTable) {
-        return tableDataNodes.containsKey(logicTable.toLowerCase()) ? Optional.of(logicTable) : Optional.empty();
+        return tableDataNodes.containsKey(logicTable) ? Optional.of(logicTable) : Optional.empty();
     }
     
     @Override
@@ -66,12 +70,12 @@ public final class BroadcastDataNodeRuleAttribute implements DataNodeRuleAttribu
     
     @Override
     public Optional<String> findLogicTableByActualTable(final String actualTable) {
-        return tableDataNodes.containsKey(actualTable.toLowerCase()) ? Optional.of(actualTable) : Optional.empty();
+        return tableDataNodes.containsKey(actualTable) ? Optional.of(actualTable) : Optional.empty();
     }
     
     @Override
     public Optional<String> findActualTableByCatalog(final String catalog, final String logicTable) {
-        return tableDataNodes.getOrDefault(logicTable.toLowerCase(), Collections.emptyList()).stream().anyMatch(each -> each.getDataSourceName().equalsIgnoreCase(catalog))
+        return tableDataNodes.getOrDefault(logicTable, Collections.emptyList()).stream().anyMatch(each -> each.getDataSourceName().equalsIgnoreCase(catalog))
                 ? Optional.of(logicTable)
                 : Optional.empty();
     }

--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/rule/attribute/BroadcastDataNodeRuleAttribute.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/rule/attribute/BroadcastDataNodeRuleAttribute.java
@@ -51,7 +51,7 @@ public final class BroadcastDataNodeRuleAttribute implements DataNodeRuleAttribu
     
     @Override
     public Collection<DataNode> getDataNodesByTableName(final String tableName) {
-        return tableDataNodes.getOrDefault(tableName, Collections.emptyList());
+        return tableDataNodes.getOrDefault(tableName.toLowerCase(), Collections.emptyList());
     }
     
     @Override

--- a/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/rule/attribute/BroadcastDataNodeRuleAttributeTest.java
+++ b/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/rule/attribute/BroadcastDataNodeRuleAttributeTest.java
@@ -52,6 +52,12 @@ class BroadcastDataNodeRuleAttributeTest {
     }
     
     @Test
+    void assertGetDataNodesByTableNameWithDifferentCase() {
+        assertThat(new BroadcastDataNodeRuleAttribute(Arrays.asList("foo_ds", "bar_ds"), Arrays.asList("foo_tbl", "bar_tbl")).getDataNodesByTableName("FOO_TBL"),
+                is(Arrays.asList(new DataNode("foo_ds.foo_tbl"), new DataNode("bar_ds.foo_tbl"))));
+    }
+    
+    @Test
     void assertFindFirstActualTable() {
         assertThat(new BroadcastDataNodeRuleAttribute(Arrays.asList("foo_ds", "bar_ds"), Arrays.asList("foo_tbl", "bar_tbl")).findFirstActualTable("foo_tbl"), is(Optional.of("foo_tbl")));
     }

--- a/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/rule/attribute/BroadcastDataNodeRuleAttributeTest.java
+++ b/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/rule/attribute/BroadcastDataNodeRuleAttributeTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -55,6 +56,18 @@ class BroadcastDataNodeRuleAttributeTest {
     void assertGetDataNodesByTableNameWithDifferentCase() {
         assertThat(new BroadcastDataNodeRuleAttribute(Arrays.asList("foo_ds", "bar_ds"), Arrays.asList("foo_tbl", "bar_tbl")).getDataNodesByTableName("FOO_TBL"),
                 is(Arrays.asList(new DataNode("foo_ds.foo_tbl"), new DataNode("bar_ds.foo_tbl"))));
+    }
+    
+    @Test
+    void assertGetDataNodesByTableNameWithLocaleSensitiveCase() {
+        Locale originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+        try {
+            assertThat(new BroadcastDataNodeRuleAttribute(Collections.singleton("foo_ds"), Collections.singleton("ID")).getDataNodesByTableName("id"),
+                    is(Collections.singletonList(new DataNode("foo_ds.ID"))));
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
     
     @Test


### PR DESCRIPTION
Fixes #39149.

Changes proposed in this pull request:
  - Normalize the table name with `.toLowerCase()` in `BroadcastDataNodeRuleAttribute.getDataNodesByTableName()` before looking up `tableDataNodes`, which is keyed by lower-cased table names in the constructor.
  - Aligns the method with its three sibling lookups (`findFirstActualTable`, `findLogicTableByActualTable`, `findActualTableByCatalog`) that already lower-case the argument, and with the case-insensitive lookups in the Sharding and Single data node rule attributes.
  - Add a unit test asserting an upper-cased table name resolves to the same data nodes as the lower-cased name.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
