### PR TITLE
Remove unused MCP database query capabilities

### DIFF
--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/metadata/GovernanceMetadataQueryService.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/metadata/GovernanceMetadataQueryService.java
@@ -52,7 +52,7 @@ public final class GovernanceMetadataQueryService {
      * @return storage unit rows
      */
     public List<Map<String, Object>> queryStorageUnits(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW STORAGE UNITS FROM %s", format(databaseName))).stream()
+        return queryFacade.query(databaseName, String.format("SHOW STORAGE UNITS FROM %s", format(databaseName))).stream()
                 .map(this::redactStorageUnitRow).toList();
     }
     
@@ -79,7 +79,7 @@ public final class GovernanceMetadataQueryService {
      * @return rule usage rows
      */
     public List<Map<String, Object>> queryRulesUsedStorageUnit(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String storageUnitName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW RULES USED STORAGE UNIT %s FROM %s", format(storageUnitName), format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW RULES USED STORAGE UNIT %s FROM %s", format(storageUnitName), format(databaseName)));
     }
     
     /**
@@ -90,7 +90,7 @@ public final class GovernanceMetadataQueryService {
      * @return single table rows
      */
     public List<Map<String, Object>> querySingleTables(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SINGLE TABLES FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SINGLE TABLES FROM %s", format(databaseName)));
     }
     
     /**
@@ -103,7 +103,7 @@ public final class GovernanceMetadataQueryService {
      */
     public List<Map<String, Object>> querySingleTable(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String tableName) {
         String actualTableName = WorkflowSQLUtils.normalizeIdentifier(tableName);
-        return queryFacade.query(databaseName, "", String.format("SHOW SINGLE TABLE %s FROM %s", format(tableName), format(databaseName))).stream()
+        return queryFacade.query(databaseName, String.format("SHOW SINGLE TABLE %s FROM %s", format(tableName), format(databaseName))).stream()
                 .filter(each -> actualTableName.equals(WorkflowSQLUtils.normalizeIdentifier(getValue(each, "table_name")))).toList();
     }
     
