### PR TITLE
Preserve JDBC setter semantics when replaying prepared statement parameters

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
 1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)
 1. Metadata: Fix Oracle metadata version comparison skipping identity and collation columns on 18c and later - [#39104](https://github.com/apache/shardingsphere/pull/39104)
+1. JDBC: Preserve JDBC setter semantics when replaying prepared statement parameters - [#39161](https://github.com/apache/shardingsphere/pull/39161)
 
 ### Enhancements
 

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractPreparedStatementAdapter.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractPreparedStatementAdapter.java
@@ -17,12 +17,10 @@
 
 package org.apache.shardingsphere.driver.jdbc.adapter;
 
-import com.google.common.io.CharStreams;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.driver.jdbc.unsupported.AbstractUnsupportedOperationPreparedStatement;
-import org.apache.shardingsphere.infra.exception.generic.UnknownSQLException;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -39,6 +37,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Adapter for {@code PreparedStatement}.
@@ -48,14 +47,16 @@ public abstract class AbstractPreparedStatementAdapter extends AbstractUnsupport
     @Getter
     private final List<Object> parameters = new ArrayList<>();
     
+    private final List<ReplaySetParameter> setParameterContexts = new ArrayList<>();
+    
     @Override
     public final void setNull(final int parameterIndex, final int sqlType) {
-        setParameter(parameterIndex, null);
+        setParameter(parameterIndex, null, new ReplaySetParameter(ReplayMethod.SET_NULL, new Object[]{sqlType}));
     }
     
     @Override
     public final void setNull(final int parameterIndex, final int sqlType, final String typeName) {
-        setParameter(parameterIndex, null);
+        setParameter(parameterIndex, null, new ReplaySetParameter(ReplayMethod.SET_NULL_WITH_NAME, new Object[]{sqlType, typeName}));
     }
     
     @Override
@@ -140,32 +141,32 @@ public abstract class AbstractPreparedStatementAdapter extends AbstractUnsupport
     
     @Override
     public final void setBlob(final int parameterIndex, final Blob x) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_BLOB, new Object[0]));
     }
     
     @Override
     public final void setBlob(final int parameterIndex, final InputStream x) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_BLOB_STREAM, new Object[0]));
     }
     
     @Override
     public final void setBlob(final int parameterIndex, final InputStream x, final long length) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_BLOB_STREAM_WITH_LENGTH, new Object[]{length}));
     }
     
     @Override
     public final void setClob(final int parameterIndex, final Clob x) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_CLOB, new Object[0]));
     }
     
     @Override
     public final void setClob(final int parameterIndex, final Reader x) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_CLOB_READER, new Object[0]));
     }
     
     @Override
     public final void setClob(final int parameterIndex, final Reader x, final long length) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_CLOB_READER_WITH_LENGTH, new Object[]{length}));
     }
     
     @Override
@@ -175,64 +176,52 @@ public abstract class AbstractPreparedStatementAdapter extends AbstractUnsupport
     
     @Override
     public final void setAsciiStream(final int parameterIndex, final InputStream x) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_ASCII_STREAM, new Object[0]));
     }
     
     @Override
     public final void setAsciiStream(final int parameterIndex, final InputStream x, final int length) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_ASCII_STREAM_WITH_INT_LENGTH, new Object[]{length}));
     }
     
     @Override
     public final void setAsciiStream(final int parameterIndex, final InputStream x, final long length) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_ASCII_STREAM_WITH_LONG_LENGTH, new Object[]{length}));
     }
     
     @Override
     public final void setUnicodeStream(final int parameterIndex, final InputStream x, final int length) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_UNICODE_STREAM, new Object[]{length}));
     }
     
     @Override
     public final void setBinaryStream(final int parameterIndex, final InputStream x) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_BINARY_STREAM, new Object[0]));
     }
     
     @Override
     public final void setBinaryStream(final int parameterIndex, final InputStream x, final int length) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_BINARY_STREAM_WITH_INT_LENGTH, new Object[]{length}));
     }
     
     @Override
     public final void setBinaryStream(final int parameterIndex, final InputStream x, final long length) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_BINARY_STREAM_WITH_LONG_LENGTH, new Object[]{length}));
     }
     
     @Override
     public final void setCharacterStream(final int parameterIndex, final Reader x) {
-        try {
-            setParameter(parameterIndex, CharStreams.toString(x));
-        } catch (final IOException ex) {
-            throw new UnknownSQLException(ex);
-        }
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_CHARACTER_STREAM, new Object[0]));
     }
     
     @Override
     public final void setCharacterStream(final int parameterIndex, final Reader x, final int length) {
-        try {
-            setParameter(parameterIndex, CharStreams.toString(x));
-        } catch (final IOException ex) {
-            throw new UnknownSQLException(ex);
-        }
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_CHARACTER_STREAM_WITH_INT_LENGTH, new Object[]{length}));
     }
     
     @Override
     public final void setCharacterStream(final int parameterIndex, final Reader x, final long length) {
-        try {
-            setParameter(parameterIndex, CharStreams.toString(x));
-        } catch (final IOException ex) {
-            throw new UnknownSQLException(ex);
-        }
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_CHARACTER_STREAM_WITH_LONG_LENGTH, new Object[]{length}));
     }
     
     @Override
