### PR TITLE
Improve MCP readwrite-splitting status planning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,10 @@ This guide is written **for AI coding agents only**. Follow it literally; improv
       Record the reason in the plan, review note, final response, or nearby code rationale.
 - **Complete Implementation**: no MVPs/placeholders/TODOs—deliver fully runnable solutions.
 
+### Dead Code Verification
+- Before declaring code unused, use semantic Find Usages; otherwise search the entire repository, covering direct calls, method references, generated accessors, overrides, reflection, SPI/framework registrations, tests, E2E, and external consumers.
+- Inspect every match; one regex or production-only search is insufficient evidence.
+
 ### Constructor Design Rules
 - Before adding or changing a constructor, inspect nearby production code and follow the module's existing conventions for visibility, Lombok, validation, and tests.
 - Keep only constructors with distinct production semantics or real framework, SPI, reflection, or serialization requirements.

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingInspectionService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingInspectionService.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.service;
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPQueryFailedException;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowDistSQLQueryUtils;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowRuleValueUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 
 import java.util.LinkedHashMap;
@@ -31,6 +32,12 @@ import java.util.Map;
  * Readwrite-splitting rule inspection service.
  */
 public final class ReadwriteSplittingInspectionService {
+    
+    String queryProxyMode(final MCPFeatureQueryFacade queryFacade, final String databaseName) {
+        String result = queryFacade.query(databaseName, "SHOW COMPUTE NODE INFO").stream().findFirst()
+                .map(each -> WorkflowRuleValueUtils.getRuleValue(each, "mode_type")).orElse("");
+        return result.isEmpty() ? "unknown" : result;
+    }
     
     /**
      * Query readwrite-splitting rules.

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingStatusWorkflowPlanningService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingStatusWorkflowPlanningService.java
@@ -39,9 +39,11 @@ import java.util.Map;
  */
 public final class ReadwriteSplittingStatusWorkflowPlanningService {
     
+    private static final String CLUSTER_MODE = "Cluster";
+    
     private static final List<String> INTERACTION_STEPS = List.of(
             "Confirm database, rule, read storage unit and target status",
-            "Inspect DistSQL-visible readwrite-splitting status",
+            "Confirm Cluster mode and inspect DistSQL-visible readwrite-splitting status",
             "Generate readwrite-splitting status DistSQL artifact",
             "Review artifacts and choose execution mode",
             "Execute or export artifacts",
@@ -75,6 +77,9 @@ public final class ReadwriteSplittingStatusWorkflowPlanningService {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_CLARIFYING, result.getStatus());
         }
         queryFacade.checkDatabaseCapability(mergedRequest.getDatabase());
+        if (!ensureClusterMode(inspectionService.queryProxyMode(queryFacade, mergedRequest.getDatabase()), result)) {
+            return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
+        }
         List<Map<String, Object>> statuses = inspectionService.queryRuleStatus(queryFacade, mergedRequest.getDatabase(), mergedRequest.getRuleName());
         if (!ensureTargetStatusRow(mergedRequest, statuses, result, queryFacade)) {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
@@ -128,6 +133,17 @@ public final class ReadwriteSplittingStatusWorkflowPlanningService {
             return false;
         }
         return true;
+    }
+    
+    private boolean ensureClusterMode(final String proxyMode, final WorkflowContextSnapshot snapshot) {
+        if (CLUSTER_MODE.equalsIgnoreCase(proxyMode)) {
+            return true;
+        }
+        snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.CLUSTER_MODE_REQUIRED, "error", WorkflowLifecycle.STEP_DISCOVERING,
+                String.format("Readwrite-splitting storage-unit status changes require Cluster mode; current Proxy mode is `%s`.", proxyMode),
+                "Connect MCP to a Cluster-mode ShardingSphere Proxy, then start a new readwrite-splitting status plan.", false,
+                Map.of("required_mode", CLUSTER_MODE, "actual_mode", proxyMode)));
+        return false;
     }
     
     private void addMissingInput(final List<String> missingInputs, final String value, final String fieldName) {

--- a/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
+++ b/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
@@ -183,7 +183,7 @@ prompts:
         - "Ask before applying generated readwrite-splitting rule DistSQL that changes runtime state."
   - name: plan_readwrite_splitting_status
     title: Plan Readwrite-Splitting Status
-    description: "Guide the model to plan a readwrite-splitting storage-unit enable or disable workflow by reading current status first."
+    description: "Guide the model to plan a Cluster-mode readwrite-splitting storage-unit enable or disable workflow by reading current status first."
     binding:
       templateResource: META-INF/shardingsphere-mcp/prompts/plan-readwrite-splitting-status.md
     arguments:
@@ -218,6 +218,7 @@ prompts:
       org.apache.shardingsphere/stop-conditions:
         - "Stop after database_gateway_plan_readwrite_splitting_status returns a planned workflow with plan_id and reviewable artifacts."
         - "Stop after a clarifying response lists missing inputs instead of guessing storage unit status."
+        - "Stop and report the Cluster-mode requirement after a failed plan returns WF-MODE-002; do not call apply or repeat the planning tool."
       org.apache.shardingsphere/ask-user-conditions:
         - "Ask when database, rule name, read storage unit, or target status is unclear."
         - "Ask before applying generated readwrite-splitting status DistSQL that changes runtime state."
@@ -563,8 +564,9 @@ tools:
   - name: database_gateway_plan_readwrite_splitting_status
     title: Plan Readwrite-Splitting Status
     description: >-
-      Plan a ShardingSphere readwrite-splitting read storage-unit enable or disable workflow. This tool creates reviewable status DistSQL artifacts
-      but does not execute them; use database_gateway_apply_workflow only after user review.
+      Plan a ShardingSphere readwrite-splitting read storage-unit enable or disable workflow. The current Proxy must run in Cluster mode;
+      otherwise this tool returns a failed plan without DistSQL artifacts. It does not execute generated artifacts;
+      use database_gateway_apply_workflow only after user review.
     inputSchema:
       type: object
       properties:

--- a/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/prompts/plan-readwrite-splitting-status.md
+++ b/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/prompts/plan-readwrite-splitting-status.md
@@ -9,5 +9,7 @@ Inputs:
 
 Before calling the planning tool, read current status from shardingsphere://features/readwrite-splitting/databases/{database}/rules/{rule}/status.
 Ask the user for the rule name, read storage unit, or target status when any input is missing.
-Return after database_gateway_plan_readwrite_splitting_status produces a plan_id or a clarification response.
+The status change requires a Cluster-mode ShardingSphere Proxy; the planning tool verifies the current Proxy mode before generating DistSQL.
+Return after database_gateway_plan_readwrite_splitting_status produces a planned, failed, or clarification response.
+If the plan reports `WF-MODE-002`, explain that Cluster mode is required and stop without calling apply or repeating the planning tool.
 Do not create, alter, unregister, or repair storage units, and do not generate physical DDL, index DDL, migration, backfill, data probes, or physical metadata probes.

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingInspectionServiceTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingInspectionServiceTest.java
@@ -39,6 +39,20 @@ import static org.mockito.Mockito.when;
 class ReadwriteSplittingInspectionServiceTest {
     
     @Test
+    void assertQueryProxyMode() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.query("logic_db", "SHOW COMPUTE NODE INFO")).thenReturn(List.of(Map.of("mode_type", "Cluster")));
+        assertThat(new ReadwriteSplittingInspectionService().queryProxyMode(queryFacade, "logic_db"), is("Cluster"));
+    }
+    
+    @Test
+    void assertQueryProxyModeWhenComputeNodeInfoIsEmpty() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.query("logic_db", "SHOW COMPUTE NODE INFO")).thenReturn(List.of());
+        assertThat(new ReadwriteSplittingInspectionService().queryProxyMode(queryFacade, "logic_db"), is("unknown"));
+    }
+    
+    @Test
     void assertQueryRules() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         new ReadwriteSplittingInspectionService().queryRules(queryFacade, "logic_db");

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowPlanningServicesTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowPlanningServicesTest.java
@@ -33,10 +33,13 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ReadwriteSplittingWorkflowPlanningServicesTest {
@@ -177,6 +180,20 @@ class ReadwriteSplittingWorkflowPlanningServicesTest {
         assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.DROP_TARGET_RULE_NOT_FOUND));
     }
     
