### PR TITLE
Remove deprecated identifier formatting method usage

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistry.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistry.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.database.connector.core.type;
 
 import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
 
@@ -65,7 +66,9 @@ public final class DatabaseTypeRegistry {
      *
      * @param identifierPattern identifier pattern
      * @return formatted identifier pattern
+     * @deprecated use {@link org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierNormalizeEngine#normalize(IdentifierCasePolicy, String)} instead
      */
+    @Deprecated
     public String formatIdentifierPattern(final String identifierPattern) {
         switch (dialectDatabaseMetaData.getIdentifierPatternType()) {
             case UPPER_CASE:

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/attribute/SingleMutableDataNodeRuleAttribute.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/attribute/SingleMutableDataNodeRuleAttribute.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.single.rule.attribute;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.datanode.DataNode;
@@ -134,11 +133,6 @@ public final class SingleMutableDataNodeRuleAttribute implements MutableDataNode
     
     private Collection<String> findMatchedTableKeys(final String tableName) {
         Collection<String> result = new LinkedList<>();
-        String formattedTableName = new DatabaseTypeRegistry(protocolType).formatIdentifierPattern(tableName);
-        if (singleTableDataNodes.containsKey(formattedTableName)) {
-            result.add(formattedTableName);
-            return result;
-        }
         if (singleTableDataNodes.containsKey(tableName)) {
             result.add(tableName);
             return result;


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove deprecated identifier formatting method usage

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