@@ -252,34 +241,221 @@ public abstract class AbstractPreparedStatementAdapter extends AbstractUnsupport
     
     @Override
     public final void setObject(final int parameterIndex, final Object x, final int targetSqlType) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_OBJECT_WITH_TYPE, new Object[]{targetSqlType}));
     }
     
     @Override
     public final void setObject(final int parameterIndex, final Object x, final int targetSqlType, final int scaleOrLength) {
-        setParameter(parameterIndex, x);
+        setParameter(parameterIndex, x, new ReplaySetParameter(ReplayMethod.SET_OBJECT_WITH_TYPE_AND_SCALE, new Object[]{targetSqlType, scaleOrLength}));
     }
     
     private void setParameter(final int parameterIndex, final Object value) {
+        setParameter(parameterIndex, value, new ReplaySetParameter(ReplayMethod.SET_OBJECT, new Object[0]));
+    }
+    
+    private void setParameter(final int parameterIndex, final Object value, final ReplaySetParameter replaySetParameter) {
         if (parameters.size() == parameterIndex - 1) {
             parameters.add(value);
+            setParameterContexts.add(replaySetParameter);
             return;
         }
         for (int i = parameters.size(); i <= parameterIndex - 1; i++) {
             parameters.add(null);
+            setParameterContexts.add(null);
         }
         parameters.set(parameterIndex - 1, value);
+        setParameterContexts.set(parameterIndex - 1, replaySetParameter);
     }
     