+    @Test
+    void assertPlanStatusFailsInStandaloneMode() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.query("logic_db", "SHOW COMPUTE NODE INFO")).thenReturn(List.of(Map.of("mode_type", "Standalone")));
+        WorkflowContextSnapshot actual = createStatusService().plan(new TestWorkflowSessionContext(), queryFacade, createStatusRequest("disable"));
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.CLUSTER_MODE_REQUIRED));
+        assertThat(actual.getIssues().getFirst().getStage(), is(WorkflowLifecycle.STEP_DISCOVERING));
+        assertFalse(actual.getIssues().getFirst().isRetryable());
+        assertThat(actual.getIssues().getFirst().getDetails(), is(Map.of("required_mode", "Cluster", "actual_mode", "Standalone")));
+        assertTrue(actual.getRuleArtifacts().isEmpty());
+        verify(queryFacade, never()).query("logic_db", "SHOW STATUS FROM READWRITE_SPLITTING RULE readwrite_ds FROM logic_db");
+    }
+    
     private ReadwriteSplittingRuleWorkflowPlanningService createRuleService() {
         return new ReadwriteSplittingRuleWorkflowPlanningService();
     }
@@ -196,7 +213,8 @@ class ReadwriteSplittingWorkflowPlanningServicesTest {
         MCPFeatureQueryFacade result = mock(MCPFeatureQueryFacade.class);
         when(result.isSameIdentifier("logic_db", IdentifierScope.TABLE, "readwrite_ds", "readwrite_ds")).thenReturn(true);
         when(result.isSameIdentifier("logic_db", IdentifierScope.TABLE, "read_ds_0", "read_ds_0")).thenReturn(true);
-        when(result.query(eq("logic_db"), any())).thenReturn(statuses);
+        when(result.query("logic_db", "SHOW COMPUTE NODE INFO")).thenReturn(List.of(Map.of("mode_type", "Cluster")));
+        when(result.query("logic_db", "SHOW STATUS FROM READWRITE_SPLITTING RULE readwrite_ds FROM logic_db")).thenReturn(statuses);
         return result;
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowIssueCode.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowIssueCode.java
@@ -64,6 +64,8 @@ public final class WorkflowIssueCode {
     
     public static final String MANUAL_EXECUTION_PENDING = "WF-MODE-001";
     
+    public static final String CLUSTER_MODE_REQUIRED = "WF-MODE-002";
+    
     public static final String UNSUPPORTED_IDENTIFIER = "WF-SQL-001";
     
     public static final String RULE_STATE_MISMATCH = "WF-VAL-002";

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
@@ -281,6 +281,9 @@ public final class WorkflowGuidancePayloadBuilder {
     }
     
     private static List<Map<String, Object>> createRecoveryPlanningActions(final WorkflowContextSnapshot snapshot) {
+        if (hasIssue(snapshot, WorkflowIssueCode.CLUSTER_MODE_REQUIRED)) {
+            return List.of(MCPNextActionUtils.stop("Connect to a Cluster-mode ShardingSphere Proxy, then start a new workflow plan."));
+        }
         String planningTool = resolvePlanningTool(snapshot);
         if (hasIssue(snapshot, WorkflowIssueCode.RULE_INPUT_CONFLICT)) {
             return planningTool.isEmpty()

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanPayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanPayloadBuilderTest.java
@@ -207,6 +207,25 @@ class WorkflowPlanPayloadBuilderTest {
     }
     
     @Test
+    void assertBuildStopsAfterClusterModeFailure() {
+        WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
+        snapshot.setPlanId("plan-1");
+        snapshot.setWorkflowKind(WorkflowKind.valueOf("readwrite.status"));
+        snapshot.setStatus(WorkflowLifecycle.STATUS_FAILED);
+        snapshot.setClarifiedIntent(new ClarifiedIntent());
+        WorkflowRequest request = new WorkflowRequest();
+        snapshot.setRequest(request);
+        snapshot.setInteractionPlan(InteractionPlan.create("plan-1", request, "Readwrite-splitting status workflow plan.", List.of("Review"), List.of("status")));
+        snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.CLUSTER_MODE_REQUIRED, "error", WorkflowLifecycle.STEP_DISCOVERING,
+                "Cluster mode is required.", "Connect to a Cluster-mode ShardingSphere Proxy.", false,
+                Map.of("required_mode", "Cluster", "actual_mode", "Standalone")));
+        Map<String, Object> actual = WorkflowPlanPayloadBuilder.build(snapshot);
+        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
+        assertThat(actualNextAction.get("type"), is("terminal"));
+        assertThat(actualNextAction.get("reason"), is("Connect to a Cluster-mode ShardingSphere Proxy, then start a new workflow plan."));
+    }
+    
+    @Test
     void assertBuildStartsNewPlanAfterInputConflict() {
         WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
         snapshot.setPlanId("plan-1");

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
@@ -151,14 +151,16 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
             assertTrue(String.valueOf(actualRule.get("read_storage_unit_names")).contains("ds_1"));
             assertThat(String.valueOf(actualRule.get("transactional_read_query_strategy")).toUpperCase(Locale.ENGLISH), is("DYNAMIC"));
             assertThat(String.valueOf(actualRule.get("load_balancer_type")).toUpperCase(Locale.ENGLISH), is("ROUND_ROBIN"));
-            Map<String, Object> actualStatusPlan = planWorkflow(interactionClient, READWRITE_SPLITTING_STATUS_PLAN_TOOL_NAME,
+            Map<String, Object> actualStatusPlan = interactionClient.call(READWRITE_SPLITTING_STATUS_PLAN_TOOL_NAME,
                     Map.of("database", getLogicalDatabaseName(), "rule", "readwrite_ds", "storage_unit", "ds_1", "target_status", "disable"));
-            Map<String, Object> actualStatusApply = applyReviewedWorkflow(interactionClient, String.valueOf(actualStatusPlan.get("plan_id")));
-            assertThat(String.valueOf(actualStatusApply.get("status")), is("failed"));
-            assertThat(getIssueCodes(actualStatusApply), hasItem(WorkflowIssueCode.RULE_EXECUTION_FAILED));
-            assertTrue(String.valueOf(actualStatusApply.get("issues")).contains("Mode must be 'cluster'"));
-            assertThat(getStringListOrEmpty(actualStatusApply.get("executed_distsql")).size(), is(0));
-            assertModelFacingPayloadContract(actualStatusApply);
+            assertThat(String.valueOf(actualStatusPlan.get("status")), is("failed"));
+            assertThat(getIssueCodes(actualStatusPlan), hasItem(WorkflowIssueCode.CLUSTER_MODE_REQUIRED));
+            Map<String, Object> actualIssueDetails = getObjectOrEmpty(getObjectListOrEmpty(actualStatusPlan.get("issues")).getFirst().get("details"));
+            assertThat(actualIssueDetails.get("required_mode"), is("Cluster"));
+            assertThat(actualIssueDetails.get("actual_mode"), is("Standalone"));
+            assertTrue(getObjectListOrEmpty(actualStatusPlan.get("distsql_artifacts")).isEmpty());
+            assertThat(getObjectListOrEmpty(actualStatusPlan.get("next_actions")).getFirst().get("type"), is("terminal"));
+            assertModelFacingPayloadContract(actualStatusPlan);
         }
     }
     


### PR DESCRIPTION
- fail status plans early when Proxy is not in Cluster mode
- return terminal guidance and document the Cluster requirement
- cover Cluster and Standalone paths with unit and Proxy E2E tests