@@ -115,7 +115,7 @@ public final class GovernanceMetadataQueryService {
      * @return default single table storage unit rows
      */
     public List<Map<String, Object>> queryDefaultSingleTableStorageUnit(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW DEFAULT SINGLE TABLE STORAGE UNIT FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW DEFAULT SINGLE TABLE STORAGE UNIT FROM %s", format(databaseName)));
     }
     
     private Map<String, Object> redactStorageUnitRow(final Map<String, Object> row) {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowProxyQueryService.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowProxyQueryService.java
@@ -36,7 +36,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Types;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -49,19 +48,17 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public final class WorkflowProxyQueryService implements MCPFeatureQueryFacade {
     
-    private static final String DEFAULT_COLUMN_DEFINITION = "VARCHAR(4000)";
-    
     private final MCPSessionManager sessionManager;
     
     private final MCPDatabaseCapabilityProvider databaseCapabilityProvider;
     
     @Override
-    public List<Map<String, Object>> query(final String databaseName, final String schemaName, final String sql) {
+    public List<Map<String, Object>> query(final String databaseName, final String sql) {
         String actualDatabaseName = WorkflowSQLUtils.normalizeIdentifier(databaseName);
         try (
                 Connection connection = openConnection(actualDatabaseName);
                 Statement statement = connection.createStatement();
-                ResultSet resultSet = executeQuery(connection, statement, schemaName, sql)) {
+                ResultSet resultSet = statement.executeQuery(sql)) {
             return extractRows(resultSet);
         } catch (final SQLException ex) {
             throw createQueryFailedException(actualDatabaseName, ex);
@@ -72,7 +69,7 @@ public final class WorkflowProxyQueryService implements MCPFeatureQueryFacade {
     public List<Map<String, Object>> queryWithAnyDatabase(final String sql) {
         String databaseName = sessionManager.getTransactionResourceManager().getRuntimeDatabases().keySet().stream().findFirst()
                 .orElseThrow(() -> new MCPUnavailableException("No runtime database is configured."));
-        return query(databaseName, "", sql);
+        return query(databaseName, sql);
     }
     
     @Override
@@ -83,29 +80,6 @@ public final class WorkflowProxyQueryService implements MCPFeatureQueryFacade {
     @Override
     public boolean isSameIdentifier(final String databaseName, final IdentifierScope identifierScope, final String identifier, final String existingIdentifier) {
         return WorkflowSQLUtils.isSameIdentifier(getDatabaseCapability(databaseName).getIdentifierCasePolicySet().getPolicy(identifierScope), identifier, existingIdentifier);
-    }
-    
-    @Override
-    public String queryColumnDefinition(final String databaseName, final String schemaName, final String tableName, final String columnName) {
-        WorkflowSQLUtils.checkSupportedIdentifier("database", databaseName);
-        WorkflowSQLUtils.checkSupportedIdentifier("schema", schemaName);
-        String actualDatabaseName = WorkflowSQLUtils.normalizeIdentifier(databaseName);
-        String actualSchemaName = WorkflowSQLUtils.normalizeIdentifier(schemaName);
-        String databaseType = getDatabaseType(actualDatabaseName);
-        String sql = String.format("SELECT %s FROM %s WHERE 1 = 0", WorkflowSQLUtils.formatSQLIdentifier(databaseType, columnName), WorkflowSQLUtils.formatSQLIdentifier(databaseType, tableName));
-        try (
-                Connection connection = openConnection(actualDatabaseName);
-                Statement statement = connection.createStatement();
-                ResultSet resultSet = executeQuery(connection, statement, actualSchemaName, sql)) {
-            ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
-            if (0 == resultSetMetaData.getColumnCount()) {
-                return DEFAULT_COLUMN_DEFINITION;
-            }
-            return formatColumnDefinition(resultSetMetaData.getColumnType(1), resultSetMetaData.getColumnTypeName(1),
-                    resultSetMetaData.getPrecision(1), resultSetMetaData.getScale(1));
-        } catch (final SQLException ex) {
-            throw new MCPDatabaseQueryFailedException(MCPJDBCExceptionClassifier.classify(databaseType, ex), ex);
-        }
     }
     
     private MCPDatabaseQueryFailedException createQueryFailedException(final String databaseName, final SQLException cause) {
@@ -124,20 +98,8 @@ public final class WorkflowProxyQueryService implements MCPFeatureQueryFacade {
         return runtimeDatabaseConfig.openConnection(databaseName);
     }
     
-    private String getDatabaseType(final String databaseName) {
-        return getDatabaseCapability(databaseName).getDatabaseType();
-    }
-    
     private MCPDatabaseCapability getDatabaseCapability(final String databaseName) {
         return databaseCapabilityProvider.provide(WorkflowSQLUtils.normalizeIdentifier(databaseName)).orElseThrow(DatabaseCapabilityNotFoundException::new);
-    }
-    
-    private ResultSet executeQuery(final Connection connection, final Statement statement, final String schemaName, final String sql) throws SQLException {
-        String actualSchemaName = WorkflowSQLUtils.normalizeIdentifier(schemaName);
-        if (!actualSchemaName.isEmpty()) {
-            connection.setSchema(actualSchemaName);
-        }
-        return statement.executeQuery(sql);
     }
     
     private List<Map<String, Object>> extractRows(final ResultSet resultSet) throws SQLException {
@@ -153,39 +115,4 @@ public final class WorkflowProxyQueryService implements MCPFeatureQueryFacade {
         return result;
     }
     
-    private String formatColumnDefinition(final int columnType, final String columnTypeName, final int precision, final int scale) {
-        String actualColumnTypeName = normalize(columnTypeName);
-        if (actualColumnTypeName.isEmpty()) {
-            return DEFAULT_COLUMN_DEFINITION;
-        }
-        switch (columnType) {
-            case Types.CHAR:
-            case Types.VARCHAR:
-            case Types.LONGVARCHAR:
-            case Types.NCHAR:
-            case Types.NVARCHAR:
-            case Types.LONGNVARCHAR:
-            case Types.BINARY:
-            case Types.VARBINARY:
-            case Types.LONGVARBINARY:
-                return 0 < precision ? String.format("%s(%d)", actualColumnTypeName, precision) : actualColumnTypeName;
-            case Types.DECIMAL:
-            case Types.NUMERIC:
-                if (0 < precision && 0 < scale) {
-                    return String.format("%s(%d, %d)", actualColumnTypeName, precision, scale);
-                }
-                return 0 < precision ? String.format("%s(%d)", actualColumnTypeName, precision) : actualColumnTypeName;
-            case Types.TIME:
-            case Types.TIME_WITH_TIMEZONE:
-            case Types.TIMESTAMP:
-            case Types.TIMESTAMP_WITH_TIMEZONE:
-                return 0 < scale ? String.format("%s(%d)", actualColumnTypeName, scale) : actualColumnTypeName;
-            default:
-                return actualColumnTypeName;
-        }
-    }
-    
-    private String normalize(final String value) {
-        return null == value ? "" : value.trim();
-    }
 }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProviderTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProviderTest.java
@@ -191,7 +191,7 @@ class MetadataCompletionProviderTest {
     @Test
     void assertCompleteStorageUnit() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
+        when(queryFacade.query("logic_db", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
         MCPCompletionProviderResult actual = new MetadataCompletionProvider().complete(createHandlerContext(mock(MCPMetadataQueryFacade.class), queryFacade),
                 createRequestContext("storageUnit", Map.of("database", "logic_db")));
         assertCandidate(actual, "write_ds");
@@ -202,7 +202,7 @@ class MetadataCompletionProviderTest {
     @Test
     void assertCompleteStorageUnitAlias() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
+        when(queryFacade.query("logic_db", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
         MCPCompletionProviderResult actual = new MetadataCompletionProvider().complete(createHandlerContext(mock(MCPMetadataQueryFacade.class), queryFacade),
                 createRequestContext("write_storage_unit", Map.of("database", "logic_db")));
         assertCandidate(actual, "write_ds");
@@ -213,7 +213,7 @@ class MetadataCompletionProviderTest {
     @Test
     void assertCompleteStorageUnitWithSingleDatabaseDefaulted() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
+        when(queryFacade.query("logic_db", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
         MCPCompletionProviderResult actual = new MetadataCompletionProvider().complete(
                 createHandlerContext(mock(MCPMetadataQueryFacade.class), queryFacade, List.of(createDatabaseProfile("logic_db"))), createRequestContext("storageUnit", Map.of()));
         assertCandidate(actual, "write_ds");

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/metadata/GovernanceMetadataQueryServiceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/metadata/GovernanceMetadataQueryServiceTest.java
@@ -35,7 +35,7 @@ class GovernanceMetadataQueryServiceTest {
     @Test
     void assertQueryStorageUnits() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of(
+        when(queryFacade.query("logic_db", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of(
                 "name", "write_ds", "password", "root", "key-value", "plain",
                 "other_attributes", "{\"credential\":\"secret\",\"healthCheckProperties\":{\"token\":\"abc\"},\"key\":\"visible\"}")));
         List<Map<String, Object>> actual = service.queryStorageUnits(queryFacade, "logic_db");
@@ -50,7 +50,7 @@ class GovernanceMetadataQueryServiceTest {
     @Test
     void assertQueryStorageUnit() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds"), Map.of("name", "read_ds")));
+        when(queryFacade.query("logic_db", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds"), Map.of("name", "read_ds")));
         List<Map<String, Object>> actual = service.queryStorageUnit(queryFacade, "logic_db", "write_ds");
         assertThat(actual, is(List.of(Map.of("name", "write_ds"))));
     }
@@ -58,7 +58,7 @@ class GovernanceMetadataQueryServiceTest {
     @Test
     void assertQueryRulesUsedStorageUnit() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW RULES USED STORAGE UNIT write_ds FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW RULES USED STORAGE UNIT write_ds FROM logic_db"))
                 .thenReturn(List.of(Map.of("type", "readwrite_splitting", "name", "ms_group_0")));
         List<Map<String, Object>> actual = service.queryRulesUsedStorageUnit(queryFacade, "logic_db", "write_ds");
         assertThat(actual, is(List.of(Map.of("type", "readwrite_splitting", "name", "ms_group_0"))));
@@ -67,7 +67,7 @@ class GovernanceMetadataQueryServiceTest {
     @Test
     void assertQuerySingleTables() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW SINGLE TABLES FROM logic_db")).thenReturn(List.of(Map.of("table_name", "t_user", "storage_unit_name", "ds_0")));
+        when(queryFacade.query("logic_db", "SHOW SINGLE TABLES FROM logic_db")).thenReturn(List.of(Map.of("table_name", "t_user", "storage_unit_name", "ds_0")));
         List<Map<String, Object>> actual = service.querySingleTables(queryFacade, "logic_db");
         assertThat(actual, is(List.of(Map.of("table_name", "t_user", "storage_unit_name", "ds_0"))));
     }
@@ -75,7 +75,7 @@ class GovernanceMetadataQueryServiceTest {
     @Test
     void assertQuerySingleTable() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW SINGLE TABLE t_user FROM logic_db")).thenReturn(List.of(Map.of("table_name", "t_user", "storage_unit_name", "ds_0")));
+        when(queryFacade.query("logic_db", "SHOW SINGLE TABLE t_user FROM logic_db")).thenReturn(List.of(Map.of("table_name", "t_user", "storage_unit_name", "ds_0")));
         List<Map<String, Object>> actual = service.querySingleTable(queryFacade, "logic_db", "t_user");
         assertThat(actual, is(List.of(Map.of("table_name", "t_user", "storage_unit_name", "ds_0"))));
     }
@@ -83,7 +83,7 @@ class GovernanceMetadataQueryServiceTest {
     @Test
     void assertQueryDefaultSingleTableStorageUnit() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW DEFAULT SINGLE TABLE STORAGE UNIT FROM logic_db")).thenReturn(List.of(Map.of("storage_unit_name", "ds_0")));
+        when(queryFacade.query("logic_db", "SHOW DEFAULT SINGLE TABLE STORAGE UNIT FROM logic_db")).thenReturn(List.of(Map.of("storage_unit_name", "ds_0")));
         List<Map<String, Object>> actual = service.queryDefaultSingleTableStorageUnit(queryFacade, "logic_db");
         assertThat(actual, is(List.of(Map.of("storage_unit_name", "ds_0"))));
     }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolHandlerTest.java
@@ -118,7 +118,7 @@ class SearchMetadataToolHandlerTest {
     @Test
     void assertHandleSearchMetadataWithStorageUnit() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
+        when(queryFacade.query("logic_db", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
         MCPFeatureRequestContext requestContext = mock(MCPFeatureRequestContext.class);
         when(requestContext.getMetadataQueryFacade()).thenReturn(mock(MCPMetadataQueryFacade.class));
         when(requestContext.getQueryFacade()).thenReturn(queryFacade);

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolServiceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolServiceTest.java
@@ -246,7 +246,7 @@ class SearchMetadataToolServiceTest {
     @Test
     void assertExecuteSearchWithStorageUnitObjectType() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW STORAGE UNITS FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW STORAGE UNITS FROM logic_db"))
                 .thenReturn(List.of(Map.of("name", "write_ds"), Map.of("name", "read_ds")));
         MetadataSearchResult actual = execute(createDatabaseMetadata(), queryFacade,
                 new MetadataSearchRequest("logic_db", "", "write", Set.of(SupportedMCPMetadataObjectType.STORAGE_UNIT)));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowProxyQueryServiceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowProxyQueryServiceTest.java
@@ -17,16 +17,9 @@
 
 package org.apache.shardingsphere.mcp.core.workflow;
 
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaSemantics;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
-import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPUnavailableException;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
 import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseCapability;
@@ -36,14 +29,12 @@ import org.apache.shardingsphere.mcp.support.database.exception.MCPDatabaseQuery
 import org.apache.shardingsphere.mcp.support.database.exception.MCPJDBCErrorCategory;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Types;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,16 +44,13 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class WorkflowProxyQueryServiceTest {
     
     @Test
-    void assertQueryReturnsLowerCaseRowsAndAppliesSchema() throws SQLException {
+    void assertQueryReturnsLowerCaseRows() throws SQLException {
         RuntimeDatabaseConfiguration runtimeDatabaseConfig = mock(RuntimeDatabaseConfiguration.class);
         Connection connection = mock(Connection.class);
         Statement statement = mock(Statement.class);
@@ -79,11 +67,10 @@ class WorkflowProxyQueryServiceTest {
         when(resultSet.getObject(1)).thenReturn("orders");
         when(resultSet.getObject(2)).thenReturn("status");
         WorkflowProxyQueryService service = createService(Map.of("logic_db", runtimeDatabaseConfig));
-        List<Map<String, Object>> actual = service.query("logic_db", "public", "SHOW MASK RULES");
+        List<Map<String, Object>> actual = service.query("logic_db", "SHOW MASK RULES");
         assertThat(actual.size(), is(1));
         assertThat(actual.get(0).get("table"), is("orders"));
         assertThat(actual.get(0).get("column"), is("status"));
-        verify(connection).setSchema("public");
     }
     
     @Test
@@ -116,7 +103,7 @@ class WorkflowProxyQueryServiceTest {
     @Test
     void assertQueryThrowsWhenDatabaseIsNotConfigured() {
         WorkflowProxyQueryService service = createService(Map.of());
-        Exception actual = assertThrows(MCPUnavailableException.class, () -> service.query("logic_db", "", "SHOW MASK RULES"));
+        Exception actual = assertThrows(MCPUnavailableException.class, () -> service.query("logic_db", "SHOW MASK RULES"));
         assertThat(actual.getMessage(), is("Database `logic_db` is not configured."));
     }
     
@@ -129,7 +116,7 @@ class WorkflowProxyQueryServiceTest {
         when(connection.createStatement()).thenReturn(statement);
         when(statement.executeQuery("SHOW MASK RULES")).thenThrow(new SQLException("access denied", "42000", 1044));
         WorkflowProxyQueryService service = createService(Map.of("logic_db", runtimeDatabaseConfig));
-        MCPDatabaseQueryFailedException actual = assertThrows(MCPDatabaseQueryFailedException.class, () -> service.query("logic_db", "", "SHOW MASK RULES"));
+        MCPDatabaseQueryFailedException actual = assertThrows(MCPDatabaseQueryFailedException.class, () -> service.query("logic_db", "SHOW MASK RULES"));
         assertThat(actual.getCategory(), is(MCPJDBCErrorCategory.AUTHORIZATION));
     }
     
@@ -149,90 +136,6 @@ class WorkflowProxyQueryServiceTest {
         assertFalse(createService(Map.of()).isSameIdentifier("logic_db", IdentifierScope.TABLE, "Phone", "phone"));
     }
     
-    @Test
-    void assertQueryColumnDefinitionFormatsDecimalDefinition() throws SQLException {
-        RuntimeDatabaseConfiguration runtimeDatabaseConfig = mock(RuntimeDatabaseConfiguration.class);
-        Connection connection = mock(Connection.class);
-        Statement statement = mock(Statement.class);
-        ResultSet resultSet = mock(ResultSet.class);
-        ResultSetMetaData resultSetMetaData = mock(ResultSetMetaData.class);
-        when(runtimeDatabaseConfig.openConnection("logic_db")).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery("SELECT amount FROM orders WHERE 1 = 0")).thenReturn(resultSet);
-        when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
-        when(resultSetMetaData.getColumnCount()).thenReturn(1);
-        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.DECIMAL);
-        when(resultSetMetaData.getColumnTypeName(1)).thenReturn("DECIMAL");
-        when(resultSetMetaData.getPrecision(1)).thenReturn(10);
-        when(resultSetMetaData.getScale(1)).thenReturn(2);
-        WorkflowProxyQueryService service = createService(Map.of("logic_db", runtimeDatabaseConfig));
-        String actual = service.queryColumnDefinition("logic_db", "public", "orders", "amount");
-        assertThat(actual, is("DECIMAL(10, 2)"));
-    }
-    
-    @Test
-    void assertQueryColumnDefinitionReturnsDefaultWhenMetadataIsEmpty() throws SQLException {
-        RuntimeDatabaseConfiguration runtimeDatabaseConfig = mock(RuntimeDatabaseConfiguration.class);
-        Connection connection = mock(Connection.class);
-        Statement statement = mock(Statement.class);
-        ResultSet resultSet = mock(ResultSet.class);
-        ResultSetMetaData resultSetMetaData = mock(ResultSetMetaData.class);
-        when(runtimeDatabaseConfig.openConnection("logic_db")).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery("SELECT amount FROM orders WHERE 1 = 0")).thenReturn(resultSet);
-        when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
-        when(resultSetMetaData.getColumnCount()).thenReturn(0);
-        WorkflowProxyQueryService service = createService(Map.of("logic_db", runtimeDatabaseConfig));
-        String actual = service.queryColumnDefinition("logic_db", "public", "orders", "amount");
-        assertThat(actual, is("VARCHAR(4000)"));
-    }
-    
-    @Test
-    void assertQueryColumnDefinitionFormatsSpecialCharacterIdentifiers() throws SQLException {
-        RuntimeDatabaseConfiguration runtimeDatabaseConfig = mock(RuntimeDatabaseConfiguration.class);
-        Connection connection = mock(Connection.class);
-        Statement statement = mock(Statement.class);
-        ResultSet resultSet = mock(ResultSet.class);
-        ResultSetMetaData resultSetMetaData = mock(ResultSetMetaData.class);
-        when(runtimeDatabaseConfig.openConnection("logic_db")).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery("SELECT `amount due` FROM `order detail` WHERE 1 = 0")).thenReturn(resultSet);
-        when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
-        when(resultSetMetaData.getColumnCount()).thenReturn(0);
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class, CALLS_REAL_METHODS);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockDialectDatabaseMetaData("MySQL", QuoteCharacter.BACK_QUOTE, DialectSchemaSemantics.DATABASE_AS_SCHEMA, typedSPILoader, databaseTypedSPILoader);
-            WorkflowProxyQueryService service = createService(Map.of("logic_db", runtimeDatabaseConfig));
-            String actual = service.queryColumnDefinition("`logic_db`", "`public`", "order detail", "amount due");
-            assertThat(actual, is("VARCHAR(4000)"));
-            verify(connection).setSchema("public");
-        }
-    }
-    
-    @Test
-    void assertQueryColumnDefinitionFormatsPostgreSQLIdentifiers() throws SQLException {
-        RuntimeDatabaseConfiguration runtimeDatabaseConfig = mock(RuntimeDatabaseConfiguration.class);
-        Connection connection = mock(Connection.class);
-        Statement statement = mock(Statement.class);
-        ResultSet resultSet = mock(ResultSet.class);
-        ResultSetMetaData resultSetMetaData = mock(ResultSetMetaData.class);
-        when(runtimeDatabaseConfig.openConnection("logic_db")).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery("SELECT \"amount due\" FROM \"order detail\" WHERE 1 = 0")).thenReturn(resultSet);
-        when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
-        when(resultSetMetaData.getColumnCount()).thenReturn(0);
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class, CALLS_REAL_METHODS);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockDialectDatabaseMetaData("PostgreSQL", QuoteCharacter.QUOTE, DialectSchemaSemantics.NATIVE_SCHEMA, typedSPILoader, databaseTypedSPILoader);
-            WorkflowProxyQueryService service = createService(Map.of("logic_db", runtimeDatabaseConfig), "PostgreSQL");
-            String actual = service.queryColumnDefinition("\"logic_db\"", "\"public\"", "order detail", "amount due");
-            assertThat(actual, is("VARCHAR(4000)"));
-            verify(connection).setSchema("public");
-        }
-    }
-    
     private WorkflowProxyQueryService createService(final Map<String, RuntimeDatabaseConfiguration> runtimeDatabases) {
         return createService(runtimeDatabases, "MySQL");
     }
@@ -247,18 +150,6 @@ class WorkflowProxyQueryServiceTest {
         MCPDatabaseCapabilityProvider databaseCapabilityProvider = mock(MCPDatabaseCapabilityProvider.class);
         when(databaseCapabilityProvider.provide("logic_db")).thenReturn(Optional.of(databaseCapability));
         return new WorkflowProxyQueryService(new MCPSessionManager(runtimeDatabases), databaseCapabilityProvider);
-    }
-    
-    private void mockDialectDatabaseMetaData(final String databaseType, final QuoteCharacter quoteCharacter, final DialectSchemaSemantics schemaSemantics,
-                                             final MockedStatic<TypedSPILoader> typedSPILoader, final MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader) {
-        DatabaseType databaseTypeFromSPI = mock(DatabaseType.class);
-        when(databaseTypeFromSPI.getTrunkDatabaseType()).thenReturn(Optional.empty());
-        typedSPILoader.when(() -> TypedSPILoader.findService(DatabaseType.class, databaseType)).thenReturn(Optional.of(databaseTypeFromSPI));
-        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
-        when(dialectDatabaseMetaData.getQuoteCharacter()).thenReturn(quoteCharacter);
-        when(dialectDatabaseMetaData.getSchemaOption()).thenReturn(new DefaultSchemaOption(false, null, schemaSemantics));
-        when(dialectDatabaseMetaData.getSequenceOption()).thenReturn(Optional.empty());
-        databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(DialectDatabaseMetaData.class, databaseTypeFromSPI)).thenReturn(Optional.of(dialectDatabaseMetaData));
     }
     
 }

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastRuleInspectionService.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastRuleInspectionService.java
@@ -36,7 +36,7 @@ public final class BroadcastRuleInspectionService {
      * @return broadcast rule rows
      */
     public List<Map<String, Object>> queryBroadcastRules(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW BROADCAST TABLE RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW BROADCAST TABLE RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
     /**
@@ -47,6 +47,6 @@ public final class BroadcastRuleInspectionService {
      * @return broadcast rule count rows
      */
     public List<Map<String, Object>> queryBroadcastRuleCount(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("COUNT BROADCAST RULE FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("COUNT BROADCAST RULE FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
 }

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastRuleInspectionServiceTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastRuleInspectionServiceTest.java
@@ -34,7 +34,7 @@ class BroadcastRuleInspectionServiceTest {
     void assertQueryBroadcastRules() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         List<Map<String, Object>> rows = List.of(Map.of("broadcast_table", "t_order"));
-        when(queryFacade.query("logic_db", "", "SHOW BROADCAST TABLE RULES FROM logic_db")).thenReturn(rows);
+        when(queryFacade.query("logic_db", "SHOW BROADCAST TABLE RULES FROM logic_db")).thenReturn(rows);
         assertThat(new BroadcastRuleInspectionService().queryBroadcastRules(queryFacade, "logic_db"), is(rows));
     }
     
@@ -42,7 +42,7 @@ class BroadcastRuleInspectionServiceTest {
     void assertQueryBroadcastRuleCount() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         List<Map<String, Object>> rows = List.of(Map.of("rule_name", "broadcast_table", "count", 1));
-        when(queryFacade.query("logic_db", "", "COUNT BROADCAST RULE FROM logic_db")).thenReturn(rows);
+        when(queryFacade.query("logic_db", "COUNT BROADCAST RULE FROM logic_db")).thenReturn(rows);
         assertThat(new BroadcastRuleInspectionService().queryBroadcastRuleCount(queryFacade, "logic_db"), is(rows));
     }
 }

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowPlanningServiceTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowPlanningServiceTest.java
@@ -116,7 +116,7 @@ class BroadcastWorkflowPlanningServiceTest {
         MCPFeatureQueryFacade result = mock(MCPFeatureQueryFacade.class);
         when(result.isSameIdentifier("logic_db", IdentifierScope.TABLE, "t_order", "t_order")).thenReturn(true);
         when(result.isSameIdentifier("logic_db", IdentifierScope.TABLE, "t_order_item", "t_order_item")).thenReturn(true);
-        when(result.query(eq("logic_db"), eq(""), any())).thenReturn(broadcastRules);
+        when(result.query(eq("logic_db"), any())).thenReturn(broadcastRules);
         return result;
     }
     

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleInspectionServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleInspectionServiceTest.java
@@ -43,7 +43,7 @@ class EncryptRuleInspectionServiceTest {
     @Test
     void assertQueryEncryptRulesForDatabase() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW ENCRYPT RULES FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW ENCRYPT RULES FROM logic_db"))
                 .thenReturn(List.of(Map.of("logic_column", "phone", "assisted_query_column", "phone_assisted")));
         List<Map<String, Object>> actual = service.queryEncryptRules(queryFacade, "logic_db");
         assertThat(actual.size(), is(1));
@@ -53,7 +53,7 @@ class EncryptRuleInspectionServiceTest {
     @Test
     void assertQueryEncryptRulesForDatabaseWithUnavailableDistSQL() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW ENCRYPT RULES FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW ENCRYPT RULES FROM logic_db"))
                 .thenThrow(new MCPQueryFailedException("syntax error near 'ENCRYPT RULES FROM logic_db'", new SQLSyntaxErrorException("syntax error")));
         assertTrue(service.queryEncryptRules(queryFacade, "logic_db").isEmpty());
     }
@@ -61,7 +61,7 @@ class EncryptRuleInspectionServiceTest {
     @Test
     void assertQueryEncryptRules() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW ENCRYPT TABLE RULE orders FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW ENCRYPT TABLE RULE orders FROM logic_db"))
                 .thenReturn(List.of(Map.of("logic_column", "phone", "like_query_column", "phone_like")));
         List<Map<String, Object>> actual = service.queryEncryptRules(queryFacade, "logic_db", "orders");
         assertThat(actual.getFirst().get("like_query_column"), is("phone_like"));
@@ -70,7 +70,7 @@ class EncryptRuleInspectionServiceTest {
     @Test
     void assertQueryEncryptRulesWithUnavailableDistSQL() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW ENCRYPT TABLE RULE orders FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW ENCRYPT TABLE RULE orders FROM logic_db"))
                 .thenThrow(new MCPQueryFailedException("syntax error near 'ENCRYPT TABLE RULE orders FROM logic_db'", new SQLSyntaxErrorException("syntax error")));
         assertTrue(service.queryEncryptRules(queryFacade, "logic_db", "orders").isEmpty());
     }
@@ -78,7 +78,7 @@ class EncryptRuleInspectionServiceTest {
     @Test
     void assertQueryEncryptRulesPropagatesQueryFailure() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW ENCRYPT TABLE RULE orders FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW ENCRYPT TABLE RULE orders FROM logic_db"))
                 .thenThrow(new MCPQueryFailedException("Connection refused.", new SQLException("Connection refused.")));
         assertThrows(MCPQueryFailedException.class, () -> service.queryEncryptRules(queryFacade, "logic_db", "orders"));
     }
@@ -86,7 +86,7 @@ class EncryptRuleInspectionServiceTest {
     @Test
     void assertQueryEncryptRulesQuotesUnicodeNames() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("逻辑库", "", "SHOW ENCRYPT TABLE RULE `订单` FROM `逻辑库`"))
+        when(queryFacade.query("逻辑库", "SHOW ENCRYPT TABLE RULE `订单` FROM `逻辑库`"))
                 .thenReturn(List.of(Map.of("logic_column", "phone")));
         List<Map<String, Object>> actual = service.queryEncryptRules(queryFacade, "逻辑库", "订单");
         assertThat(actual.getFirst().get("logic_column"), is("phone"));

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskRuleInspectionServiceTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskRuleInspectionServiceTest.java
@@ -41,7 +41,7 @@ class MaskRuleInspectionServiceTest {
     @Test
     void assertQueryMaskRulesForDatabase() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW MASK RULES FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW MASK RULES FROM logic_db"))
                 .thenReturn(List.of(Map.of("column", "phone", "algorithm_type", "MASK_FROM_X_TO_Y", "algorithm_props", "from-x=4")));
         List<Map<String, Object>> actual = service.queryMaskRules(queryFacade, "logic_db");
         assertThat(actual.size(), is(1));
@@ -53,7 +53,7 @@ class MaskRuleInspectionServiceTest {
     @Test
     void assertQueryMaskRulesForDatabaseWithUnavailableDistSQL() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW MASK RULES FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW MASK RULES FROM logic_db"))
                 .thenThrow(new MCPQueryFailedException("syntax error near 'MASK RULES FROM logic_db'", new SQLSyntaxErrorException("syntax error")));
         assertTrue(service.queryMaskRules(queryFacade, "logic_db").isEmpty());
     }
@@ -61,7 +61,7 @@ class MaskRuleInspectionServiceTest {
     @Test
     void assertQueryMaskRules() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW MASK RULE orders FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW MASK RULE orders FROM logic_db"))
                 .thenReturn(List.of(Map.of("column", "phone", "algorithm_type", "MD5")));
         List<Map<String, Object>> actual = service.queryMaskRules(queryFacade, "logic_db", "orders");
         assertThat(actual.getFirst().get("column"), is("phone"));
@@ -70,7 +70,7 @@ class MaskRuleInspectionServiceTest {
     @Test
     void assertQueryMaskRulesWithUnavailableDistSQL() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW MASK RULE orders FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW MASK RULE orders FROM logic_db"))
                 .thenThrow(new MCPQueryFailedException("syntax error near 'MASK RULE orders FROM logic_db'", new SQLSyntaxErrorException("syntax error")));
         assertTrue(service.queryMaskRules(queryFacade, "logic_db", "orders").isEmpty());
     }
@@ -78,7 +78,7 @@ class MaskRuleInspectionServiceTest {
     @Test
     void assertQueryMaskRulesPropagatesQueryFailure() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW MASK RULE orders FROM logic_db"))
+        when(queryFacade.query("logic_db", "SHOW MASK RULE orders FROM logic_db"))
                 .thenThrow(new MCPQueryFailedException("Connection refused.", new SQLException("Connection refused.")));
         assertThrows(MCPQueryFailedException.class, () -> service.queryMaskRules(queryFacade, "logic_db", "orders"));
     }
@@ -86,7 +86,7 @@ class MaskRuleInspectionServiceTest {
     @Test
     void assertQueryMaskRulesQuotesUnicodeNames() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("逻辑库", "", "SHOW MASK RULE `订单` FROM `逻辑库`"))
+        when(queryFacade.query("逻辑库", "SHOW MASK RULE `订单` FROM `逻辑库`"))
                 .thenReturn(List.of(Map.of("column", "phone", "algorithm_type", "MD5")));
         List<Map<String, Object>> actual = service.queryMaskRules(queryFacade, "逻辑库", "订单");
         assertThat(actual.getFirst().get("column"), is("phone"));

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingInspectionService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingInspectionService.java
@@ -40,7 +40,7 @@ public final class ReadwriteSplittingInspectionService {
      * @return readwrite-splitting rules
      */
     public List<Map<String, Object>> queryRules(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW READWRITE_SPLITTING RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW READWRITE_SPLITTING RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
     /**
@@ -52,7 +52,7 @@ public final class ReadwriteSplittingInspectionService {
      * @return readwrite-splitting rule rows
      */
     public List<Map<String, Object>> queryRule(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String ruleName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW READWRITE_SPLITTING RULE %s FROM %s",
+        return queryFacade.query(databaseName, String.format("SHOW READWRITE_SPLITTING RULE %s FROM %s",
                 WorkflowSQLUtils.formatDistSQLIdentifier(ruleName), WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
@@ -64,7 +64,7 @@ public final class ReadwriteSplittingInspectionService {
      * @return count rows
      */
     public List<Map<String, Object>> queryRuleCount(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("COUNT READWRITE_SPLITTING RULE FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("COUNT READWRITE_SPLITTING RULE FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
     /**
@@ -75,7 +75,7 @@ public final class ReadwriteSplittingInspectionService {
      * @return status rows
      */
     public List<Map<String, Object>> queryStatuses(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW STATUS FROM READWRITE_SPLITTING RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW STATUS FROM READWRITE_SPLITTING RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
     /**
@@ -87,7 +87,7 @@ public final class ReadwriteSplittingInspectionService {
      * @return status rows
      */
     public List<Map<String, Object>> queryRuleStatus(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String ruleName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW STATUS FROM READWRITE_SPLITTING RULE %s FROM %s",
+        return queryFacade.query(databaseName, String.format("SHOW STATUS FROM READWRITE_SPLITTING RULE %s FROM %s",
                 WorkflowSQLUtils.formatDistSQLIdentifier(ruleName), WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingInspectionServiceTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingInspectionServiceTest.java
@@ -42,14 +42,14 @@ class ReadwriteSplittingInspectionServiceTest {
     void assertQueryRules() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         new ReadwriteSplittingInspectionService().queryRules(queryFacade, "logic_db");
-        verify(queryFacade).query(eq("logic_db"), eq(""), eq("SHOW READWRITE_SPLITTING RULES FROM logic_db"));
+        verify(queryFacade).query(eq("logic_db"), eq("SHOW READWRITE_SPLITTING RULES FROM logic_db"));
     }
     
     @Test
     void assertQueryRuleStatus() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         new ReadwriteSplittingInspectionService().queryRuleStatus(queryFacade, "logic_db", "readwrite_ds");
-        verify(queryFacade).query(eq("logic_db"), eq(""), eq("SHOW STATUS FROM READWRITE_SPLITTING RULE readwrite_ds FROM logic_db"));
+        verify(queryFacade).query(eq("logic_db"), eq("SHOW STATUS FROM READWRITE_SPLITTING RULE readwrite_ds FROM logic_db"));
     }
     
     @Test
@@ -81,7 +81,7 @@ class ReadwriteSplittingInspectionServiceTest {
     @Test
     void assertQueryRuleCount() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query(eq("logic_db"), eq(""), eq("COUNT READWRITE_SPLITTING RULE FROM logic_db"))).thenReturn(List.of(Map.of("count", 1)));
+        when(queryFacade.query(eq("logic_db"), eq("COUNT READWRITE_SPLITTING RULE FROM logic_db"))).thenReturn(List.of(Map.of("count", 1)));
         assertThat(new ReadwriteSplittingInspectionService().queryRuleCount(queryFacade, "logic_db"), is(List.of(Map.of("count", 1))));
     }
 }

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowPlanningServicesTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowPlanningServicesTest.java
@@ -189,7 +189,7 @@ class ReadwriteSplittingWorkflowPlanningServicesTest {
     private MCPFeatureQueryFacade mockRuleQueryFacade(final List<Map<String, Object>> rules) {
         MCPFeatureQueryFacade result = mock(MCPFeatureQueryFacade.class);
         when(result.isSameIdentifier("logic_db", IdentifierScope.TABLE, "readwrite_ds", "readwrite_ds")).thenReturn(true);
-        when(result.query(eq("logic_db"), eq(""), any())).thenReturn(rules);
+        when(result.query(eq("logic_db"), any())).thenReturn(rules);
         return result;
     }
     
@@ -197,7 +197,7 @@ class ReadwriteSplittingWorkflowPlanningServicesTest {
         MCPFeatureQueryFacade result = mock(MCPFeatureQueryFacade.class);
         when(result.isSameIdentifier("logic_db", IdentifierScope.TABLE, "readwrite_ds", "readwrite_ds")).thenReturn(true);
         when(result.isSameIdentifier("logic_db", IdentifierScope.TABLE, "read_ds_0", "read_ds_0")).thenReturn(true);
-        when(result.query(eq("logic_db"), eq(""), any())).thenReturn(statuses);
+        when(result.query(eq("logic_db"), any())).thenReturn(statuses);
         return result;
     }
     

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowInspectionService.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowInspectionService.java
@@ -40,7 +40,7 @@ public final class ShadowInspectionService {
      * @return shadow rule rows
      */
     public List<Map<String, Object>> queryRules(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHADOW RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHADOW RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
     /**
@@ -52,7 +52,7 @@ public final class ShadowInspectionService {
      * @return shadow rule rows
      */
     public List<Map<String, Object>> queryRule(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String ruleName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHADOW RULE %s FROM %s",
+        return queryFacade.query(databaseName, String.format("SHOW SHADOW RULE %s FROM %s",
                 WorkflowSQLUtils.formatDistSQLIdentifier(ruleName), WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
@@ -64,7 +64,7 @@ public final class ShadowInspectionService {
      * @return shadow table rule rows
      */
     public List<Map<String, Object>> queryTableRules(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHADOW TABLE RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHADOW TABLE RULES FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
     /**
@@ -76,7 +76,7 @@ public final class ShadowInspectionService {
      * @return shadow table rule rows
      */
     public List<Map<String, Object>> queryTableRule(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String tableName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHADOW TABLE RULE %s FROM %s",
+        return queryFacade.query(databaseName, String.format("SHOW SHADOW TABLE RULE %s FROM %s",
                 WorkflowSQLUtils.formatDistSQLIdentifier(tableName), WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
@@ -88,7 +88,7 @@ public final class ShadowInspectionService {
      * @return configured shadow algorithm rows
      */
     public List<Map<String, Object>> queryAlgorithms(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHADOW ALGORITHMS FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHADOW ALGORITHMS FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
     /**
@@ -99,7 +99,7 @@ public final class ShadowInspectionService {
      * @return default shadow algorithm rows
      */
     public List<Map<String, Object>> queryDefaultAlgorithm(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW DEFAULT SHADOW ALGORITHM FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW DEFAULT SHADOW ALGORITHM FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
     /**
@@ -110,7 +110,7 @@ public final class ShadowInspectionService {
      * @return count rows
      */
     public List<Map<String, Object>> queryRuleCount(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("COUNT SHADOW RULE FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
+        return queryFacade.query(databaseName, String.format("COUNT SHADOW RULE FROM %s", WorkflowSQLUtils.formatDistSQLIdentifier(databaseName)));
     }
     
     /**

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowInspectionServiceTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowInspectionServiceTest.java
@@ -41,21 +41,21 @@ class ShadowInspectionServiceTest {
     void assertQueryRules() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         new ShadowInspectionService().queryRules(queryFacade, "logic_db");
-        verify(queryFacade).query("logic_db", "", "SHOW SHADOW RULES FROM logic_db");
+        verify(queryFacade).query("logic_db", "SHOW SHADOW RULES FROM logic_db");
     }
     
     @Test
     void assertQueryRule() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         new ShadowInspectionService().queryRule(queryFacade, "logic_db", "shadow_rule");
-        verify(queryFacade).query("logic_db", "", "SHOW SHADOW RULE shadow_rule FROM logic_db");
+        verify(queryFacade).query("logic_db", "SHOW SHADOW RULE shadow_rule FROM logic_db");
     }
     
     @Test
     void assertQueryTableRule() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         new ShadowInspectionService().queryTableRule(queryFacade, "logic_db", "t_order");
-        verify(queryFacade).query("logic_db", "", "SHOW SHADOW TABLE RULE t_order FROM logic_db");
+        verify(queryFacade).query("logic_db", "SHOW SHADOW TABLE RULE t_order FROM logic_db");
     }
     
     @Test

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingInspectionService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingInspectionService.java
@@ -90,7 +90,7 @@ public final class ShardingInspectionService {
      * @return sharding algorithm rows
      */
     public List<Map<String, Object>> queryAlgorithms(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING ALGORITHMS FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING ALGORITHMS FROM %s", format(databaseName)));
     }
     
     /**
@@ -101,7 +101,7 @@ public final class ShardingInspectionService {
      * @return sharding table rule rows
      */
     public List<Map<String, Object>> queryTableRules(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING TABLE RULES FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING TABLE RULES FROM %s", format(databaseName)));
     }
     
     /**
@@ -113,7 +113,7 @@ public final class ShardingInspectionService {
      * @return sharding table rule rows
      */
     public List<Map<String, Object>> queryTableRule(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String tableName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING TABLE RULE %s FROM %s", format(tableName), format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING TABLE RULE %s FROM %s", format(tableName), format(databaseName)));
     }
     
     /**
@@ -124,7 +124,7 @@ public final class ShardingInspectionService {
      * @return sharding table node rows
      */
     public List<Map<String, Object>> queryTableNodes(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING TABLE NODES FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING TABLE NODES FROM %s", format(databaseName)));
     }
     
     /**
@@ -136,7 +136,7 @@ public final class ShardingInspectionService {
      * @return sharding table node rows
      */
     public List<Map<String, Object>> queryTableNode(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String tableName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING TABLE NODES %s FROM %s", format(tableName), format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING TABLE NODES %s FROM %s", format(tableName), format(databaseName)));
     }
     
     /**
@@ -147,7 +147,7 @@ public final class ShardingInspectionService {
      * @return table reference rule rows
      */
     public List<Map<String, Object>> queryTableReferenceRules(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING TABLE REFERENCE RULES FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING TABLE REFERENCE RULES FROM %s", format(databaseName)));
     }
     
     /**
@@ -159,7 +159,7 @@ public final class ShardingInspectionService {
      * @return table reference rule rows
      */
     public List<Map<String, Object>> queryTableReferenceRule(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String ruleName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING TABLE REFERENCE RULE %s FROM %s", format(ruleName), format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING TABLE REFERENCE RULE %s FROM %s", format(ruleName), format(databaseName)));
     }
     
     /**
@@ -170,7 +170,7 @@ public final class ShardingInspectionService {
      * @return default sharding strategy rows
      */
     public List<Map<String, Object>> queryDefaultStrategy(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW DEFAULT SHARDING STRATEGY FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW DEFAULT SHARDING STRATEGY FROM %s", format(databaseName)));
     }
     
     /**
@@ -181,7 +181,7 @@ public final class ShardingInspectionService {
      * @return key generator rows
      */
     public List<Map<String, Object>> queryKeyGenerators(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING KEY GENERATORS FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING KEY GENERATORS FROM %s", format(databaseName)));
     }
     
     /**
@@ -193,7 +193,7 @@ public final class ShardingInspectionService {
      * @return key generator rows
      */
     public List<Map<String, Object>> queryKeyGenerator(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String keyGeneratorName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING KEY GENERATOR %s FROM %s", format(keyGeneratorName), format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING KEY GENERATOR %s FROM %s", format(keyGeneratorName), format(databaseName)));
     }
     
     /**
@@ -204,7 +204,7 @@ public final class ShardingInspectionService {
      * @return key generate strategy rows
      */
     public List<Map<String, Object>> queryKeyGenerateStrategies(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING KEY GENERATE STRATEGIES FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING KEY GENERATE STRATEGIES FROM %s", format(databaseName)));
     }
     
     /**
@@ -216,7 +216,7 @@ public final class ShardingInspectionService {
      * @return key generate strategy rows
      */
     public List<Map<String, Object>> queryKeyGenerateStrategy(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String strategyName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING KEY GENERATE STRATEGY %s FROM %s", format(strategyName), format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING KEY GENERATE STRATEGY %s FROM %s", format(strategyName), format(databaseName)));
     }
     
     /**
@@ -227,7 +227,7 @@ public final class ShardingInspectionService {
      * @return auditor rows
      */
     public List<Map<String, Object>> queryAuditors(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING AUDITORS FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING AUDITORS FROM %s", format(databaseName)));
     }
     
     /**
@@ -238,7 +238,7 @@ public final class ShardingInspectionService {
      * @return unused sharding algorithm rows
      */
     public List<Map<String, Object>> queryUnusedAlgorithms(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW UNUSED SHARDING ALGORITHMS FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW UNUSED SHARDING ALGORITHMS FROM %s", format(databaseName)));
     }
     
     /**
@@ -249,7 +249,7 @@ public final class ShardingInspectionService {
      * @return unused sharding key generator rows
      */
     public List<Map<String, Object>> queryUnusedKeyGenerators(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW UNUSED SHARDING KEY GENERATORS FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW UNUSED SHARDING KEY GENERATORS FROM %s", format(databaseName)));
     }
     
     /**
@@ -260,7 +260,7 @@ public final class ShardingInspectionService {
      * @return unused sharding auditor rows
      */
     public List<Map<String, Object>> queryUnusedAuditors(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW UNUSED SHARDING AUDITORS FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW UNUSED SHARDING AUDITORS FROM %s", format(databaseName)));
     }
     
     /**
@@ -272,7 +272,7 @@ public final class ShardingInspectionService {
      * @return table rule rows
      */
     public List<Map<String, Object>> queryTableRulesUsedAlgorithm(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String algorithmName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING TABLE RULES USED ALGORITHM %s FROM %s", format(algorithmName), format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING TABLE RULES USED ALGORITHM %s FROM %s", format(algorithmName), format(databaseName)));
     }
     
     /**
@@ -284,7 +284,7 @@ public final class ShardingInspectionService {
      * @return table rule rows
      */
     public List<Map<String, Object>> queryTableRulesUsedKeyGenerator(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String keyGeneratorName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING TABLE RULES USED KEY GENERATOR %s FROM %s", format(keyGeneratorName), format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING TABLE RULES USED KEY GENERATOR %s FROM %s", format(keyGeneratorName), format(databaseName)));
     }
     
     /**
@@ -296,7 +296,7 @@ public final class ShardingInspectionService {
      * @return table rule rows
      */
     public List<Map<String, Object>> queryTableRulesUsedAuditor(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String auditorName) {
-        return queryFacade.query(databaseName, "", String.format("SHOW SHARDING TABLE RULES USED AUDITOR %s FROM %s", format(auditorName), format(databaseName)));
+        return queryFacade.query(databaseName, String.format("SHOW SHARDING TABLE RULES USED AUDITOR %s FROM %s", format(auditorName), format(databaseName)));
     }
     
     /**
@@ -307,7 +307,7 @@ public final class ShardingInspectionService {
      * @return rule count rows
      */
     public List<Map<String, Object>> queryRuleCount(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
-        return queryFacade.query(databaseName, "", String.format("COUNT SHARDING RULE FROM %s", format(databaseName)));
+        return queryFacade.query(databaseName, String.format("COUNT SHARDING RULE FROM %s", format(databaseName)));
     }
     
     private String format(final String value) {

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingInspectionServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingInspectionServiceTest.java
@@ -47,7 +47,7 @@ class ShardingInspectionServiceTest {
     void assertDatabaseScopedQuery(final String name, final QueryInvocation invocation, final String expectedSQL) {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         invocation.invoke(new ShardingInspectionService(), queryFacade);
-        verify(queryFacade).query(eq("logic_db"), eq(""), eq(expectedSQL));
+        verify(queryFacade).query(eq("logic_db"), eq(expectedSQL));
     }
     
     @Test

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialect.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialect.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.mcp.support.database.capability;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaSemantics;
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.SystemDatabase;
@@ -53,15 +52,6 @@ public final class MCPDatabaseDialect {
         DialectDatabaseMetaData dialectDatabaseMetaData = DatabaseTypedSPILoader.findService(DialectDatabaseMetaData.class, databaseTypeFromSPI)
                 .orElseThrow(() -> new ServiceProviderNotFoundException(DialectDatabaseMetaData.class, actualDatabaseType));
         return new MCPDatabaseDialect(dialectDatabaseMetaData, new SystemDatabase(databaseTypeFromSPI));
-    }
-    
-    /**
-     * Get identifier quote character.
-     *
-     * @return identifier quote character
-     */
-    public QuoteCharacter getIdentifierQuoteCharacter() {
-        return dialectDatabaseMetaData.getQuoteCharacter();
     }
     
     /**

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/spi/MCPFeatureQueryFacade.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/spi/MCPFeatureQueryFacade.java
@@ -32,11 +32,10 @@ public interface MCPFeatureQueryFacade {
      * Query rows from a target database.
      *
      * @param databaseName database name
-     * @param schemaName schema name
      * @param sql SQL text
      * @return query rows
      */
-    List<Map<String, Object>> query(String databaseName, String schemaName, String sql);
+    List<Map<String, Object>> query(String databaseName, String sql);
     
     /**
      * Query rows using any configured database.
@@ -65,16 +64,5 @@ public interface MCPFeatureQueryFacade {
      * @throws DatabaseCapabilityNotFoundException when database capability does not exist
      */
     boolean isSameIdentifier(String databaseName, IdentifierScope identifierScope, String identifier, String existingIdentifier);
-    
-    /**
-     * Query column definition.
-     *
-     * @param databaseName database name
-     * @param schemaName schema name
-     * @param tableName table name
-     * @param columnName column name
-     * @return formatted column definition
-     */
-    String queryColumnDefinition(String databaseName, String schemaName, String tableName, String columnName);
     
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowDistSQLQueryUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowDistSQLQueryUtils.java
@@ -53,7 +53,7 @@ public final class WorkflowDistSQLQueryUtils {
      */
     public static List<Map<String, Object>> queryRuleRows(final MCPFeatureQueryFacade queryFacade, final String databaseName, final String sql) {
         try {
-            return queryFacade.query(databaseName, "", sql);
+            return queryFacade.query(databaseName, sql);
         } catch (final MCPQueryFailedException ex) {
             if (isUnsupportedDistSQLQueryFailure(ex)) {
                 return List.of();

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtils.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.enums
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPInvalidRequestException;
-import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseDialect;
 
 import java.util.Locale;
 import java.util.Map;
@@ -119,22 +118,6 @@ public final class WorkflowSQLUtils {
         String actualIdentifier = normalizeIdentifier(trimToEmpty(identifier));
         checkSupportedIdentifier("identifier", actualIdentifier);
         return actualIdentifier.isEmpty() ? actualIdentifier : wrapIdentifier(QuoteCharacter.BACK_QUOTE, actualIdentifier);
-    }
-    
-    /**
-     * Format a database SQL identifier.
-     *
-     * @param databaseType database type
-     * @param identifier identifier to format
-     * @return formatted SQL identifier
-     */
-    public static String formatSQLIdentifier(final String databaseType, final String identifier) {
-        String rawIdentifier = trimToEmpty(identifier);
-        String actualIdentifier = normalizeIdentifier(rawIdentifier);
-        checkSupportedIdentifier("identifier", actualIdentifier);
-        return actualIdentifier.isEmpty() || !isSpecialSQLIdentifier(actualIdentifier) && !isDelimitedIdentifier(rawIdentifier)
-                ? actualIdentifier
-                : wrapIdentifier(MCPDatabaseDialect.of(databaseType).getIdentifierQuoteCharacter(), actualIdentifier);
     }
     
     /**

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowValidationSupport.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowValidationSupport.java
@@ -96,19 +96,6 @@ public final class WorkflowValidationSupport {
     }
     
     /**
-     * Create the baseline projection SQL used by workflow validation.
-     *
-     * @param snapshot workflow snapshot
-     * @param databaseType database type
-     * @return projection validation SQL
-     */
-    public String createProjectionValidationSql(final WorkflowContextSnapshot snapshot, final String databaseType) {
-        String columnName = WorkflowSQLUtils.formatSQLIdentifier(databaseType, snapshot.getRequest().getColumn());
-        String tableName = WorkflowSQLUtils.formatSQLIdentifier(databaseType, snapshot.getRequest().getTable());
-        return String.format("SELECT %s FROM %s", columnName, tableName);
-    }
-    
-    /**
      * Persist validation result and create response payload.
      *
      * @param workflowSessionContext workflow session context

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialectTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialectTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.mcp.support.database.capability;
 
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaSemantics;
@@ -28,14 +27,10 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.exception.ServiceProviderNotFoundException;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -51,20 +46,6 @@ class MCPDatabaseDialectTest {
     @Test
     void assertOfWithEmptyDatabaseType() {
         assertThrows(ServiceProviderNotFoundException.class, () -> MCPDatabaseDialect.of(""));
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("getIdentifierQuoteCharacterArguments")
-    void assertGetIdentifierQuoteCharacter(final String name, final String databaseType, final QuoteCharacter expected) {
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            DatabaseType databaseTypeFromSPI = mockDatabaseType(databaseType, typedSPILoader);
-            DialectDatabaseMetaData dialectDatabaseMetaData = mockDialectDatabaseMetaData(databaseTypeFromSPI, databaseTypedSPILoader);
-            when(dialectDatabaseMetaData.getQuoteCharacter()).thenReturn(expected);
-            QuoteCharacter actual = MCPDatabaseDialect.of(databaseType).getIdentifierQuoteCharacter();
-            assertThat(actual, is(expected));
-        }
     }
     
     @Test
@@ -170,13 +151,6 @@ class MCPDatabaseDialectTest {
             when(dialectSystemDatabase.getSystemSchemas()).thenReturn(List.of("fixture_system"));
             assertFalse(MCPDatabaseDialect.of("Fixture").isSystemSchema("pg_catalog"));
         }
-    }
-    
-    private static Stream<Arguments> getIdentifierQuoteCharacterArguments() {
-        return Stream.of(
-                Arguments.of("back quote", "FixtureBackQuote", QuoteCharacter.BACK_QUOTE),
-                Arguments.of("brackets", "FixtureBrackets", QuoteCharacter.BRACKETS),
-                Arguments.of("quote", "FixtureQuote", QuoteCharacter.QUOTE));
     }
     
     private static DatabaseType mockDatabaseType(final String databaseType, final MockedStatic<TypedSPILoader> typedSPILoader) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowDistSQLQueryUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowDistSQLQueryUtilsTest.java
@@ -62,14 +62,14 @@ class WorkflowDistSQLQueryUtilsTest {
     void assertQueryRuleRows() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         List<Map<String, Object>> expected = List.of(Map.of("name", "orders"));
-        when(queryFacade.query("logic_db", "", "SHOW MASK RULES")).thenReturn(expected);
+        when(queryFacade.query("logic_db", "SHOW MASK RULES")).thenReturn(expected);
         assertThat(WorkflowDistSQLQueryUtils.queryRuleRows(queryFacade, "logic_db", "SHOW MASK RULES"), is(expected));
     }
     
     @Test
     void assertQueryRuleRowsWithUnsupportedDistSQL() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
-        when(queryFacade.query("logic_db", "", "SHOW MASK RULES")).thenThrow(
+        when(queryFacade.query("logic_db", "SHOW MASK RULES")).thenThrow(
                 new MCPDatabaseQueryFailedException(MCPJDBCErrorCategory.SYNTAX, new SQLException("syntax error", "42601")));
         assertTrue(WorkflowDistSQLQueryUtils.queryRuleRows(queryFacade, "logic_db", "SHOW MASK RULES").isEmpty());
     }
@@ -78,7 +78,7 @@ class WorkflowDistSQLQueryUtilsTest {
     void assertQueryRuleRowsWithConnectionFailure() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         MCPQueryFailedException expected = new MCPQueryFailedException("Connection refused.", new SQLException("Connection refused."));
-        when(queryFacade.query("logic_db", "", "SHOW MASK RULES")).thenThrow(expected);
+        when(queryFacade.query("logic_db", "SHOW MASK RULES")).thenThrow(expected);
         MCPQueryFailedException actual = assertThrows(MCPQueryFailedException.class, () -> WorkflowDistSQLQueryUtils.queryRuleRows(queryFacade, "logic_db", "SHOW MASK RULES"));
         assertThat(actual, sameInstance(expected));
     }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtilsTest.java
@@ -17,22 +17,14 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.service;
 
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
-import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.spi.exception.ServiceProviderNotFoundException;
-import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.MockedStatic;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,10 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
 
 class WorkflowSQLUtilsTest {
     
@@ -145,74 +133,6 @@ class WorkflowSQLUtilsTest {
     }
     
     @Test
-    void assertFormatSQLIdentifierUsesMysqlQuoteStyle() {
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class, CALLS_REAL_METHODS);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockQuoteCharacter("MySQL", QuoteCharacter.BACK_QUOTE, typedSPILoader, databaseTypedSPILoader);
-            String actualValue = WorkflowSQLUtils.formatSQLIdentifier("MySQL", "order detail");
-            assertThat(actualValue, is("`order detail`"));
-        }
-    }
-    
-    @Test
-    void assertFormatSQLIdentifierKeepsSafeIdentifier() {
-        String actualValue = WorkflowSQLUtils.formatSQLIdentifier("MySQL", "orders_01");
-        assertThat(actualValue, is("orders_01"));
-    }
-    
-    @Test
-    void assertFormatSQLIdentifierKeepsPostgreSQLMixedCaseIdentifier() {
-        String actualValue = WorkflowSQLUtils.formatSQLIdentifier("PostgreSQL", "Phone");
-        assertThat(actualValue, is("Phone"));
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("getSQLPlainIdentifierCases")
-    void assertFormatSQLIdentifierKeepsPlainIdentifier(final String name, final String databaseType, final String identifier, final String expectedValue) {
-        String actualValue = WorkflowSQLUtils.formatSQLIdentifier(databaseType, identifier);
-        assertThat(actualValue, is(expectedValue));
-    }
-    
-    @Test
-    void assertFormatSQLIdentifierRejectsEmptyDatabaseType() {
-        assertThrows(ServiceProviderNotFoundException.class, () -> WorkflowSQLUtils.formatSQLIdentifier("", "order detail"));
-    }
-    
-    @Test
-    void assertFormatSQLIdentifierUsesPostgreSQLQuoteStyle() {
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class, CALLS_REAL_METHODS);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockQuoteCharacter("PostgreSQL", QuoteCharacter.QUOTE, typedSPILoader, databaseTypedSPILoader);
-            String actualValue = WorkflowSQLUtils.formatSQLIdentifier("PostgreSQL", "order detail");
-            assertThat(actualValue, is("\"order detail\""));
-        }
-    }
-    
-    @Test
-    void assertFormatSQLIdentifierUsesSQLServerQuoteStyle() {
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class, CALLS_REAL_METHODS);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockQuoteCharacter("SQLServer", QuoteCharacter.BRACKETS, typedSPILoader, databaseTypedSPILoader);
-            String actualValue = WorkflowSQLUtils.formatSQLIdentifier("SQLServer", "order detail");
-            assertThat(actualValue, is("[order detail]"));
-        }
-    }
-    
-    @Test
-    void assertFormatSQLIdentifierPreservesDelimitedSafeIdentifier() {
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class, CALLS_REAL_METHODS);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockQuoteCharacter("PostgreSQL", QuoteCharacter.QUOTE, typedSPILoader, databaseTypedSPILoader);
-            String actualValue = WorkflowSQLUtils.formatSQLIdentifier("PostgreSQL", "\"orders\"");
-            assertThat(actualValue, is("\"orders\""));
-        }
-    }
-    
-    @Test
     void assertIsSameIdentifierWithCaseInsensitiveDatabase() {
         assertTrue(WorkflowSQLUtils.isSameIdentifier(IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.TABLE), "Phone", "phone"));
     }
@@ -286,28 +206,4 @@ class WorkflowSQLUtilsTest {
                 Arguments.of("quote uppercase algorithm keyword", "AES", "`AES`"));
     }
     
-    private static Stream<Arguments> getSQLPlainIdentifierCases() {
-        return Stream.of(
-                Arguments.of("keep MySQL rank identifier", "MySQL", "rank", "rank"),
-                Arguments.of("keep MySQL user identifier", "MySQL", "user", "user"),
-                Arguments.of("keep PostgreSQL key identifier", "PostgreSQL", "key", "key"),
-                Arguments.of("keep PostgreSQL user identifier", "PostgreSQL", "user", "user"));
-    }
-    
-    private static void mockQuoteCharacter(final String databaseType, final QuoteCharacter quoteCharacter,
-                                           final MockedStatic<TypedSPILoader> typedSPILoader, final MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader) {
-        DialectDatabaseMetaData dialectDatabaseMetaData = mockDialectDatabaseMetaData(databaseType, typedSPILoader, databaseTypedSPILoader);
-        when(dialectDatabaseMetaData.getQuoteCharacter()).thenReturn(quoteCharacter);
-    }
-    
-    private static DialectDatabaseMetaData mockDialectDatabaseMetaData(final String databaseType,
-                                                                       final MockedStatic<TypedSPILoader> typedSPILoader,
-                                                                       final MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader) {
-        DatabaseType databaseTypeFromSPI = mock(DatabaseType.class);
-        when(databaseTypeFromSPI.getTrunkDatabaseType()).thenReturn(Optional.empty());
-        typedSPILoader.when(() -> TypedSPILoader.findService(DatabaseType.class, databaseType)).thenReturn(Optional.of(databaseTypeFromSPI));
-        DialectDatabaseMetaData result = mock(DialectDatabaseMetaData.class);
-        databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(DialectDatabaseMetaData.class, databaseTypeFromSPI)).thenReturn(Optional.of(result));
-        return result;
-    }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowValidationSupportTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowValidationSupportTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.service;
 
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
-import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.InteractionPlan;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationReport;
@@ -31,22 +26,16 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
 
 class WorkflowValidationSupportTest {
     
@@ -130,37 +119,6 @@ class WorkflowValidationSupportTest {
                 new ValidationSection("failed", List.of(), ""),
                 new ValidationSection("passed", List.of(), ""));
         assertThat(actualStatus, is("failed"));
-    }
-    
-    @Test
-    void assertCreateProjectionValidationSql() {
-        assertThat(validationSupport.createProjectionValidationSql(createSnapshot(), "MySQL"), is("SELECT phone FROM orders"));
-    }
-    
-    @Test
-    void assertCreateProjectionValidationSqlWithSpecialCharacterIdentifiers() {
-        WorkflowContextSnapshot snapshot = createSnapshot();
-        snapshot.getRequest().setTable("order detail");
-        snapshot.getRequest().setColumn("Phone Number");
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class, CALLS_REAL_METHODS);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockQuoteCharacter("MySQL", QuoteCharacter.BACK_QUOTE, typedSPILoader, databaseTypedSPILoader);
-            assertThat(validationSupport.createProjectionValidationSql(snapshot, "MySQL"), is("SELECT `Phone Number` FROM `order detail`"));
-        }
-    }
-    
-    @Test
-    void assertCreateProjectionValidationSqlWithPostgreSQLIdentifiers() {
-        WorkflowContextSnapshot snapshot = createSnapshot();
-        snapshot.getRequest().setTable("order detail");
-        snapshot.getRequest().setColumn("Phone Number");
-        try (
-                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class, CALLS_REAL_METHODS);
-                MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockQuoteCharacter("PostgreSQL", QuoteCharacter.QUOTE, typedSPILoader, databaseTypedSPILoader);
-            assertThat(validationSupport.createProjectionValidationSql(snapshot, "PostgreSQL"), is("SELECT \"Phone Number\" FROM \"order detail\""));
-        }
     }
     
     @Test
@@ -248,16 +206,6 @@ class WorkflowValidationSupportTest {
         assertThat(actualMismatch.get("actual"), is("actual"));
         assertThat(actualMismatch.get("impact"), is("impact"));
         assertThat(actualMismatch.get("remediation"), is("fix it"));
-    }
-    
-    private static void mockQuoteCharacter(final String databaseType, final QuoteCharacter quoteCharacter,
-                                           final MockedStatic<TypedSPILoader> typedSPILoader, final MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader) {
-        DatabaseType databaseTypeFromSPI = mock(DatabaseType.class);
-        when(databaseTypeFromSPI.getTrunkDatabaseType()).thenReturn(Optional.empty());
-        typedSPILoader.when(() -> TypedSPILoader.findService(DatabaseType.class, databaseType)).thenReturn(Optional.of(databaseTypeFromSPI));
-        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
-        when(dialectDatabaseMetaData.getQuoteCharacter()).thenReturn(quoteCharacter);
-        databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(DialectDatabaseMetaData.class, databaseTypeFromSPI)).thenReturn(Optional.of(dialectDatabaseMetaData));
     }
     
     private WorkflowContextSnapshot createSnapshot() {


### PR DESCRIPTION
- simplify the MCP feature query facade
- remove obsolete column definition and identifier formatting logic
- clean up related callers and tests