+    @SuppressWarnings("deprecation")
     protected final void replaySetParameter(final PreparedStatement preparedStatement, final List<Object> params) throws SQLException {
         int index = 0;
         for (Object each : params) {
-            preparedStatement.setObject(++index, each);
+            index++;
+            ReplaySetParameter context = matchReplaySetParameter(index - 1, each);
+            
+            if (context == null) {
+                preparedStatement.setObject(index, each);
+                continue;
+            }
+            
+            Object[] args = context.getArguments();
+            switch (context.getMethod()) {
+                case SET_NULL:
+                    preparedStatement.setNull(index, (int) args[0]);
+                    break;
+                case SET_NULL_WITH_NAME:
+                    preparedStatement.setNull(index, (int) args[0], (String) args[1]);
+                    break;
+                case SET_BLOB:
+                    if (each instanceof Blob) {
+                        preparedStatement.setBlob(index, (Blob) each);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_BLOB_STREAM:
+                    if (each instanceof InputStream) {
+                        preparedStatement.setBlob(index, (InputStream) each);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_BLOB_STREAM_WITH_LENGTH:
+                    if (each instanceof InputStream) {
+                        preparedStatement.setBlob(index, (InputStream) each, (long) args[0]);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_CLOB:
+                    if (each instanceof Clob) {
+                        preparedStatement.setClob(index, (Clob) each);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_CLOB_READER:
+                    if (each instanceof Reader) {
+                        preparedStatement.setClob(index, (Reader) each);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_CLOB_READER_WITH_LENGTH:
+                    if (each instanceof Reader) {
+                        preparedStatement.setClob(index, (Reader) each, (long) args[0]);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_ASCII_STREAM:
+                    if (each instanceof InputStream) {
+                        preparedStatement.setAsciiStream(index, (InputStream) each);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_ASCII_STREAM_WITH_INT_LENGTH:
+                    if (each instanceof InputStream) {
+                        preparedStatement.setAsciiStream(index, (InputStream) each, (int) args[0]);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_ASCII_STREAM_WITH_LONG_LENGTH:
+                    if (each instanceof InputStream) {
+                        preparedStatement.setAsciiStream(index, (InputStream) each, (long) args[0]);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_UNICODE_STREAM:
+                    if (each instanceof InputStream) {
+                        preparedStatement.setUnicodeStream(index, (InputStream) each, (int) args[0]);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_BINARY_STREAM:
+                    if (each instanceof InputStream) {
+                        preparedStatement.setBinaryStream(index, (InputStream) each);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_BINARY_STREAM_WITH_INT_LENGTH:
+                    if (each instanceof InputStream) {
+                        preparedStatement.setBinaryStream(index, (InputStream) each, (int) args[0]);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_BINARY_STREAM_WITH_LONG_LENGTH:
+                    if (each instanceof InputStream) {
+                        preparedStatement.setBinaryStream(index, (InputStream) each, (long) args[0]);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_CHARACTER_STREAM:
+                    if (each instanceof Reader) {
+                        preparedStatement.setCharacterStream(index, (Reader) each);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_CHARACTER_STREAM_WITH_INT_LENGTH:
+                    if (each instanceof Reader) {
+                        preparedStatement.setCharacterStream(index, (Reader) each, (int) args[0]);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_CHARACTER_STREAM_WITH_LONG_LENGTH:
+                    if (each instanceof Reader) {
+                        preparedStatement.setCharacterStream(index, (Reader) each, (long) args[0]);
+                    } else {
+                        preparedStatement.setObject(index, each);
+                    }
+                    break;
+                case SET_OBJECT_WITH_TYPE:
+                    preparedStatement.setObject(index, each, (int) args[0]);
+                    break;
+                case SET_OBJECT_WITH_TYPE_AND_SCALE:
+                    preparedStatement.setObject(index, each, (int) args[0], (int) args[1]);
+                    break;
+                case SET_OBJECT:
+                default:
+                    preparedStatement.setObject(index, each);
+                    break;
+            }
         }
+    }
+    
+    private ReplaySetParameter matchReplaySetParameter(final int paramIndex, final Object each) {
+        if (paramIndex < parameters.size()) {
+            Object original = parameters.get(paramIndex);
+            if (Objects.equals(each, original)) {
+                return setParameterContexts.get(paramIndex);
+            }
+        }
+        
+        if (each != null) {
+            for (int i = 0; i < parameters.size(); i++) {
+                if (each == parameters.get(i)) {
+                    return setParameterContexts.get(i);
+                }
+            }
+        }
+        
+        return null;
     }
     
     @Override
     public final void clearParameters() {
         parameters.clear();
+        setParameterContexts.clear();
+    }
+    
+    @RequiredArgsConstructor
+    @Getter
+    protected static class ReplaySetParameter {
+        
+        private final ReplayMethod method;
+        
+        private final Object[] arguments;
+    }
+    
+    protected enum ReplayMethod {
+        
+        SET_NULL, SET_NULL_WITH_NAME,
+        SET_BLOB, SET_BLOB_STREAM, SET_BLOB_STREAM_WITH_LENGTH,
+        SET_CLOB, SET_CLOB_READER, SET_CLOB_READER_WITH_LENGTH,
+        SET_ASCII_STREAM, SET_ASCII_STREAM_WITH_INT_LENGTH, SET_ASCII_STREAM_WITH_LONG_LENGTH,
+        SET_UNICODE_STREAM,
+        SET_BINARY_STREAM, SET_BINARY_STREAM_WITH_INT_LENGTH, SET_BINARY_STREAM_WITH_LONG_LENGTH,
+        SET_CHARACTER_STREAM, SET_CHARACTER_STREAM_WITH_INT_LENGTH, SET_CHARACTER_STREAM_WITH_LONG_LENGTH,
+        SET_OBJECT, SET_OBJECT_WITH_TYPE, SET_OBJECT_WITH_TYPE_AND_SCALE
     }
 }

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/PreparedStatementAdapterTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/PreparedStatementAdapterTest.java
@@ -47,13 +47,18 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PreparedStatementAdapterTest {
@@ -226,12 +231,15 @@ class PreparedStatementAdapterTest {
     
     @Test
     void assertSetCharacterStream() {
-        shardingSpherePreparedStatement.setCharacterStream(1, new StringReader("value"));
-        shardingSpherePreparedStatement.setCharacterStream(2, new StringReader("value"), 100);
-        shardingSpherePreparedStatement.setCharacterStream(3, new StringReader("value"), 100L);
-        assertParameter(shardingSpherePreparedStatement, 1, "value");
-        assertParameter(shardingSpherePreparedStatement, 2, "value");
-        assertParameter(shardingSpherePreparedStatement, 3, "value");
+        Reader reader1 = new StringReader("value1");
+        Reader reader2 = new StringReader("value2");
+        Reader reader3 = new StringReader("value3");
+        shardingSpherePreparedStatement.setCharacterStream(1, reader1);
+        shardingSpherePreparedStatement.setCharacterStream(2, reader2, 100);
+        shardingSpherePreparedStatement.setCharacterStream(3, reader3, 100L);
+        assertParameter(shardingSpherePreparedStatement, 1, reader1);
+        assertParameter(shardingSpherePreparedStatement, 2, reader2);
+        assertParameter(shardingSpherePreparedStatement, 3, reader3);
     }
     
     @Test
@@ -259,6 +267,62 @@ class PreparedStatementAdapterTest {
         assertParameter(shardingSpherePreparedStatement, 3, null);
         assertParameter(shardingSpherePreparedStatement, 4, null);
         assertParameter(shardingSpherePreparedStatement, 5, obj);
+    }
+    
+    @Test
+    void assertReplaySetParameter() throws SQLException {
+        PreparedStatement mockPreparedStatement = mock(PreparedStatement.class);
+        
+        InputStream stream = new ByteArrayInputStream(new byte[]{});
+        Reader reader = new StringReader("value");
+        Blob blob = mock(Blob.class);
+        
+        shardingSpherePreparedStatement.setBlob(1, blob);
+        shardingSpherePreparedStatement.setBinaryStream(2, stream, 10);
+        shardingSpherePreparedStatement.setClob(3, reader);
+        shardingSpherePreparedStatement.setObject(4, "test", Types.VARCHAR);
+        shardingSpherePreparedStatement.setNull(5, Types.INTEGER);
+        shardingSpherePreparedStatement.setInt(6, 100);
+        
+        shardingSpherePreparedStatement.replaySetParameter(mockPreparedStatement, shardingSpherePreparedStatement.getParameters());
+        
+        verify(mockPreparedStatement).setBlob(1, blob);
+        verify(mockPreparedStatement).setBinaryStream(2, stream, 10);
+        verify(mockPreparedStatement).setClob(3, reader);
+        verify(mockPreparedStatement).setObject(4, "test", Types.VARCHAR);
+        verify(mockPreparedStatement).setNull(5, Types.INTEGER);
+        verify(mockPreparedStatement).setObject(6, 100);
+    }
+    
+    @Test
+    void assertReplaySetParameterWithShiftedParams() throws SQLException {
+        PreparedStatement mockPreparedStatement = mock(PreparedStatement.class);
+        
+        InputStream stream = new ByteArrayInputStream(new byte[]{});
+        shardingSpherePreparedStatement.setBinaryStream(1, stream);
+        
+        List<Object> rewrittenParams = Arrays.asList("inserted_param", stream);
+        
+        shardingSpherePreparedStatement.replaySetParameter(mockPreparedStatement, rewrittenParams);
+        
+        verify(mockPreparedStatement).setObject(1, "inserted_param");
+        verify(mockPreparedStatement).setBinaryStream(2, stream);
+    }
+    
+    @Test
+    void assertReplaySetParameterForBlobInputStreamRegression() throws SQLException {
+        PreparedStatement mockPreparedStatement = mock(PreparedStatement.class);
+        InputStream inputStream1 = new ByteArrayInputStream(new byte[]{});
+        InputStream inputStream2 = new ByteArrayInputStream(new byte[]{});
+        
+        shardingSpherePreparedStatement.setBlob(1, inputStream1);
+        shardingSpherePreparedStatement.setBlob(2, inputStream2, 100L);
+        shardingSpherePreparedStatement.replaySetParameter(mockPreparedStatement, shardingSpherePreparedStatement.getParameters());
+        
+        verify(mockPreparedStatement).setBlob(1, inputStream1);
+        verify(mockPreparedStatement).setBlob(2, inputStream2, 100L);
+        verify(mockPreparedStatement, never()).setObject(eq(1), any());
+        verify(mockPreparedStatement, never()).setObject(eq(2), any());
     }
     
     private void assertParameter(final PreparedStatement actual, final int index, final Object param) {


### PR DESCRIPTION
Fixes #37504 

Preserve the original JDBC setter semantics during prepared statement replay by tracking the parameter-binding method independently of the logical parameter values. This fixes cases where stream and LOB-based parameters, such as Oracle BLOB values bound via setBlob(InputStream), were previously replayed using setObject(), resulting in driver-specific failures (for example, ORA-17004: invalid column type). Add regression tests covering replay of BLOB, stream, CLOB, typed object, null, and shifted parameter scenarios to ensure the original binding method is preserved during execution.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in the comment I request) added corresponding labels for the pull request.
- [x] I have passed Maven check locally: `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
