### PR TITLE
Refactor MCP model-facing payload contracts

### DIFF
--- a/docs/document/content/reference/mcp/protocol-surface.cn.md
+++ b/docs/document/content/reference/mcp/protocol-surface.cn.md
@@ -218,19 +218,18 @@ Client 应在选择不确定的 database、schema、table、column、storage uni
 
 - `items`
 - `count`
-- `has_more`
 - `continuation_mode`
+- 存在后续结果时的 `next_page_token`
 
 大结果 payload 会使用：
 
 - `truncated`
 - `total_count`
-- `returned_count`
 - `large_result_guidance`
 
-可恢复错误 payload 保留 `message`，并增加 `recovery` 提示。
+可恢复错误 payload 使用 `summary`、`error_id` 和结构化 `recovery` 提示。
 常见恢复场景包括缺失参数、不支持的 tool/resource、非法枚举、workflow 状态错误和 SQL tool 选错。
-需要继续操作的模型可见业务 payload 会包含顶层 `summary` 和结构化 `next_actions`。
+需要继续操作的模型可见业务 payload 会包含顶层 `summary` 和唯一的顶层 `next_actions`。
 Workflow 规划、执行、人工执行包导出和校验响应使用这些字段，引导下一次 tool call、用户补问、resource read、completion call 或终止。
 
 JSON-RPC 数字错误码属于 MCP 协议错误契约。

--- a/docs/document/content/reference/mcp/protocol-surface.en.md
+++ b/docs/document/content/reference/mcp/protocol-surface.en.md
@@ -218,19 +218,18 @@ List-shaped business payloads usually contain:
 
 - `items`
 - `count`
-- `has_more`
 - `continuation_mode`
+- `next_page_token` when continuation is available
 
 Large-result payloads use:
 
 - `truncated`
 - `total_count`
-- `returned_count`
 - `large_result_guidance`
 
-Recoverable error payloads keep `message` and add `recovery` hints.
+Recoverable error payloads use `summary`, `error_id`, and structured `recovery` hints.
 Common recovery cases include missing arguments, unsupported tools or resources, invalid enum values, workflow state errors, and unsafe SQL tool selection.
-Model-facing business payloads that require continuation include a top-level `summary` and structured `next_actions`.
+Model-facing business payloads that require continuation include a top-level `summary` and canonical top-level `next_actions`.
 Workflow planning, apply, manual-only export, and validation responses use these fields to guide the next tool call, user question, resource read, completion call, or terminal stop.
 
 JSON-RPC numeric error codes are the MCP protocol error contract.

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/MCPTransportErrorFactory.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/MCPTransportErrorFactory.java
@@ -76,7 +76,7 @@ public final class MCPTransportErrorFactory {
     private static McpError createInternalError(final Throwable cause) {
         MCPErrorPayload errorPayload = new MCPErrorPayload("Service is temporarily unavailable.");
         Map<String, Object> payload = errorPayload.toPayload();
-        log.error("Unexpected MCP request failure, request ID: {}.", payload.get("request_id"), cause);
+        log.error("Unexpected MCP request failure, error ID: {}.", payload.get("error_id"), cause);
         return createProtocolError(errorPayload, payload, McpSchema.ErrorCodes.INTERNAL_ERROR);
     }
     

--- a/mcp/bootstrap/src/main/resources/META-INF/shardingsphere-mcp/instructions/server-instructions.md
+++ b/mcp/bootstrap/src/main/resources/META-INF/shardingsphere-mcp/instructions/server-instructions.md
@@ -26,4 +26,4 @@ Use `database_gateway_execute_explain_query` for execution-plan diagnostics.
 Use `database_gateway_execute_update` with `execution_mode=preview` before side effects.
 Treat `database_gateway_execute_update` preview as database-aware validation and classification, not as a database dry run.
 
-Continue from `next_actions` or `recovery.next_actions` instead of guessing hidden tools or arguments.
+Continue from top-level `next_actions` instead of guessing hidden tools or arguments.

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/MCPTransportErrorFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/MCPTransportErrorFactoryTest.java
@@ -41,7 +41,7 @@ class MCPTransportErrorFactoryTest {
         assertThat(actual.getJsonRpcError().message(), is("foo_message"));
         @SuppressWarnings("unchecked")
         Map<String, Object> actualData = (Map<String, Object>) actual.getJsonRpcError().data();
-        assertThat(actualData.get("message"), is("foo_message"));
+        assertThat(actualData.get("summary"), is("foo_message"));
     }
     
     @Test
@@ -58,7 +58,7 @@ class MCPTransportErrorFactoryTest {
         assertThat(actual.getJsonRpcError().message(), is("Unsupported tool `foo_tool`."));
         @SuppressWarnings("unchecked")
         Map<String, Object> actualData = (Map<String, Object>) actual.getJsonRpcError().data();
-        assertThat(actualData.get("message"), is("Unsupported tool `foo_tool`."));
+        assertThat(actualData.get("summary"), is("Unsupported tool `foo_tool`."));
     }
     
     @Test

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/completion/MCPCompletionSpecificationFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/completion/MCPCompletionSpecificationFactoryTest.java
@@ -62,7 +62,7 @@ class MCPCompletionSpecificationFactoryTest {
         assertThat(actual.meta().get(MCPShardingSphereMetadataKeys.RESPONSE_MODE), is("list"));
         assertThat(actual.meta().get(MCPShardingSphereMetadataKeys.DIAGNOSTIC), is("ok"));
         assertThat(actual.meta().get(MCPShardingSphereMetadataKeys.MATCH_STRATEGY), is("prefix"));
-        assertThat(actual.meta().get(MCPShardingSphereMetadataKeys.MATCHED_CANDIDATE_COUNT), is(1));
+        assertThat(actual.meta().get(MCPShardingSphereMetadataKeys.CANDIDATE_COUNT), is(2));
         assertThat(((List<?>) actual.meta().get(MCPShardingSphereMetadataKeys.VALUE_DETAILS)).size(), is(1));
     }
     

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/resource/MCPResourceSpecificationFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/resource/MCPResourceSpecificationFactoryTest.java
@@ -92,7 +92,8 @@ class MCPResourceSpecificationFactoryTest {
         assertThat(actualContents.uri(), is("shardingsphere://capabilities"));
         assertThat(actualContents.mimeType(), is("application/json"));
         assertTrue(actualContents.text().contains("\"response_mode\":\"catalog\""));
-        assertTrue(actualContents.text().contains("\"guidanceResource\":\"shardingsphere://guidance\""));
+        assertTrue(actualContents.text().contains("\"resourceNavigation\""));
+        assertTrue(actualContents.text().contains("\"to\":\"shardingsphere://guidance\""));
     }
     
     @Test
@@ -123,7 +124,7 @@ class MCPResourceSpecificationFactoryTest {
         assertThat(actual.getJsonRpcError().message(), is("Unsupported resource URI `shardingsphere://unknown`."));
         @SuppressWarnings("unchecked")
         Map<String, Object> actualData = (Map<String, Object>) actual.getJsonRpcError().data();
-        assertThat(actualData.get("message"), is("Unsupported resource URI `shardingsphere://unknown`."));
+        assertThat(actualData.get("summary"), is("Unsupported resource URI `shardingsphere://unknown`."));
     }
     
     @Test

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPCallToolResultFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPCallToolResultFactoryTest.java
@@ -93,7 +93,8 @@ class MCPCallToolResultFactoryTest extends AbstractMCPToolSpecificationFactoryTe
         CallToolResult actual = new MCPCallToolResultFactory().create(new MCPErrorPayload(""));
         Map<String, Object> actualPayload = getTextContentPayload(actual);
         assertThat(actualPayload.get("response_mode"), is("recovery"));
-        assertThat(actualPayload.get("message"), is(""));
+        assertThat(actualPayload.get("summary"), is("Recovery guidance is available."));
+        assertFalse(actualPayload.containsKey("message"));
         assertNull(actual.structuredContent());
         assertTrue(actual.isError());
     }
@@ -115,7 +116,7 @@ class MCPCallToolResultFactoryTest extends AbstractMCPToolSpecificationFactoryTe
         assertFalse(actual.isError());
         assertThat(actualPayload.get("status"), is("failed"));
         assertFalse(((Map<?, ?>) actualPayload.get("recovery")).containsKey("database"));
-        assertFalse(((Map<?, ?>) actualPayload.get("recovery")).containsKey("request_id"));
+        assertFalse(((Map<?, ?>) actualPayload.get("recovery")).containsKey("next_actions"));
         assertThat(((TextContent) actual.content().getFirst()).text(), is(JsonUtils.toJsonString(actualPayload)));
     }
     
@@ -205,10 +206,10 @@ class MCPCallToolResultFactoryTest extends AbstractMCPToolSpecificationFactoryTe
                 MCPResourceHintUtils.create("shardingsphere://capabilities", "capability", "read_first", "Read capabilities.", "resources_to_read")));
         CallToolResult actual = new MCPCallToolResultFactory().create(new MCPErrorPayload("", recovery));
         Map<String, Object> actualPayload = getTextContentPayload(actual);
-        Map<?, ?> actualRecovery = (Map<?, ?>) actualPayload.get("recovery");
         assertTrue(actual.isError());
         assertNull(actual.structuredContent());
-        assertThat(actualRecovery.get("request_id"), is(actualPayload.get("request_id")));
+        assertThat(actualPayload.get("error_id"), isA(String.class));
+        assertFalse(((Map<?, ?>) actualPayload.get("recovery")).containsKey("error_id"));
         assertThat(actual.content().get(1), isA(ResourceLink.class));
         assertThat(((ResourceLink) actual.content().get(1)).uri(), is("shardingsphere://capabilities"));
         assertThat(actual.meta().get(MCPShardingSphereMetadataKeys.RESOURCE_LINKS_EMITTED), is(1));

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolElicitationFlowTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolElicitationFlowTest.java
@@ -80,7 +80,7 @@ class MCPToolElicitationFlowTest extends AbstractMCPToolSpecificationFactoryTest
             CallToolResult actual = callTool(createToolSpecification(MCPTransportType.STDIO), exchange, toolName, Map.of());
             assertTrue(actual.isError());
             assertNull(actual.structuredContent());
-            assertThat(getTextContentPayload(actual).get("message"), is("Database capability does not exist."));
+            assertThat(getTextContentPayload(actual).get("summary"), is("Database capability does not exist."));
         }
     }
     

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolSpecificationFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolSpecificationFactoryTest.java
@@ -123,7 +123,7 @@ class MCPToolSpecificationFactoryTest extends AbstractMCPToolSpecificationFactor
             assertThat(actual.getJsonRpcError().message(), is("Unsupported tool `database_gateway_search_metadata`."));
             @SuppressWarnings("unchecked")
             Map<String, Object> actualData = (Map<String, Object>) actual.getJsonRpcError().data();
-            assertThat(actualData.get("message"), is("Unsupported tool `database_gateway_search_metadata`."));
+            assertThat(actualData.get("summary"), is("Unsupported tool `database_gateway_search_metadata`."));
         }
     }
     
@@ -136,7 +136,7 @@ class MCPToolSpecificationFactoryTest extends AbstractMCPToolSpecificationFactor
             CallToolResult actual = callTool(createToolSpecification(MCPTransportType.STDIO), createExchange(), "fixture_ping", Map.of());
             assertTrue(actual.isError());
             assertNull(actual.structuredContent());
-            assertThat(getTextContentPayload(actual).get("message"), is("Database capability does not exist."));
+            assertThat(getTextContentPayload(actual).get("summary"), is("Database capability does not exist."));
         }
     }
     
@@ -148,7 +148,7 @@ class MCPToolSpecificationFactoryTest extends AbstractMCPToolSpecificationFactor
                     .thenThrow(new MCPInvalidRequestException(" "));
             CallToolResult actual = callTool(createToolSpecification(MCPTransportType.STDIO), createExchange(), "fixture_ping", Map.of());
             assertTrue(actual.isError());
-            assertThat(getTextContentPayload(actual).get("message"), is("Invalid request."));
+            assertThat(getTextContentPayload(actual).get("summary"), is("Invalid request."));
         }
     }
     
@@ -172,7 +172,7 @@ class MCPToolSpecificationFactoryTest extends AbstractMCPToolSpecificationFactor
         CallToolResult actual = callTool(actualSpecification, createExchange(), "database_gateway_search_metadata", Map.of("query", "order", "object_types", List.of("TABLE")));
         Map<String, Object> actualPayload = getTextContentPayload(actual);
         Map<?, ?> actualRecovery = (Map<?, ?>) actualPayload.get("recovery");
-        assertThat(actualPayload.get("message"), is("object_types[0] must be one of [database, schema, table, view, column, index, storage_unit, sequence]."));
+        assertThat(actualPayload.get("summary"), is("object_types[0] must be one of [database, schema, table, view, column, index, storage_unit, sequence]."));
         assertThat(actualRecovery.get("category"), is("invalid_enum_value"));
         assertThat(actualRecovery.get("field"), is("object_types[0]"));
         assertThat(actualRecovery.get("allowed_values"), is(List.of("database", "schema", "table", "view", "column", "index", "storage_unit", "sequence")));
@@ -188,7 +188,7 @@ class MCPToolSpecificationFactoryTest extends AbstractMCPToolSpecificationFactor
             mockToolDispatch(mockedToolDefinitionRegistry, toolDefinition, Map.of(), new MCPMapPayload(Map.of("count", 1)));
             CallToolResult actual = callTool(createToolSpecification(createRuntimeContext(MCPTransportType.HTTP)), createExchange(), "database_gateway_search_metadata", Map.of());
             Map<String, Object> actualPayload = getTextContentPayload(actual);
-            assertTrue(String.valueOf(actualPayload.get("message")).contains("database_gateway_search_metadata"));
+            assertTrue(String.valueOf(actualPayload.get("summary")).contains("database_gateway_search_metadata"));
             assertNull(actual.structuredContent());
             assertTrue(actual.isError());
         }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionService.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionService.java
@@ -165,7 +165,7 @@ public final class MCPCompletionService {
                                            final Map<String, String> contextArguments, final Map<String, Object> inferredContextArguments, final Collection<String> missingContextArguments,
                                            final String nearestResourceUri, final Collection<MCPCompletionCandidate> candidates, final Collection<MCPCompletionCandidate> filteredCandidates,
                                            final Collection<MCPCompletionCandidate> returnedCandidates) {
-        Map<String, Object> result = new LinkedHashMap<>(14, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(12, 1F);
         result.put(MCPShardingSphereMetadataKeys.RESPONSE_MODE, MCPResponseMode.LIST);
         result.put(MCPShardingSphereMetadataKeys.REFERENCE_TYPE, descriptor.getReferenceType());
         result.put(MCPShardingSphereMetadataKeys.REFERENCE, descriptor.getReference());
@@ -174,8 +174,6 @@ public final class MCPCompletionService {
         result.put(MCPShardingSphereMetadataKeys.MATCH_STRATEGY, matchStrategy);
         result.put(MCPShardingSphereMetadataKeys.CONTEXT_ARGUMENTS, contextArguments);
         result.put(MCPShardingSphereMetadataKeys.CANDIDATE_COUNT, candidates.size());
-        result.put(MCPShardingSphereMetadataKeys.MATCHED_CANDIDATE_COUNT, filteredCandidates.size());
-        result.put(MCPShardingSphereMetadataKeys.RETURNED_CANDIDATE_COUNT, returnedCandidates.size());
         putInferredContext(result, inferredContextArguments);
         result.put(MCPShardingSphereMetadataKeys.MISSING_CONTEXT_ARGUMENTS, missingContextArguments);
         String diagnostic = createDiagnostic(candidates, filteredCandidates, missingContextArguments);
@@ -227,12 +225,10 @@ public final class MCPCompletionService {
     }
     
     private Map<String, Object> createRecovery(final String prefix, final String diagnostic, final Collection<String> missingContextArguments, final String nearestResourceUri) {
-        Map<String, Object> result = new LinkedHashMap<>(8, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(6, 1F);
         String recoveryCategory = "missing_context".equals(diagnostic) ? "missing_context" : "empty_scope";
         result.put("response_mode", MCPResponseMode.RECOVERY);
         result.put("recovery_category", recoveryCategory);
-        result.put("category", recoveryCategory);
-        result.put("diagnostic", diagnostic);
         if (!prefix.isEmpty()) {
             result.put("requested_token", prefix);
         }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPBasicRecoveryPayloadFactory.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPBasicRecoveryPayloadFactory.java
@@ -23,8 +23,6 @@ import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidMetadataO
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidToolArgumentException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPToolArgumentContractViolationException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPToolCallLimitExceededException;
-import org.apache.shardingsphere.mcp.core.resource.handler.ResourceDefinitionRegistry;
-import org.apache.shardingsphere.mcp.core.tool.handler.ToolDefinitionRegistry;
 import org.apache.shardingsphere.mcp.support.protocol.MCPNextActionUtils;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 import org.apache.shardingsphere.mcp.support.protocol.MCPResourceHintUtils;
@@ -43,12 +41,11 @@ final class MCPBasicRecoveryPayloadFactory {
     static Map<String, Object> createUnsupportedToolRecovery(final String toolName) {
         Map<String, Object> result = MCPRecoveryPayloadSupport.createBaseRecovery("unsupported_tool", "Call one of the supported tools returned by tools/list.");
         result.put("tool_name", toolName);
-        result.put("supported_tools", ToolDefinitionRegistry.getSupportedTools());
+        result.put("discovery_method", "tools/list");
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, MCPRecoveryPayloadSupport.createResourceHintList(
                 "shardingsphere://capabilities", "capability", "Read ShardingSphere catalog details after checking tools/list."));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.readResource("shardingsphere://capabilities",
                 "Read the ShardingSphere domain catalog only when tools/list does not provide enough context.")));
-        result.put("ask_user_when_uncertain", false);
         return result;
     }
     
@@ -56,12 +53,11 @@ final class MCPBasicRecoveryPayloadFactory {
         Map<String, Object> result = MCPRecoveryPayloadSupport.createBaseRecovery(
                 "unsupported_resource", "Read one of the supported resources or templates returned by resources/list and resources/templates/list.");
         result.put(MCPPayloadFieldNames.RESOURCE, MCPResourceHintUtils.create(resourceUri, "resource", "inspect_detail", "Unsupported resource URI requested.", MCPPayloadFieldNames.RECOVERY));
-        result.put("matching_resource_templates", ResourceDefinitionRegistry.getSupportedResources());
+        result.put("discovery_methods", List.of("resources/list", "resources/templates/list"));
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, MCPRecoveryPayloadSupport.createResourceHintList(
                 "shardingsphere://capabilities", "capability", "Read ShardingSphere catalog details after checking resources/list and resources/templates/list."));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.readResource("shardingsphere://capabilities",
                 "Read the ShardingSphere domain catalog only when official resource discovery does not provide enough context.")));
-        result.put("ask_user_when_uncertain", false);
         return result;
     }
     
@@ -75,7 +71,6 @@ final class MCPBasicRecoveryPayloadFactory {
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, MCPRecoveryPayloadSupport.createResourceHintList(
                 "shardingsphere://guidance", "guidance", "Read the current MCP safety policy before retrying."));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.readResource("shardingsphere://guidance", "Read current MCP safety policy and tool call limits.")));
-        result.put("ask_user_when_uncertain", true);
         return result;
     }
     
@@ -87,7 +82,6 @@ final class MCPBasicRecoveryPayloadFactory {
     static Map<String, Object> createToolArgumentContractViolationRecovery(final MCPToolArgumentContractViolationException cause) {
         Map<String, Object> result = MCPRecoveryPayloadSupport.createBaseRecovery(cause.getCategory(), createToolArgumentContractModelAction(cause));
         result.put(MCPPayloadFieldNames.FIELD, cause.getArgumentPath());
-        result.put("argument_path", cause.getArgumentPath());
         result.put("tool_name", cause.getToolName());
         if (!cause.getExpectedType().isEmpty()) {
             result.put("expected_type", cause.getExpectedType());
@@ -99,7 +93,6 @@ final class MCPBasicRecoveryPayloadFactory {
             result.put("suggested_arguments", cause.getSuggestedArguments());
         }
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, createToolArgumentContractNextActions(cause));
-        result.put("ask_user_when_uncertain", cause.getSuggestedArguments().isEmpty());
         return result;
     }
     
@@ -130,7 +123,6 @@ final class MCPBasicRecoveryPayloadFactory {
         result.put("missing_fields", List.of(argumentName));
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, createMissingArgumentResourcesToRead(argumentName));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, createMissingArgumentNextActions(argumentName));
-        result.put("ask_user_when_uncertain", true);
         return result;
     }
     
@@ -142,7 +134,6 @@ final class MCPBasicRecoveryPayloadFactory {
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.retryTool("database_gateway_search_metadata",
                 "Retry database_gateway_search_metadata with allowed object_types values, or omit object_types to search every supported metadata type.",
                 Map.of("object_types", cause.getAllowedValues()))));
-        result.put("ask_user_when_uncertain", false);
         return result;
     }
     
@@ -150,7 +141,6 @@ final class MCPBasicRecoveryPayloadFactory {
                                                                             final int minimumValue, final int maximumValue) {
         Map<String, Object> result = MCPRecoveryPayloadSupport.createBaseRecovery("invalid_integer_argument", "Retry with an integer value inside the documented bounds.");
         result.put(MCPPayloadFieldNames.FIELD, fieldName);
-        result.put("argument_path", fieldName);
         if (!sourceTool.isEmpty()) {
             result.put("source_tool", sourceTool);
         }
@@ -163,7 +153,6 @@ final class MCPBasicRecoveryPayloadFactory {
         Map<String, Object> suggestedArguments = Map.of(fieldName, suggestedValue);
         result.put("suggested_arguments", suggestedArguments);
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, createInvalidIntegerArgumentNextActions(fieldName, targetTool, suggestedArguments));
-        result.put("ask_user_when_uncertain", false);
         return result;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorPayload.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorPayload.java
@@ -35,7 +35,7 @@ public final class MCPErrorPayload {
     
     private final Map<String, Object> recovery;
     
-    private final String requestId;
+    private final String errorId;
     
     public MCPErrorPayload(final String message) {
         this(message, Map.of());
@@ -44,7 +44,7 @@ public final class MCPErrorPayload {
     public MCPErrorPayload(final String message, final Map<String, Object> recovery) {
         this.message = message;
         this.recovery = recovery;
-        requestId = UUID.randomUUID().toString();
+        errorId = UUID.randomUUID().toString();
     }
     
     /**
@@ -53,13 +53,15 @@ public final class MCPErrorPayload {
      * @return error payload
      */
     public Map<String, Object> toPayload() {
-        Map<String, Object> result = new LinkedHashMap<>(6, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(5, 1F);
         result.put("response_mode", MCPResponseMode.RECOVERY);
         result.put(MCPPayloadFieldNames.SUMMARY, message.isEmpty() ? "Recovery guidance is available." : message);
-        result.put("request_id", requestId);
-        result.put(MCPPayloadFieldNames.MESSAGE, message);
+        result.put("error_id", errorId);
         if (!recovery.isEmpty()) {
-            result.put(MCPPayloadFieldNames.RECOVERY, createRecoveryPayload());
+            Map<String, Object> recoveryPayload = createRecoveryPayload();
+            if (!recoveryPayload.isEmpty()) {
+                result.put(MCPPayloadFieldNames.RECOVERY, recoveryPayload);
+            }
             if (recovery.containsKey(MCPPayloadFieldNames.NEXT_ACTIONS)) {
                 result.put(MCPPayloadFieldNames.NEXT_ACTIONS, recovery.get(MCPPayloadFieldNames.NEXT_ACTIONS));
             }
@@ -68,9 +70,9 @@ public final class MCPErrorPayload {
     }
     
     private Map<String, Object> createRecoveryPayload() {
-        Map<String, Object> result = new LinkedHashMap<>(recovery.size() + 1, 1F);
-        result.putAll(recovery);
-        result.putIfAbsent("request_id", requestId);
+        Map<String, Object> result = new LinkedHashMap<>(recovery);
+        result.remove("response_mode");
+        result.remove(MCPPayloadFieldNames.NEXT_ACTIONS);
         return result;
     }
 }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPRuntimeDatabaseRecoveryPayloadFactory.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPRuntimeDatabaseRecoveryPayloadFactory.java
@@ -59,7 +59,6 @@ public final class MCPRuntimeDatabaseRecoveryPayloadFactory {
         Map<String, Object> result = MCPRecoveryPayloadSupport.createBaseRecovery(category, createModelAction(category));
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, createResourcesToRead(category));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, createNextActions(category));
-        result.put("ask_user_when_uncertain", true);
         return result;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPSQLRecoveryPayloadFactory.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPSQLRecoveryPayloadFactory.java
@@ -53,7 +53,6 @@ final class MCPSQLRecoveryPayloadFactory {
         cause.getClassificationResult().getSavepointName().ifPresent(optional -> result.put("savepoint", optional));
         result.put("suggested_arguments", cause.getSuggestedArguments());
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.callTool(cause.getTargetTool(), createSQLToolMismatchActionReason(cause), cause.getSuggestedArguments())));
-        result.put("ask_user_when_uncertain", false);
         return result;
     }
     
@@ -71,7 +70,6 @@ final class MCPSQLRecoveryPayloadFactory {
                 MCPNextActionUtils.dependsOn(MCPNextActionUtils.callTool("database_gateway_execute_explain_query",
                         "Regenerate explain_sql from sql without changing sql, then retry the explain tool with the generated explain_sql.",
                         createExplainRetryArguments(cause)), 1)));
-        result.put("ask_user_when_uncertain", false);
         return result;
     }
     
@@ -96,7 +94,6 @@ final class MCPSQLRecoveryPayloadFactory {
         result.put("secret_safe", true);
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, createRuleDistSQLExecutionResources(cause.getDatabase()));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, createRuleDistSQLExecutionNextActions(cause.getDatabase()));
-        result.put("ask_user_when_uncertain", false);
         return result;
     }
     
@@ -137,7 +134,6 @@ final class MCPSQLRecoveryPayloadFactory {
         Map<String, Object> suggestedArguments = createMetadataSearchArguments(cause.getStatementType());
         result.put("suggested_arguments", suggestedArguments);
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, createMetadataIntrospectionNextActions(resourcesToRead, suggestedArguments));
-        result.put("ask_user_when_uncertain", false);
         return result;
     }
     
@@ -193,7 +189,6 @@ final class MCPSQLRecoveryPayloadFactory {
     static Map<String, Object> createMultipleStatementsRecovery() {
         Map<String, Object> result = MCPRecoveryPayloadSupport.createBaseRecovery(
                 "multiple_sql_statements", "Split the user intent into separate MCP calls and handle each statement independently.");
-        result.put("ask_user_when_uncertain", true);
         result.put("suggested_arguments", Map.of(MCPPayloadFieldNames.EXECUTION_MODE, "preview"));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.askUser(
                 "Ask the user which single statement should be handled first.", List.of("single_sql_statement"))));
@@ -206,7 +201,6 @@ final class MCPSQLRecoveryPayloadFactory {
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, MCPRecoveryPayloadSupport.createResourceHintList(
                 "shardingsphere://capabilities", "capability", "Read supported SQL statement classes before retrying."));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.readResource("shardingsphere://capabilities", "Read supported statement classes before retrying.")));
-        result.put("ask_user_when_uncertain", true);
         return result;
     }
     
@@ -217,7 +211,6 @@ final class MCPSQLRecoveryPayloadFactory {
                 "shardingsphere://capabilities", "capability", "Read supported safe alternatives before asking the user."));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.askUser(
                 "Ask for a safer supported operation instead of executing the banned SQL.", List.of("safe_sql_or_metadata_request"))));
-        result.put("ask_user_when_uncertain", true);
         return result;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPWorkflowRecoveryPayloadFactory.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPWorkflowRecoveryPayloadFactory.java
@@ -58,7 +58,6 @@ final class MCPWorkflowRecoveryPayloadFactory {
         result.put("suggested_arguments", suggestedArguments);
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.callTool(
                 WorkflowToolDescriptors.APPLY_TOOL_NAME, "Preview again, then copy only visible approval_step values into approved_steps.", suggestedArguments)));
-        result.put("ask_user_when_uncertain", true);
         return result;
     }
     
@@ -80,7 +79,6 @@ final class MCPWorkflowRecoveryPayloadFactory {
                         .build()),
                 MCPNextActionUtils.dependsOn(MCPNextActionUtils.readResource(
                         "shardingsphere://capabilities", "Read current workflow tools, then re-run the matching planning tool if completion has no usable plan."), 1)));
-        result.put("ask_user_when_uncertain", false);
         return result;
     }
     
@@ -115,7 +113,6 @@ final class MCPWorkflowRecoveryPayloadFactory {
             result.put("missing_fields", List.of(WorkflowFieldNames.EXECUTION_MODE));
         }
         result.put(MCPPayloadFieldNames.FIELD, WorkflowFieldNames.EXECUTION_MODE);
-        result.put("source_tool", toolName);
         result.put("tool_name", toolName);
         result.put(MCPPayloadFieldNames.ALLOWED_VALUES, allowedValues);
         Map<String, Object> suggestedArguments = MCPRecoveryPayloadSupport.getSuggestedArguments(sourceSuggestedArguments,
@@ -124,7 +121,6 @@ final class MCPWorkflowRecoveryPayloadFactory {
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(retryTool
                 ? MCPNextActionUtils.retryTool(toolName, retryReason, suggestedArguments)
                 : MCPNextActionUtils.callTool(toolName, retryReason, suggestedArguments)));
-        result.put("ask_user_when_uncertain", true);
         return result;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandler.java
@@ -62,19 +62,16 @@ public final class RuntimeStatusHandler implements MCPResourceHandler<MCPFeature
         boolean hasConfiguredDatabase = !databases.isEmpty();
         MCPTransportType activeTransport = handlerContext.getActiveTransport();
         String activeTransportName = activeTransport.name().toLowerCase(Locale.ENGLISH);
-        Map<String, Object> result = new LinkedHashMap<>(15, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(12, 1F);
         result.put("response_mode", MCPResponseMode.RUNTIME);
         result.put(MCPPayloadFieldNames.SUMMARY, createSummary(hasConfiguredDatabase, databases.size()));
-        result.put("server_status", hasConfiguredDatabase ? "ready" : "configuration_required");
         result.put("status", hasConfiguredDatabase ? "available" : "configuration_required");
-        result.put("transport", activeTransportName);
         result.put("active_transport", activeTransportName);
         result.put("transport_security_summary", createTransportSecuritySummary(activeTransport));
         result.put("configured_database_count", databases.size());
         result.put("databases", databases.stream().map(each -> createDatabaseStatus(handlerContext, each)).toList());
         result.put("readiness", createReadiness(hasConfiguredDatabase));
         result.put("runtime_protection", MCPRuntimeProtectionPolicy.createRuntimeProtectionPayload());
-        result.put("redaction_summary", Map.of("categories", List.of(), "redacted_count", 0, "marker", "******"));
         result.put("diagnostics", createDiagnostics(hasConfiguredDatabase));
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, createResourcesToRead(hasConfiguredDatabase));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, createNextActions(hasConfiguredDatabase));
@@ -88,8 +85,7 @@ public final class RuntimeStatusHandler implements MCPResourceHandler<MCPFeature
     }
     
     private Map<String, Object> createTransportSecuritySummary(final MCPTransportType activeTransport) {
-        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
-        result.put("transport", activeTransport.name().toLowerCase(Locale.ENGLISH));
+        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
         result.put("authentication", MCPTransportType.HTTP == activeTransport ? "not_enabled_by_mcp_transport" : "local_client_process");
         result.put("recommended_exposure", MCPTransportType.HTTP == activeTransport ? "loopback_or_trusted_gateway" : "local_stdio_session");
         result.put("model_action", "Do not request or echo JDBC URLs, credentials, raw environment variables, or stack traces.");
@@ -170,15 +166,10 @@ public final class RuntimeStatusHandler implements MCPResourceHandler<MCPFeature
     
     private Map<String, Object> createDatabaseStatus(final MCPFeatureRequestContext handlerContext, final RuntimeDatabaseProfile database) {
         Optional<MCPDatabaseCapability> capability = handlerContext.getCapabilityFacade().provide(database.getDatabase());
-        Map<String, Object> result = new LinkedHashMap<>(10, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
         result.put("database", database.getDatabase());
         result.put("database_type", database.getDatabaseType());
-        result.put("driver_category", database.getDatabaseType().toLowerCase());
-        result.put("schema_count", 0);
-        result.put("metadata_visibility", "ready");
         result.put("capabilities", capability.map(this::createCapabilityStatus).orElseGet(this::createUnavailableCapabilityStatus));
-        result.put("capability_visibility", capability.isPresent() ? "ready" : "unavailable");
-        result.put("feature_visibility", "ready");
         result.put(MCPPayloadFieldNames.RESOURCE, MCPResourceHintUtils.create(String.format("shardingsphere://databases/%s", MCPUriPathSegmentUtils.encodePathSegment(database.getDatabase())),
                 "logical-database", "inspect_detail", "Read this logical database resource for metadata details.", "databases"));
         return result;

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandler.java
@@ -21,8 +21,6 @@ import org.apache.shardingsphere.mcp.support.protocol.payload.MCPMapPayload;
 import org.apache.shardingsphere.mcp.api.payload.MCPSuccessPayload;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
 import org.apache.shardingsphere.mcp.api.MCPRequestContext;
-import org.apache.shardingsphere.mcp.core.resource.handler.ResourceDefinitionRegistry;
-import org.apache.shardingsphere.mcp.core.tool.handler.ToolDefinitionRegistry;
 import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPStatement;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogIndex;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
@@ -48,7 +46,6 @@ public final class ServerCapabilitiesHandler implements MCPResourceHandler<MCPRe
     
     @Override
     public MCPSuccessPayload handle(final MCPRequestContext handlerContext, final MCPUriVariables uriVariables) {
-        return new MCPMapPayload(MCPDescriptorCatalogIndex.createCapabilityPayload(
-                ResourceDefinitionRegistry.getSupportedResources(), ToolDefinitionRegistry.getSupportedTools(), Set.of(SupportedMCPStatement.values())));
+        return new MCPMapPayload(MCPDescriptorCatalogIndex.createCapabilityPayload(Set.of(SupportedMCPStatement.values())));
     }
 }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceResponseFactory.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceResponseFactory.java
@@ -71,7 +71,7 @@ public final class MetadataResourceResponseFactory {
         if (items.isEmpty()) {
             appendEmptyStateGuidance(navigationPayload, metadata, requestContext, uriVariables, descriptor.getUriTemplate());
         } else if (isTruncated(items, returnedItems)) {
-            appendLargeResultGuidance(navigationPayload, metadata, uriVariables, items.size());
+            appendLargeResultGuidance(navigationPayload, metadata, uriVariables);
         }
         return new MCPItemsPayload(returnedItems, navigationPayload);
     }
@@ -86,7 +86,6 @@ public final class MetadataResourceResponseFactory {
     
     private void appendListSizeMetadata(final Map<String, Object> payload, final int totalCount, final int returnedCount) {
         payload.put("total_count", totalCount);
-        payload.put("returned_count", returnedCount);
         payload.put("truncated", returnedCount < totalCount);
     }
     
@@ -95,19 +94,15 @@ public final class MetadataResourceResponseFactory {
     }
     
     private Map<String, Object> createDetailPayload(final ShardingSphereMCPResourceMetadata metadata, final List<?> items, final Map<String, Object> navigationPayload) {
-        Map<String, Object> result = new LinkedHashMap<>(navigationPayload.size() + 7, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(navigationPayload.size() + 6, 1F);
         result.put("response_mode", MCPResponseMode.DETAIL);
         result.put(MCPPayloadFieldNames.SUMMARY, createDetailSummary(metadata, items));
         result.put(MCPPayloadFieldNames.RESOURCE_KIND, "detail");
         if (null != metadata.getObjectScope()) {
             result.put("object_scope", metadata.getObjectScope());
         }
-        result.put("found", !items.isEmpty());
         result.put(MCPPayloadFieldNames.ITEMS, items);
         result.put("count", items.size());
-        if (!items.isEmpty()) {
-            result.put("item", items.getFirst());
-        }
         result.putAll(navigationPayload);
         return result;
     }
@@ -143,7 +138,7 @@ public final class MetadataResourceResponseFactory {
         emptyState.put(MCPPayloadFieldNames.RESOURCE_KIND, resourceKind);
         payload.put("empty_state", emptyState);
         String parentUri = getResourceHintUri(payload.get(MCPPayloadFieldNames.PARENT_RESOURCE));
-        payload.put(MCPPayloadFieldNames.RECOVERY, createRecovery(recoveryCategory, resourceKind, parentUri, uriVariables));
+        payload.put(MCPPayloadFieldNames.RECOVERY, createRecovery(recoveryCategory, uriVariables));
         payload.put(MCPPayloadFieldNames.NEXT_ACTIONS, parentUri.isEmpty()
                 ? List.of(MCPNextActionUtils.stop(reason))
                 : List.of(MCPNextActionUtils.readResource(parentUri, "Read the parent metadata resource before broadening or correcting the request.")));
@@ -205,21 +200,22 @@ public final class MetadataResourceResponseFactory {
                 : "No metadata items are visible in this scope. Check metadata permissions if objects are expected.";
     }
     
-    private Map<String, Object> createRecovery(final String category, final String resourceKind, final String parentUri, final MCPUriVariables uriVariables) {
-        Map<String, Object> result = new LinkedHashMap<>(6, 1F);
-        result.put("response_mode", MCPResponseMode.RECOVERY);
-        result.put("recovery_category", category);
+    private Map<String, Object> createRecovery(final String category, final MCPUriVariables uriVariables) {
+        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
+        result.put("recovery_category", normalizeRecoveryCategory(category));
         result.put("category", category);
-        result.put(MCPPayloadFieldNames.RESOURCE_KIND, resourceKind);
-        if (!parentUri.isEmpty()) {
-            result.put("parent_resource_uri", parentUri);
-        }
         String requestedToken = createRequestedToken(uriVariables);
         if (!requestedToken.isEmpty()) {
             result.put("requested_token", requestedToken);
-            result.put("retry_arguments", Map.of("query", requestedToken));
         }
         return result;
+    }
+    
+    private String normalizeRecoveryCategory(final String category) {
+        if (MCPDiagnosticCategory.NO_RUNTIME_DATABASE.equals(category)) {
+            return "unavailable_runtime";
+        }
+        return MCPDiagnosticCategory.EMPTY_SCOPE.equals(category) ? MCPDiagnosticCategory.EMPTY_SCOPE : MCPDiagnosticCategory.NOT_FOUND;
     }
     
     private String createRequestedToken(final MCPUriVariables uriVariables) {
@@ -227,11 +223,9 @@ public final class MetadataResourceResponseFactory {
                 .filter(uriVariables::containsVariable).findFirst().map(uriVariables::getValue).orElse("");
     }
     
-    private void appendLargeResultGuidance(final Map<String, Object> payload, final ShardingSphereMCPResourceMetadata metadata,
-                                           final MCPUriVariables uriVariables, final int itemCount) {
+    private void appendLargeResultGuidance(final Map<String, Object> payload, final ShardingSphereMCPResourceMetadata metadata, final MCPUriVariables uriVariables) {
         Map<String, Object> largeResult = new LinkedHashMap<>(4, 1F);
         largeResult.put("state", "broad_metadata_list");
-        largeResult.put("count", itemCount);
         largeResult.put("threshold", LARGE_RESULT_THRESHOLD);
         largeResult.put(MCPPayloadFieldNames.REASON,
                 "This metadata resource returned many items. Use database_gateway_search_metadata with an explicit query or scope before reading many detail resources.");
@@ -244,7 +238,7 @@ public final class MetadataResourceResponseFactory {
     }
     
     private Map<String, Object> createNarrowSearchArguments(final ShardingSphereMCPResourceMetadata metadata, final MCPUriVariables uriVariables) {
-        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
         if (uriVariables.containsVariable("database")) {
             result.put("database", uriVariables.getValue("database"));
         }
@@ -283,7 +277,6 @@ public final class MetadataResourceResponseFactory {
         String uriTemplate = descriptor.getUriTemplate();
         Optional<String> selfUri = new MCPUriTemplate(uriTemplate).expandIfComplete(uriVariables);
         selfUri.ifPresent(uri -> {
-            result.put("self_uri", uri);
             result.put(MCPPayloadFieldNames.SELF_RESOURCE,
                     MCPResourceHintUtils.create(uri, resolveResourceKind(uri), "inspect_self", "Read this metadata resource.", MCPPayloadFieldNames.SELF_RESOURCE));
         });

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandler.java
@@ -124,7 +124,6 @@ public final class ExecuteUpdateToolHandler implements MCPToolHandler<MCPFeature
         result.put("review_guidance", createReviewGuidance(classificationResult));
         String reviewSummary = createReviewSummary(classificationResult);
         result.put(MCPPayloadFieldNames.SUMMARY, reviewSummary);
-        result.put("review_summary", reviewSummary);
         Map<String, Object> suggestedArguments = createSuggestedArguments(toolArguments, classificationResult);
         result.put("suggested_arguments", suggestedArguments);
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, createResourcesToRead(toolArguments));

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataPayloadBuilder.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataPayloadBuilder.java
@@ -52,11 +52,10 @@ public final class SearchMetadataPayloadBuilder {
      */
     public static Map<String, Object> build(final MCPFeatureRequestContext requestContext, final MetadataSearchRequest request,
                                             final MetadataSearchResult searchResult, final String toolName) {
-        Map<String, Object> result = new LinkedHashMap<>(9, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(8, 1F);
         result.put(MCPPayloadFieldNames.SUMMARY, createSummary(searchResult));
         result.put("search_context", searchResult.getSearchContext());
         result.put("total_match_count", searchResult.getTotalMatchCount());
-        result.put("returned_count", searchResult.getReturnedCount());
         result.put("truncated", searchResult.isTruncated());
         if (searchResult.isTruncated()) {
             result.put("large_result_guidance", createLargeResultGuidance(searchResult));

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/payload/RuntimeDatabaseValidationPayload.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/payload/RuntimeDatabaseValidationPayload.java
@@ -66,9 +66,13 @@ public final class RuntimeDatabaseValidationPayload implements MCPSuccessPayload
         result.put("database", validationResult.getDatabase());
         result.put("checks", createChecksPayload());
         result.put("category", validationResult.getCategory());
-        result.put(MCPPayloadFieldNames.RECOVERY, recovery);
-        if (recovery.containsKey(MCPPayloadFieldNames.NEXT_ACTIONS)) {
-            result.put(MCPPayloadFieldNames.NEXT_ACTIONS, recovery.get(MCPPayloadFieldNames.NEXT_ACTIONS));
+        if (!recovery.isEmpty()) {
+            Map<String, Object> recoveryPayload = new LinkedHashMap<>(recovery);
+            result.put(MCPPayloadFieldNames.NEXT_ACTIONS, recoveryPayload.remove(MCPPayloadFieldNames.NEXT_ACTIONS));
+            recoveryPayload.remove("response_mode");
+            recoveryPayload.remove("category");
+            recoveryPayload.remove("database");
+            result.put(MCPPayloadFieldNames.RECOVERY, recoveryPayload);
         }
         return result;
     }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/payload/SQLExecutionPayload.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/payload/SQLExecutionPayload.java
@@ -95,9 +95,6 @@ public final class SQLExecutionPayload implements MCPSuccessPayload {
         if (SQLExecutionResultKind.UPDATE_COUNT == executionResult.getResultKind()) {
             result.put("affected_rows", executionResult.getAffectedRows());
         }
-        if (SQLExecutionResultKind.STATEMENT_ACK == executionResult.getResultKind()) {
-            result.put(MCPPayloadFieldNames.MESSAGE, createStatementAcknowledgement());
-        }
         result.put("applied_max_rows", executionResult.getAppliedMaxRows());
         result.put("applied_timeout_ms", executionResult.getAppliedTimeoutMs());
         result.put("truncated", executionResult.isTruncated());

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyOutcome.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyOutcome.java
@@ -36,12 +36,9 @@ public final class WorkflowApplyOutcome {
     
     private final List<Map<String, Object>> stepResults = new LinkedList<>();
     
-    private final List<String> executedDistSql = new LinkedList<>();
-    
     private final List<Map<String, Object>> issues = new LinkedList<>();
     
     void addExecutedArtifact(final WorkflowArtifactBundle.ExecutableWorkflowArtifact artifact) {
-        executedDistSql.add(artifact.displaySql());
         stepResults.add(createStepResult(WorkflowArtifactPayloadUtils.ARTIFACT_TYPE_RULE_DISTSQL, WorkflowLifecycle.STATUS_PASSED, artifact.displaySql()));
     }
     
@@ -61,16 +58,15 @@ public final class WorkflowApplyOutcome {
                 "Inspect mismatches and re-run validation after the Proxy state converges.", true, Map.of("mismatches", mismatches)).toMap());
     }
     
-    void addSecretReferenceManualExecutionRequired(final String category, final Map<String, Object> secretReferenceSummary) {
+    void addSecretReferenceManualExecutionRequired() {
         issues.add(new WorkflowIssue(WorkflowIssueCode.SECRET_REFERENCE_MANUAL_EXECUTION_REQUIRED, "error", WorkflowLifecycle.STEP_REVIEW,
                 "Sensitive placeholders require manual execution outside MCP.",
-                "Review manual artifacts, replace neutral placeholders outside MCP, and execute them through the normal operational channel.", true,
-                Map.of("category", category, "secret_reference_summary", secretReferenceSummary)).toMap());
+                "Review manual artifacts, replace neutral placeholders outside MCP, and execute them through the normal operational channel.", true, Map.of()).toMap());
     }
     
     Map<String, Object> createResponse(final String status, final WorkflowContextSnapshot snapshot, final String executionMode, final Map<String, Object> manualArtifactPackage) {
         return new WorkflowApplyResponseBuilder().build(snapshot, status, executionMode,
-                issues, stepResults, executedDistSql, manualArtifactPackage);
+                issues, stepResults, manualArtifactPackage);
     }
     
     private static Map<String, Object> createStepResult(final String artifactType, final String status, final String sql) {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilder.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilder.java
@@ -48,29 +48,26 @@ public final class WorkflowApplyResponseBuilder {
      * @param executionMode execution mode
      * @param issues workflow issues
      * @param stepResults step results
-     * @param executedDistSql executed DistSQL
      * @param manualArtifactPackage manual artifact package
      * @return workflow apply response payload
      */
     public Map<String, Object> build(final WorkflowContextSnapshot snapshot, final String status, final String executionMode,
                                      final Collection<Map<String, Object>> issues, final Collection<Map<String, Object>> stepResults,
-                                     final Collection<String> executedDistSql, final Map<String, Object> manualArtifactPackage) {
+                                     final Map<String, Object> manualArtifactPackage) {
         String planId = snapshot.getPlanId();
-        Map<String, Object> result = new LinkedHashMap<>(24, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(16, 1F);
         result.put("response_mode", resolveResponseMode(status, executionMode));
-        result.put(MCPPayloadFieldNames.SUMMARY, createSummary(planId, status, executionMode, issues, executedDistSql));
+        result.put(MCPPayloadFieldNames.SUMMARY, createSummary(planId, status, executionMode, issues, stepResults));
         result.put(WorkflowFieldNames.PLAN_ID, planId);
         result.put("status", status);
         result.put(WorkflowFieldNames.EXECUTION_MODE, executionMode);
         result.put("issues", issues);
-        result.put("step_results", stepResults);
-        result.put("executed_distsql", executedDistSql);
-        result.put("applied_artifacts", executedDistSql);
-        result.put("manual_artifacts", manualArtifactPackage.isEmpty() ? List.of() : List.of(manualArtifactPackage));
-        result.put(WorkflowArtifactPayloadUtils.PAYLOAD_KEY_MANUAL_ARTIFACT_PACKAGE, manualArtifactPackage);
-        if (WorkflowLifecycle.STATUS_AWAITING_MANUAL_EXECUTION.equals(status) && !manualArtifactPackage.isEmpty()) {
+        if (!stepResults.isEmpty()) {
+            result.put("step_results", stepResults);
+        }
+        if (!manualArtifactPackage.isEmpty()) {
+            result.put(WorkflowArtifactPayloadUtils.PAYLOAD_KEY_MANUAL_ARTIFACT_PACKAGE, manualArtifactPackage);
             result.put("manual_artifact_summary", createManualArtifactSummary(planId, manualArtifactPackage));
-            result.put("manual_follow_up", createManualFollowUp());
         }
         WorkflowGuidancePayloadBuilder.appendApplyGuidance(result, status);
         return result;
@@ -86,7 +83,7 @@ public final class WorkflowApplyResponseBuilder {
      */
     Map<String, Object> buildFailureResponse(final WorkflowContextSnapshot snapshot, final String executionMode,
                                              final Collection<Map<String, Object>> issues) {
-        return build(snapshot, WorkflowLifecycle.STATUS_FAILED, executionMode, issues, List.of(), List.of(), Map.of());
+        return build(snapshot, WorkflowLifecycle.STATUS_FAILED, executionMode, issues, List.of(), Map.of());
     }
     
     /**
@@ -95,20 +92,17 @@ public final class WorkflowApplyResponseBuilder {
      * @param snapshot workflow snapshot
      * @param executableArtifacts executable workflow artifacts
      * @param applyExecutionMode execution mode to use after preview
-     * @param manualArtifactPackage manual artifact package
      * @return workflow preview response payload
      */
     public Map<String, Object> buildPreviewResponse(final WorkflowContextSnapshot snapshot, final Collection<WorkflowArtifactBundle.ExecutableWorkflowArtifact> executableArtifacts,
-                                                    final String applyExecutionMode, final Map<String, Object> manualArtifactPackage) {
+                                                    final String applyExecutionMode) {
         List<Map<String, Object>> previewArtifacts = createPreviewArtifacts(executableArtifacts);
         Map<String, Object> result = build(snapshot, STATUS_PREVIEW, WorkflowLifecycle.EXECUTION_MODE_PREVIEW,
-                List.of(), List.of(), List.of(), manualArtifactPackage);
+                List.of(), List.of(), Map.of());
         result.put("would_apply", false);
         result.put("preview_artifacts", previewArtifacts);
         result.put("review_focus", createPreviewReviewFocus(applyExecutionMode, previewArtifacts));
-        String reviewSummary = createReviewSummary(previewArtifacts);
-        result.put(MCPPayloadFieldNames.SUMMARY, reviewSummary);
-        result.put("review_summary", reviewSummary);
+        result.put(MCPPayloadFieldNames.SUMMARY, createReviewSummary(previewArtifacts));
         result.put("argument_provenance", createPreviewArgumentProvenance());
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, createPreviewNextActions(snapshot, applyExecutionMode, previewArtifacts));
         return result;
@@ -125,12 +119,13 @@ public final class WorkflowApplyResponseBuilder {
     }
     
     private String createSummary(final String planId, final String status, final String executionMode, final Collection<Map<String, Object>> issues,
-                                 final Collection<String> executedDistSql) {
+                                 final Collection<Map<String, Object>> stepResults) {
         if (WorkflowLifecycle.EXECUTION_MODE_PREVIEW.equals(executionMode)) {
             return String.format("Workflow apply preview is ready for plan `%s`.", planId);
         }
         if (WorkflowLifecycle.STATUS_COMPLETED.equals(status)) {
-            return String.format("Workflow apply completed for plan `%s` with %d applied artifact(s).", planId, executedDistSql.size());
+            long appliedArtifactCount = stepResults.stream().filter(each -> WorkflowLifecycle.STATUS_PASSED.equals(each.get("status"))).count();
+            return String.format("Workflow apply completed for plan `%s` with %d applied artifact(s).", planId, appliedArtifactCount);
         }
         if (WorkflowLifecycle.STATUS_AWAITING_MANUAL_EXECUTION.equals(status)) {
             return String.format("Workflow apply exported manual artifacts for plan `%s`; external execution is required before validation.", planId);
@@ -209,25 +204,17 @@ public final class WorkflowApplyResponseBuilder {
         return Map.of(WorkflowFieldNames.PLAN_ID, snapshot.getPlanId(), WorkflowFieldNames.EXECUTION_MODE, executionMode);
     }
     
-    private Map<String, Object> createManualFollowUp() {
-        return Map.of(
-                "confirmation_required", true,
-                "confirmation_field", "manual_artifacts_executed",
-                "validation_blocked_until", "manual_artifacts_executed",
-                "validation_tool_after_manual_execution", WorkflowToolDescriptors.VALIDATE_TOOL_NAME,
-                "safe_independent_read_only_checks", "database_gateway_execute_query may run before manual execution confirmation when the user asked for read-only verification.");
-    }
-    
     private Map<String, Object> createManualArtifactSummary(final String planId, final Map<String, Object> manualArtifactPackage) {
         int distSqlArtifactCount = getCollectionSize(manualArtifactPackage, WorkflowArtifactPayloadUtils.PAYLOAD_KEY_DISTSQL_ARTIFACTS);
         Map<String, Object> result = new LinkedHashMap<>(7, 1F);
-        result.put("total_artifact_count", distSqlArtifactCount);
         result.put("distsql_artifact_count", distSqlArtifactCount);
         result.put("external_execution_required", true);
         result.put("requires_user_confirmation", true);
         result.put("validation_blocked_until", "manual_artifacts_executed");
         result.put("validation_tool_after_manual_execution", WorkflowToolDescriptors.VALIDATE_TOOL_NAME);
         result.put("validation_arguments_after_manual_execution", Map.of(WorkflowFieldNames.PLAN_ID, planId));
+        result.put("safe_independent_read_only_checks",
+                "database_gateway_execute_query may run before manual execution confirmation when the user asked for read-only verification.");
         return result;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionService.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionService.java
@@ -188,7 +188,7 @@ public final class WorkflowExecutionService {
                 result.put("would_apply", false);
                 result.put("preview_artifacts", List.of());
             }
-            result.put("review_summary", "Workflow apply blocked invalid generated artifacts before approval.");
+            result.put(MCPPayloadFieldNames.SUMMARY, "Workflow apply blocked invalid generated artifacts before approval.");
             result.put(MCPPayloadFieldNames.NEXT_ACTIONS,
                     MCPNextActionUtils.ordered(MCPNextActionUtils.stop("Fix generated workflow artifacts, then preview the workflow again.")));
             return result;
@@ -199,7 +199,7 @@ public final class WorkflowExecutionService {
     private Map<String, Object> previewApply(final WorkflowSessionContext workflowSessionContext, final WorkflowContextSnapshot snapshot) {
         persistSnapshot(workflowSessionContext, snapshot, WorkflowLifecycle.STEP_REVIEW, WorkflowLifecycle.STATUS_PREVIEWED);
         return new WorkflowApplyResponseBuilder().buildPreviewResponse(snapshot,
-                createExecutableArtifacts(snapshot), resolveApplyExecutionMode(snapshot), createArtifactPayload(snapshot));
+                createExecutableArtifacts(snapshot), resolveApplyExecutionMode(snapshot));
     }
     
     private Map<String, Object> createPreviewSuggestedArguments(final WorkflowContextSnapshot snapshot) {
@@ -266,16 +266,15 @@ public final class WorkflowExecutionService {
                                                                            final String executionMode, final WorkflowApplyOutcome applyOutcome) {
         persistSnapshot(workflowSessionContext, snapshot, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
         WorkflowPropertySource propertySource = getPropertySource(snapshot);
-        Map<String, Object> secretReferenceSummary = WorkflowArtifactMaskUtils.createSecretReferenceSummary(propertySource);
         String category = WorkflowSecretReferenceUtils.hasMalformedSecretReferences(propertySource)
                 ? MCPDiagnosticCategory.SECRET_REFERENCE_MALFORMED
                 : MCPDiagnosticCategory.SECRET_REFERENCE_MANUAL_EXECUTION_REQUIRED;
-        applyOutcome.addSecretReferenceManualExecutionRequired(category, secretReferenceSummary);
+        applyOutcome.addSecretReferenceManualExecutionRequired();
         Map<String, Object> result = applyOutcome.createResponse(WorkflowLifecycle.STATUS_FAILED, snapshot, executionMode, createArtifactPayload(snapshot));
         result.put("response_mode", MCPResponseMode.RECOVERY);
         result.put("category", category);
-        result.put("message", "This workflow contains sensitive placeholders that must be filled outside MCP before execution.");
-        result.put("secret_reference_summary", secretReferenceSummary);
+        result.put(MCPPayloadFieldNames.SUMMARY, "This workflow contains sensitive placeholders that must be filled outside MCP before execution.");
+        result.put("secret_reference_summary", WorkflowArtifactMaskUtils.createSecretReferenceSummary(propertySource));
         WorkflowGuidancePayloadBuilder.appendApplyGuidance(result, WorkflowLifecycle.STATUS_FAILED);
         return result;
     }

--- a/mcp/core/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-core.yaml
+++ b/mcp/core/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-core.yaml
@@ -19,8 +19,8 @@ resources:
     name: server-capability-catalog
     title: ShardingSphere MCP Capability Catalog
     description: >
-      Generated ShardingSphere domain catalog for resources, resource templates, tools, prompts, completions, workflow relationships,
-      and navigation hints. Read shardingsphere://guidance for model-facing workflow and safety guidance.
+      Generated ShardingSphere domain catalog for supported SQL statement classes, completion targets, workflow relationships, and navigation hints.
+      Use MCP list methods for resources, resource templates, tools, and prompts. Read shardingsphere://guidance for model-facing workflow and safety guidance.
     mimeType: application/json
     annotations:
       audience:
@@ -945,9 +945,6 @@ tools:
         count:
           type: integer
           description: "Number of matched metadata items returned in this response."
-        has_more:
-          type: boolean
-          description: "Whether an application-level continuation mode is active. Metadata search returns false; not MCP list pagination."
         continuation_mode:
           type: string
           description: "ShardingSphere application continuation mode for this metadata search result; not MCP cursor or nextCursor semantics."
@@ -959,9 +956,6 @@ tools:
         total_match_count:
           type: integer
           description: "Total matched metadata objects for this search scope."
-        returned_count:
-          type: integer
-          description: "Number of matched metadata objects returned after search result capping."
         truncated:
           type: boolean
           description: "Whether search hits were capped by the large-result threshold."
@@ -1072,10 +1066,8 @@ tools:
                 - name
               matched_value: orders
           count: 1
-          has_more: false
           continuation_mode: none
           total_match_count: 1
-          returned_count: 1
           truncated: false
           search_context:
             query: orders
@@ -1157,10 +1149,10 @@ tools:
           description: "Overall result category. ready indicates success; other values reuse runtime database connection failure categories."
         recovery:
           type: object
-          description: "Structured runtime recovery payload. Empty when status is ready."
+          description: "Structured runtime recovery payload present only when status is failed."
         next_actions:
           type: array
-          description: "Top-level structured follow-up actions copied from recovery when validation fails."
+          description: "Canonical top-level structured follow-up actions when validation fails."
           items:
             type: object
             properties:
@@ -1640,9 +1632,6 @@ tools:
         affected_rows:
           type: integer
           description: "Affected row count when the database reports one."
-        message:
-          type: string
-          description: "Execution message for statements without row results."
         columns:
           type: array
           description: "Returned column definitions when result_kind is result_set."
@@ -1682,9 +1671,6 @@ tools:
         review_guidance:
           type: string
           description: "Preview-only guidance before execution."
-        review_summary:
-          type: string
-          description: "Preview-only natural-language summary that confirms the statement was not executed."
         suggested_arguments:
           type: object
           description: "Preview-only arguments to reuse for execution after review."
@@ -1747,7 +1733,6 @@ tools:
           review_guidance: >-
             Review normalized_sql and side_effect_scope before execution. This preview performs database-aware validation and classification; it does not guarantee
             rule validation, algorithm initialization, affected rows, or runtime success.
-          review_summary: Previewed UPDATE statement with side-effect scope physical-data. It has not been executed.
           suggested_arguments:
             execution_mode: execute
           next_actions:
@@ -1757,7 +1742,6 @@ tools:
               question: Confirm that normalized_sql and side_effect_scope still match the intended side effect before execution.
               required_inputs:
                 - execution_approved
-              reason: Confirm that normalized_sql and side_effect_scope still match the intended side effect before execution.
             - order: 2
               type: tool_call
               title: Call database_gateway_execute_update

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionServiceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionServiceTest.java
@@ -80,7 +80,7 @@ class MCPCompletionServiceTest {
         assertThat(actual.getTotal(), is(2));
         assertTrue(actual.hasMore());
         assertThat(actual.getMeta().get(MCPShardingSphereMetadataKeys.DIAGNOSTIC), is("ok"));
-        assertThat(actual.getMeta().get(MCPShardingSphereMetadataKeys.RETURNED_CANDIDATE_COUNT), is(1));
+        assertThat(actual.getMeta().get(MCPShardingSphereMetadataKeys.CANDIDATE_COUNT), is(2));
     }
     
     @Test

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorConverterTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorConverterTest.java
@@ -79,8 +79,8 @@ class MCPErrorConverterTest {
         MCPErrorPayload actual = MCPErrorConverter.convert(cause);
         Map<String, Object> actualPayload = actual.toPayload();
         assertThat(actualPayload.get("response_mode"), is("recovery"));
-        assertThat(actualPayload.get("message"), is(expectedMessage));
-        assertTrue(String.valueOf(actualPayload.get("request_id")).matches("[0-9a-f\\-]{36}"));
+        assertThat(actualPayload.get("summary"), is(expectedMessage));
+        assertTrue(String.valueOf(actualPayload.get("error_id")).matches("[0-9a-f\\-]{36}"));
         assertFalse(actualPayload.containsKey("recovery"));
     }
     
@@ -92,8 +92,8 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("recovery_category"), is("unsupported_target"));
         assertThat(actualRecovery.get("tool_name"), is("missing_tool"));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://capabilities"));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("resource_uri"), is("shardingsphere://capabilities"));
-        assertTrue(((Collection<?>) actualRecovery.get("supported_tools")).contains("database_gateway_execute_query"));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("resource_uri"), is("shardingsphere://capabilities"));
+        assertThat(actualRecovery.get("discovery_method"), is("tools/list"));
     }
     
     @Test
@@ -104,8 +104,8 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("recovery_category"), is("unsupported_target"));
         assertThat(((Map<?, ?>) actualRecovery.get("resource")).get("uri"), is("shardingsphere://unknown"));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://capabilities"));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("type"), is("resource_read"));
-        assertTrue(((Collection<?>) actualRecovery.get("matching_resource_templates")).contains("shardingsphere://capabilities"));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("type"), is("resource_read"));
+        assertThat(actualRecovery.get("discovery_methods"), is(List.of("resources/list", "resources/templates/list")));
     }
     
     @Test
@@ -116,8 +116,7 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("recovery_category"), is("missing_context"));
         assertThat(actualRecovery.get("missing_fields"), is(List.of("database")));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://databases"));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("resource_uri"), is("shardingsphere://databases"));
-        assertTrue((Boolean) actualRecovery.get("ask_user_when_uncertain"));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("resource_uri"), is("shardingsphere://databases"));
     }
     
     @Test
@@ -128,7 +127,7 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("recovery_category"), is("missing_context"));
         assertThat(actualRecovery.get("missing_fields"), is(List.of("execution_mode")));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("execution_mode", "preview")));
-        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
+        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_execute_update"));
     }
@@ -141,11 +140,10 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("category"), is("missing_execution_mode"));
         assertThat(actualRecovery.get("recovery_category"), is("missing_context"));
         assertThat(actualRecovery.get("field"), is("execution_mode"));
-        assertThat(actualRecovery.get("source_tool"), is("database_gateway_apply_workflow"));
         assertThat(actualRecovery.get("tool_name"), is("database_gateway_apply_workflow"));
         assertThat(actualRecovery.get("allowed_values"), is(List.of("preview", "review-then-execute", "manual-only")));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("execution_mode", "preview")));
-        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
+        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_apply_workflow"));
     }
@@ -159,7 +157,7 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("recovery_category"), is("invalid_enum"));
         assertThat(actualRecovery.get("allowed_values"), is(List.of("preview", "review-then-execute", "manual-only")));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("execution_mode", "preview")));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("tool_name"), is("database_gateway_apply_workflow"));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("tool_name"), is("database_gateway_apply_workflow"));
     }
     
     @Test
@@ -174,7 +172,7 @@ class MCPErrorConverterTest {
                 is("Retry database_gateway_apply_workflow with execution_mode=preview, review the returned preview_artifacts, "
                         + "then pass explicit approved_steps copied from visible preview_artifacts.approval_step values."));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("execution_mode", "preview")));
-        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
+        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_apply_workflow"));
         assertThat(actualNextAction.get("arguments"), is(Map.of("execution_mode", "preview")));
     }
@@ -189,7 +187,7 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("field"), is("object_types"));
         assertTrue(((Collection<?>) actualRecovery.get("allowed_values")).contains("table"));
         assertTrue(((Collection<?>) ((Map<?, ?>) actualRecovery.get("suggested_arguments")).get("object_types")).contains("table"));
-        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
+        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_search_metadata"));
     }
@@ -200,13 +198,13 @@ class MCPErrorConverterTest {
                 new MCPInvalidRequestException("max_rows must be an integer."))).toPayload();
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
         assertThat(actualRecovery.get("category"), is("invalid_integer_argument"));
-        assertThat(actualRecovery.get("argument_path"), is("max_rows"));
+        assertThat(actualRecovery.get("field"), is("max_rows"));
         assertThat(actualRecovery.get("source_tool"), is("database_gateway_execute_query"));
         assertThat(actualRecovery.get("tool_name"), is("database_gateway_execute_query"));
         assertThat(actualRecovery.get("minimum_value"), is(0));
         assertThat(actualRecovery.get("maximum_value"), is(5000));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("max_rows", 100)));
-        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
+        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_execute_query"));
     }
     
@@ -215,8 +213,8 @@ class MCPErrorConverterTest {
         Map<String, Object> actual = MCPErrorConverter.convert(new MCPInvalidToolArgumentException("", "", "timeout_ms", 0, 300000, 0,
                 new MCPInvalidRequestException("timeout_ms must be an integer."))).toPayload();
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
-        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
-        assertThat(actualRecovery.get("argument_path"), is("timeout_ms"));
+        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
+        assertThat(actualRecovery.get("field"), is("timeout_ms"));
         assertThat(actualNextAction.get("type"), is("ask_user"));
         assertFalse(actualNextAction.containsKey("tool_name"));
     }
@@ -230,11 +228,10 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("category"), is("invalid_enum_value"));
         assertThat(actualRecovery.get("recovery_category"), is("invalid_enum"));
         assertThat(actualRecovery.get("field"), is("object_types[0]"));
-        assertThat(actualRecovery.get("argument_path"), is("object_types[0]"));
         assertThat(actualRecovery.get("tool_name"), is("database_gateway_search_metadata"));
         assertThat(actualRecovery.get("allowed_values"), is(List.of("database", "schema", "table")));
         assertThat(actualRecovery.get("suggested_arguments"), is(suggestedArguments));
-        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
+        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_search_metadata"));
     }
@@ -246,7 +243,6 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("category"), is("multiple_sql_statements"));
         assertThat(actualRecovery.get("recovery_category"), is("unsafe_sql"));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("execution_mode", "preview")));
-        assertTrue((Boolean) actualRecovery.get("ask_user_when_uncertain"));
     }
     
     @Test
@@ -264,7 +260,7 @@ class MCPErrorConverterTest {
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
         assertThat(actualRecovery.get("category"), is("banned_sql_statement"));
         assertThat(actualRecovery.get("recovery_category"), is("terminal_operator_action"));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("type"), is("ask_user"));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("type"), is("ask_user"));
     }
     
     @Test
@@ -293,23 +289,22 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("source_tool"), is("database_gateway_execute_query"));
         assertThat(actualRecovery.get("normalized_sql"), is("UPDATE orders SET status = 'PAID'"));
         assertThat(actualRecovery.get("suggested_arguments"), is(suggestedArguments));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("arguments"), is(suggestedArguments));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("arguments"), is(suggestedArguments));
     }
     
     @Test
     void assertConvertExplainSQLSyntaxWithRecovery() {
         Map<String, Object> actual = MCPErrorConverter.convert(new ExplainSQLSyntaxException("logic_db", "public", "SELECT * FROM orders", "EXPLAIN BROKEN SELECT * FROM orders",
                 new MCPInvalidRequestException("bad explain", new SQLSyntaxErrorException("bad explain")))).toPayload();
-        assertThat(actual.get("message"), is("Generated explain_sql is not valid for the target database."));
+        assertThat(actual.get("summary"), is("Generated explain_sql is not valid for the target database."));
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
         assertThat(actualRecovery.get("category"), is("invalid_explain_sql"));
         assertThat(actualRecovery.get("rejected_explain_sql"), is("EXPLAIN BROKEN SELECT * FROM orders"));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("database", "logic_db", "schema", "public", "sql", "SELECT * FROM orders")));
-        List<?> actualNextActions = (List<?>) actualRecovery.get("next_actions");
+        List<?> actualNextActions = (List<?>) actual.get("next_actions");
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("reason"),
                 is("Read the target database type before regenerating database-native explain_sql."));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("tool_name"), is("database_gateway_execute_explain_query"));
-        assertFalse((Boolean) actualRecovery.get("ask_user_when_uncertain"));
     }
     
     @Test
@@ -339,7 +334,7 @@ class MCPErrorConverterTest {
         when(classificationResult.getSideEffectScope()).thenReturn("rule-metadata");
         Map<String, Object> actual = MCPErrorConverter.convert(new RuleDistSQLExecutionException(
                 "sharding_db", classificationResult, new SQLSyntaxErrorException("syntax error"))).toPayload();
-        assertThat(actual.get("message"),
+        assertThat(actual.get("summary"),
                 is("Rule DistSQL execution failed for database `sharding_db`; check MCP runtime capability and workflow guidance before asking for corrected SQL."));
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
         assertThat(actualRecovery.get("category"), is("rule_distsql_execution_failed"));
@@ -347,9 +342,8 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("database"), is("sharding_db"));
         assertThat(actualRecovery.get("side_effect_scope"), is(List.of("rule-metadata")));
         assertTrue((Boolean) actualRecovery.get("secret_safe"));
-        assertFalse((Boolean) actualRecovery.get("ask_user_when_uncertain"));
         assertThat(getResourceToRead(actualRecovery, 1).get("uri"), is("shardingsphere://databases/sharding_db/capabilities"));
-        List<?> actualNextActions = (List<?>) actualRecovery.get("next_actions");
+        List<?> actualNextActions = (List<?>) actual.get("next_actions");
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("resource_uri"), is("shardingsphere://guidance"));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("type"), is("resource_read"));
         assertFalse(String.valueOf(actual).contains("syntax error"));
@@ -363,7 +357,7 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("statement_type"), is("SHOW"));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://databases"));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("object_types", List.of("database"))));
-        List<?> actualNextActions = (List<?>) actualRecovery.get("next_actions");
+        List<?> actualNextActions = (List<?>) actual.get("next_actions");
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("resource_uri"), is("shardingsphere://databases"));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("tool_name"), is("database_gateway_search_metadata"));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("arguments"), is(Map.of("object_types", List.of("database"))));
@@ -377,7 +371,7 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("statement_type"), is("SHOW STORAGE UNITS"));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://databases/{database}/storage-units"));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("object_types", List.of("storage_unit"))));
-        List<?> actualNextActions = (List<?>) actualRecovery.get("next_actions");
+        List<?> actualNextActions = (List<?>) actual.get("next_actions");
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("resource_uri"), is("shardingsphere://databases/{database}/storage-units"));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("tool_name"), is("database_gateway_search_metadata"));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("arguments"), is(Map.of("object_types", List.of("storage_unit"))));
@@ -389,7 +383,7 @@ class MCPErrorConverterTest {
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
         assertThat(actualRecovery.get("statement_type"), is("SHOW DEFAULT SINGLE TABLE STORAGE UNIT"));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://databases/{database}/single-table/default-storage-unit"));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("resource_uri"),
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("resource_uri"),
                 is("shardingsphere://databases/{database}/single-table/default-storage-unit"));
     }
     
@@ -403,12 +397,12 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("plan_id"), is("plan-missing"));
         assertThat(actualRecovery.get("completion_first"), is(Map.of("argument", "plan_id", "scope", "current MCP session")));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://capabilities"));
-        Map<?, ?> actualCompletionAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
+        Map<?, ?> actualCompletionAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actualCompletionAction.get("type"), is("completion"));
         assertThat(actualCompletionAction.get("ref"), is(Map.of("type", "ref/resource", "uri", "shardingsphere://workflows/{plan_id}")));
         assertThat(actualCompletionAction.get("resume_ref"), is(Map.of("type", "ref/resource", "uri", "shardingsphere://workflows/{plan_id}")));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).get(1)).get("type"), is("resource_read"));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).get(1)).get("depends_on"), is(List.of(1)));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).get(1)).get("type"), is("resource_read"));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).get(1)).get("depends_on"), is(List.of(1)));
     }
     
     @Test
@@ -422,7 +416,7 @@ class MCPErrorConverterTest {
         Map<?, ?> actualResourceToRead = getFirstResourceToRead(actualRecovery);
         assertThat(actualResourceToRead.get("uri"), is("shardingsphere://runtime"));
         assertThat(actualResourceToRead.get("resource_kind"), is("runtime"));
-        List<?> actualNextActions = (List<?>) actualRecovery.get("next_actions");
+        List<?> actualNextActions = (List<?>) actual.get("next_actions");
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("resource_uri"), is("shardingsphere://runtime"));
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("order"), is(1));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("depends_on"), is(List.of(1)));
@@ -451,7 +445,7 @@ class MCPErrorConverterTest {
         Map<?, ?> actualDatabasesResourceToRead = getResourceToRead(actualRecovery, 1);
         assertThat(actualDatabasesResourceToRead.get("uri"), is("shardingsphere://databases"));
         assertThat(actualDatabasesResourceToRead.get("resource_kind"), is("logical-database"));
-        List<?> actualNextActions = (List<?>) actualRecovery.get("next_actions");
+        List<?> actualNextActions = (List<?>) actual.get("next_actions");
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("resource_uri"), is("shardingsphere://runtime"));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("resource_uri"), is("shardingsphere://databases"));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("depends_on"), is(List.of(1)));
@@ -469,30 +463,29 @@ class MCPErrorConverterTest {
         Map<?, ?> actualResourceToRead = getFirstResourceToRead(actualRecovery);
         assertThat(actualResourceToRead.get("uri"), is("shardingsphere://guidance"));
         assertThat(actualResourceToRead.get("resource_kind"), is("guidance"));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("resource_uri"), is("shardingsphere://guidance"));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("resource_uri"), is("shardingsphere://guidance"));
     }
     
     @Test
     void assertConvertInvalidRuntimeConfigurationWithRecovery() {
         Map<String, Object> actual = MCPErrorConverter.convert(RuntimeDatabaseConnectionException.invalidConfiguration("logic_db", new IllegalStateException("bad config"))).toPayload();
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
-        assertThat(actual.get("message"), is("Runtime database `logic_db` connection failed: invalid_configuration."));
+        assertThat(actual.get("summary"), is("Runtime database `logic_db` connection failed: invalid_configuration."));
         assertThat(actualRecovery.get("category"), is("invalid_configuration"));
         assertThat(actualRecovery.get("recovery_category"), is("unavailable_runtime"));
         assertThat(actualRecovery.get("model_action"), is("Fix the MCP runtime database configuration outside MCP, then retry."));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://runtime"));
-        assertTrue((Boolean) actualRecovery.get("ask_user_when_uncertain"));
     }
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("assertConvertQueryFailureWithRecoveryCases")
     void assertConvertQueryFailureWithRecovery(final String name, final Throwable cause, final String expectedMessage, final String expectedCategory, final String expectedActionType) {
         Map<String, Object> actual = MCPErrorConverter.convert(cause).toPayload();
-        assertThat(actual.get("message"), is(expectedMessage));
+        assertThat(actual.get("summary"), is(expectedMessage));
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
         assertThat(actualRecovery.get("category"), is(expectedCategory));
         assertTrue((Boolean) actualRecovery.get("secret_safe"));
-        assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("type"), is(expectedActionType));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("type"), is(expectedActionType));
         assertFalse(String.valueOf(actualRecovery).contains("SQLException"));
     }
     
@@ -500,7 +493,7 @@ class MCPErrorConverterTest {
     void assertConvertQueryFailureRecoveryOmitsSensitiveFields() {
         Map<String, Object> actual = MCPErrorConverter.convert(new MCPQueryFailedException("jdbc:mysql://127.0.0.1:3306/logic_db password=secret token=abc")).toPayload();
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
-        assertThat(actual.get("message"), is("MCP query failed."));
+        assertThat(actual.get("summary"), is("MCP query failed."));
         assertThat(actualRecovery.get("category"), is("query_failed"));
         assertFalse(String.valueOf(actual).contains("jdbc:mysql"));
         assertFalse(String.valueOf(actual).contains("password=secret"));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorPayloadTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorPayloadTest.java
@@ -33,22 +33,23 @@ class MCPErrorPayloadTest {
     @Test
     void assertToPayload() {
         Map<String, Object> actual = new MCPErrorPayload("foo_message").toPayload();
-        assertNotNull(actual.get("request_id"));
+        assertNotNull(actual.get("error_id"));
         assertFalse(actual.containsKey("recovery"));
         assertThat(actual.get("response_mode"), is("recovery"));
         assertThat(actual.get("summary"), is("foo_message"));
-        assertThat(actual.get("message"), is("foo_message"));
+        assertFalse(actual.containsKey("message"));
     }
     
     @Test
     void assertToPayloadWithRecovery() {
         Map<String, Object> actual = new MCPErrorPayload("foo_message", Map.of("recoverable", true)).toPayload();
-        assertNotNull(actual.get("request_id"));
+        assertNotNull(actual.get("error_id"));
         assertThat(actual.get("response_mode"), is("recovery"));
-        assertThat(actual.get("message"), is("foo_message"));
+        assertThat(actual.get("summary"), is("foo_message"));
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
         assertTrue((Boolean) actualRecovery.get("recoverable"));
-        assertThat(actualRecovery.get("request_id"), is(actual.get("request_id")));
+        assertFalse(actualRecovery.containsKey("response_mode"));
+        assertFalse(actualRecovery.containsKey("error_id"));
     }
     
     @Test
@@ -56,5 +57,6 @@ class MCPErrorPayloadTest {
         Map<String, Object> actual = new MCPErrorPayload("", Map.of("next_actions", List.of(Map.of("order", 1, "type", "terminal", "title", "Stop")))).toPayload();
         assertThat(actual.get("summary"), is("Recovery guidance is available."));
         assertThat(actual.get("next_actions"), is(List.of(Map.of("order", 1, "type", "terminal", "title", "Stop"))));
+        assertFalse(actual.containsKey("recovery"));
     }
 }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPRuntimeDatabaseRecoveryPayloadFactoryTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPRuntimeDatabaseRecoveryPayloadFactoryTest.java
@@ -37,7 +37,6 @@ class MCPRuntimeDatabaseRecoveryPayloadFactoryTest {
         assertThat(actual.get("category"), is("invalid_configuration"));
         assertThat(actual.get("recovery_category"), is("unavailable_runtime"));
         assertFalse(actual.containsKey("database"));
-        assertFalse(actual.containsKey("request_id"));
     }
     
     @Test

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -80,19 +81,17 @@ class CoreResourceHandlerSurfaceTest {
             }
             if (HandlerResultType.SERVICE_CAPABILITY == handlerCase.getExpectedType()) {
                 assertThat(actual, isA(MCPMapPayload.class));
-                assertTrue(((List<?>) actualPayload.get("supportedResources")).contains("shardingsphere://capabilities"));
-                assertTrue(((List<?>) actualPayload.get("supportedResources")).contains("shardingsphere://guidance"));
-                assertTrue(((List<?>) actualPayload.get("prompts")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
+                assertFalse(((Collection<?>) actualPayload.get("supportedStatementClasses")).isEmpty());
                 assertTrue(((List<?>) actualPayload.get("completionTargets")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
                 assertTrue(((List<?>) actualPayload.get("resourceNavigation")).stream().map(String::valueOf).anyMatch(each -> each.contains("database_gateway_apply_workflow")));
+                assertFalse(actualPayload.containsKey("resources"));
+                assertFalse(actualPayload.containsKey("tools"));
                 assertFalse(actualPayload.containsKey("fingerprints"));
-                assertTrue((Boolean) ((Map<?, ?>) actualPayload.get("protocolAvailability")).get("resourceNavigation"));
                 return;
             }
             if (HandlerResultType.SERVICE_GUIDANCE == handlerCase.getExpectedType()) {
                 assertThat(actual, isA(MCPMapPayload.class));
                 assertThat(actualPayload.get("response_mode"), is("guidance"));
-                assertThat(actualPayload.get("guidance_resource"), is("shardingsphere://guidance"));
                 assertTrue(actualPayload.containsKey("model_contract"));
                 assertTrue(actualPayload.containsKey("common_flows"));
                 return;
@@ -115,7 +114,8 @@ class CoreResourceHandlerSurfaceTest {
             Map<String, Object> actualPayload = actual.toPayload();
             assertThat(actual, isA(MCPItemsPayload.class));
             assertThat(actualPayload.get("count"), is(0));
-            assertThat(actualPayload.get("self_uri"), is("shardingsphere://databases/warehouse/schemas/warehouse/tables/facts/indexes"));
+            assertThat(((Map<?, ?>) actualPayload.get("self_resource")).get("uri"),
+                    is("shardingsphere://databases/warehouse/schemas/warehouse/tables/facts/indexes"));
         }
     }
     
@@ -156,12 +156,11 @@ class CoreResourceHandlerSurfaceTest {
         if (actualPayload.containsKey("resource_kind")) {
             assertThat(actual, isA(MCPMapPayload.class));
             assertThat(actualPayload.get("resource_kind"), is("detail"));
-            assertThat(actualPayload.get("found"), is(!handlerCase.getExpectedObjectNames().isEmpty()));
         } else {
             assertThat(actual, isA(MCPItemsPayload.class));
         }
         assertThat(actualPayload.get("count"), is(handlerCase.getExpectedObjectNames().size()));
-        assertThat(actualPayload.get("self_uri"), is(handlerCase.getResourceUri()));
+        assertThat(((Map<?, ?>) actualPayload.get("self_resource")).get("uri"), is(handlerCase.getResourceUri()));
         assertParentResource(handlerCase.getResourceUri(), actualPayload);
         assertNextResources(handlerCase.getResourceUri(), actualPayload);
         assertThat(extractMetadataNames(actualPayload), is(handlerCase.getExpectedObjectNames()));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/ResourceDefinitionRegistryTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/ResourceDefinitionRegistryTest.java
@@ -56,7 +56,7 @@ class ResourceDefinitionRegistryTest {
     void assertDispatch() {
         Optional<MCPSuccessPayload> actual = ResourceDefinitionRegistry.dispatch(mock(MCPFeatureRuntimeRequestContext.class), "shardingsphere://capabilities");
         assertTrue(actual.isPresent());
-        assertTrue(actual.get().toPayload().containsKey("supportedTools"));
+        assertTrue(actual.get().toPayload().containsKey("supportedStatementClasses"));
     }
     
     @Test

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandlerTest.java
@@ -43,14 +43,11 @@ class RuntimeStatusHandlerTest {
         Map<String, Object> actual = new RuntimeStatusHandler().handle(requestContext, new MCPUriVariables(Map.of())).toPayload();
         assertThat(actual.get("response_mode"), is("runtime"));
         assertThat(actual.get("summary"), is("Runtime is ready with 3 configured logical database(s)."));
-        assertThat(actual.get("server_status"), is("ready"));
         assertThat(actual.get("status"), is("available"));
-        assertThat(actual.get("transport"), is("http"));
         assertThat(actual.get("active_transport"), is("http"));
         assertThat(((Map<?, ?>) actual.get("transport_security_summary")).get("recommended_exposure"), is("loopback_or_trusted_gateway"));
         assertThat(actual.get("configured_database_count"), is(3));
         assertTrue(((List<?>) actual.get("databases")).stream().map(each -> ((Map<?, ?>) each).get("database")).anyMatch("logic_db"::equals));
-        assertThat(((Map<?, ?>) actual.get("redaction_summary")).get("marker"), is("******"));
         assertRuntimeDiagnostics(actual, "ready");
         assertRuntimeProtection(actual);
         assertFalse(actual.containsKey("capability_fingerprint"));
@@ -65,7 +62,6 @@ class RuntimeStatusHandlerTest {
                 new MCPFeatureRuntimeRequestContext(ResourceTestDataFactory.createRuntimeContext(ResourceTestDataFactory.createDatabaseMetadata(), MCPTransportType.STDIO),
                         new MCPSessionIdentity("session-1", "", "", Map.of()));
         Map<String, Object> actual = new RuntimeStatusHandler().handle(requestContext, new MCPUriVariables(Map.of())).toPayload();
-        assertThat(actual.get("transport"), is("stdio"));
         assertThat(actual.get("active_transport"), is("stdio"));
         assertThat(((Map<?, ?>) actual.get("transport_security_summary")).get("recommended_exposure"), is("local_stdio_session"));
     }
@@ -75,7 +71,6 @@ class RuntimeStatusHandlerTest {
         MCPFeatureRuntimeRequestContext requestContext = new MCPFeatureRuntimeRequestContext(ResourceTestDataFactory.createRuntimeContext(List.of(), MCPTransportType.HTTP),
                 new MCPSessionIdentity("session-1", "", "", Map.of()));
         Map<String, Object> actual = new RuntimeStatusHandler().handle(requestContext, new MCPUriVariables(Map.of())).toPayload();
-        assertThat(actual.get("server_status"), is("configuration_required"));
         assertThat(actual.get("summary"), is("Runtime requires at least one configured logical database before metadata discovery or SQL execution."));
         assertThat(actual.get("status"), is("configuration_required"));
         assertThat(actual.get("configured_database_count"), is(0));
@@ -133,9 +128,6 @@ class RuntimeStatusHandlerTest {
     
     private void assertRuntimeCapability(final List<?> databases, final String databaseName) {
         Map<?, ?> actualDatabase = databases.stream().map(each -> (Map<?, ?>) each).filter(each -> databaseName.equals(each.get("database"))).findFirst().orElseThrow();
-        assertThat(actualDatabase.get("metadata_visibility"), is("ready"));
-        assertThat(actualDatabase.get("capability_visibility"), is("ready"));
-        assertThat(actualDatabase.get("feature_visibility"), is("ready"));
         Map<?, ?> actualCapabilities = (Map<?, ?>) actualDatabase.get("capabilities");
         assertTrue((Boolean) actualCapabilities.get("available"));
         assertTrue(((List<?>) actualCapabilities.get("supported_statement_classes")).contains("QUERY"));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
@@ -21,10 +21,8 @@ import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
 import org.apache.shardingsphere.mcp.core.context.MCPFeatureRuntimeRequestContext;
 import org.apache.shardingsphere.mcp.core.resource.ResourceTestDataFactory;
-import org.apache.shardingsphere.mcp.support.descriptor.MCPShardingSphereMetadataKeys;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,39 +38,27 @@ class ServerCapabilitiesHandlerTest {
     void assertHandleReturnsCoreModelSurfaceContract() {
         Map<String, Object> actual = createCapabilitiesPayload();
         assertBaselineTopLevelKeys(actual);
-        assertTrue(((Collection<?>) actual.get("supportedResources")).contains("shardingsphere://capabilities"));
-        assertTrue(((Collection<?>) actual.get("supportedResources")).contains("shardingsphere://guidance"));
-        assertTrue(
-                ((Collection<?>) actual.get("supportedTools")).containsAll(List.of("database_gateway_search_metadata", "database_gateway_validate_runtime_database", "database_gateway_execute_query",
-                        "database_gateway_execute_explain_query", "database_gateway_execute_update", "database_gateway_apply_workflow", "database_gateway_validate_workflow")));
-        assertThat(actual.get("guidanceResource"), is("shardingsphere://guidance"));
-        assertFalse(((List<?>) actual.get("resources")).isEmpty());
-        assertFalse(((List<?>) actual.get("resourceTemplates")).isEmpty());
-        assertFalse(((List<?>) actual.get("tools")).isEmpty());
-        assertFalse(((List<?>) actual.get("prompts")).isEmpty());
+        assertFalse(((Set<?>) actual.get("supportedStatementClasses")).isEmpty());
         assertFalse(((List<?>) actual.get("completionTargets")).isEmpty());
         assertFalse(((List<?>) actual.get("resourceNavigation")).isEmpty());
+        Map<?, ?> navigation = findByKey((List<?>) actual.get("resourceNavigation"), "to", "shardingsphere://guidance");
+        assertThat(navigation.get("from_type"), is("resource"));
+        assertThat(navigation.get("to_type"), is("resource"));
+        assertFalse(actual.containsKey("resources"));
+        assertFalse(actual.containsKey("tools"));
+        assertFalse(actual.containsKey("protocolAvailability"));
         assertFalse(actual.containsKey("fingerprints"));
-        assertResourcePayloadContracts(actual);
-        assertCoreToolSchemas(actual);
     }
     
     @Test
     void assertHandleReturnsGuidanceContract() {
         Map<String, Object> actual = createGuidancePayload();
         assertGuidanceTopLevelKeys(actual);
-        assertModelFirstSummary(actual);
+        assertDiscovery(actual);
         assertModelContract(actual);
-        assertSurfaceSummary(actual);
-        assertFieldNamingContract(actual);
         assertNextActionContract(actual);
         assertCommonFlows(actual);
         assertSecurityHints(actual);
-    }
-    
-    @Test
-    void assertHandleReturnsImplementedProtocolAvailabilityOnly() {
-        assertProtocolAvailability(createCapabilitiesPayload());
     }
     
     private Map<String, Object> createCapabilitiesPayload() {
@@ -86,79 +72,24 @@ class ServerCapabilitiesHandlerTest {
     }
     
     private void assertBaselineTopLevelKeys(final Map<String, Object> capabilities) {
-        assertThat(capabilities.keySet(), is(Set.of("response_mode", "supportedResources", "supportedTools", "supportedStatementClasses", "guidanceResource", "resources",
-                "resourceTemplates", "tools", "prompts", "completionTargets", "resourceNavigation", "protocolAvailability")));
+        assertThat(capabilities.keySet(), is(Set.of("response_mode", "supportedStatementClasses", "completionTargets", "resourceNavigation")));
     }
     
     private void assertGuidanceTopLevelKeys(final Map<String, Object> guidance) {
-        assertThat(guidance.keySet(), is(Set.of("response_mode", "guidance_resource", "model_first_summary", "model_contract", "surface_summary", "field_naming_contract",
-                "next_action_contract", "common_flows", "security_hints")));
+        assertThat(guidance.keySet(), is(Set.of("response_mode", "discovery", "model_contract", "next_action_contract", "common_flows", "security_hints")));
         assertThat(guidance.get("response_mode"), is("guidance"));
-        assertThat(guidance.get("guidance_resource"), is("shardingsphere://guidance"));
     }
     
-    private void assertProtocolAvailability(final Map<String, Object> capabilities) {
-        Map<?, ?> actual = (Map<?, ?>) capabilities.get("protocolAvailability");
-        assertThat(actual, is(Map.of(
-                "resources", true,
-                "resourceTemplates", true,
-                "tools", true,
-                "toolAnnotations", true,
-                "toolOutputSchemas", true,
-                "prompts", true,
-                "completions", true,
-                "resourceNavigation", true)));
-        for (String each : List.of("logging", "progress", "cancellation", "tasks", "sampling", "roots", "subscriptions", "listChanged")) {
-            assertFalse(actual.containsKey(each), "Unexpected optional MCP capability: " + each);
-        }
-    }
-    
-    private void assertModelFirstSummary(final Map<String, Object> capabilities) {
-        Map<?, ?> actual = (Map<?, ?>) capabilities.get("model_first_summary");
+    private void assertDiscovery(final Map<String, Object> capabilities) {
+        Map<?, ?> actual = (Map<?, ?>) capabilities.get("discovery");
         assertThat(actual.get("official_discovery_methods"), is(createOfficialDiscoveryMethods()));
         assertThat(actual.get("argument_completion_method"), is("completion/complete"));
         assertThat(actual.get("guidance_resource_role"),
                 is("shardingsphere://guidance complements MCP list methods with ShardingSphere domain guidance, workflow guidance, and side-effect notes."));
-        assertThat(actual.get("guidance_resource"), is("shardingsphere://guidance"));
-        assertFalse(actual.containsKey("safe_first_resource"));
-        Map<?, ?> firstRoute = findByKey((List<?>) actual.get("first_call_routes"), "intent", "inspect_metadata");
-        assertThat(firstRoute.get("first_action"), is("read_resource shardingsphere://databases"));
-        Map<?, ?> ruleWorkflowRoute = findByKey((List<?>) actual.get("first_call_routes"), "intent", "rule_workflow");
-        assertThat(ruleWorkflowRoute.get("first_action"), is("call_tool matching database_gateway_plan_* workflow tool without plan_id for a new plan"));
-        Map<?, ?> recoveryRoute = findByKey((List<?>) actual.get("first_call_routes"), "intent", "recover_error");
-        assertThat(recoveryRoute.get("first_action"), is("follow top-level next_actions"));
-        Map<?, ?> metadataRule = (Map<?, ?>) actual.get("metadata_rule");
-        assertThat(metadataRule.get("first_resource"), is("shardingsphere://databases"));
-        assertThat(metadataRule.get("search_tool"), is("database_gateway_search_metadata"));
-        assertThat(((Map<?, ?>) actual.get("preflight_rule")).get("tool"), is("database_gateway_validate_runtime_database"));
-        Map<?, ?> sqlToolSelection = (Map<?, ?>) actual.get("sql_tool_selection");
-        assertThat(((Map<?, ?>) sqlToolSelection.get("read_only")).get("tool"), is("database_gateway_execute_query"));
-        assertThat(((Map<?, ?>) sqlToolSelection.get("explain")).get("tool"), is("database_gateway_execute_explain_query"));
-        assertThat(((Map<?, ?>) sqlToolSelection.get("side_effecting")).get("first_mode"), is("preview"));
-        assertThat(((Map<?, ?>) sqlToolSelection.get("side_effecting")).get("rule_change_preference"),
-                is("For natural-language rule changes, use the matching database_gateway_plan_* workflow tool before raw SQL execution; "
-                        + "omit plan_id for a new plan."));
-        assertTrue(String.valueOf(actual.get("side_effect_rule")).contains("requested side effect is still intended"));
-        Map<?, ?> workflowRule = (Map<?, ?>) actual.get("workflow_rule");
-        assertThat(workflowRule.get("selection_rule"),
-                is("For natural-language rule changes, use the matching database_gateway_plan_* workflow tool before raw side-effect SQL; "
-                        + "omit plan_id for a new plan and reuse only returned plan_id values."));
-        assertTrue(workflowRule.containsKey("planning_tools"));
-        assertThat(((Map<?, ?>) workflowRule.get("preview_tool")).get("tool"), is("database_gateway_apply_workflow"));
-        assertThat(((Map<?, ?>) workflowRule.get("execute_tool")).get("execute_requires"),
-                is("execution_mode=review-then-execute and explicit approved_steps copied from preview_artifacts.approval_step"));
-        assertThat(workflowRule.get("validate_tool"), is("database_gateway_validate_workflow"));
-        assertTrue(String.valueOf(actual.get("completion_rule")).contains("before guessing identifiers"));
-        assertTrue(String.valueOf(actual.get("recovery_rule")).contains("recovery.next_actions"));
     }
     
     private void assertModelContract(final Map<String, Object> capabilities) {
         Map<?, ?> actual = (Map<?, ?>) capabilities.get("model_contract");
-        assertThat(actual.get("public_surface_source"), is("MCP list methods expose the protocol surface: tools/list, resources/list, resources/templates/list, prompts/list."));
-        assertThat(actual.get("official_discovery_methods"), is(createOfficialDiscoveryMethods()));
-        assertThat(actual.get("argument_completion_method"), is("completion/complete"));
-        assertThat(actual.get("guidance_resource"), is("shardingsphere://guidance"));
-        assertFalse(actual.containsKey("safe_first_resource"));
         assertThat(actual.get("metadata_first_resource"), is("shardingsphere://databases"));
         assertTrue(String.valueOf(actual.get("preflight_rule")).contains("database_gateway_validate_runtime_database"));
         Map<?, ?> sqlToolSelection = (Map<?, ?>) actual.get("sql_tool_selection");
@@ -167,28 +98,9 @@ class ServerCapabilitiesHandlerTest {
         assertTrue(sqlToolSelection.containsKey("side_effecting"));
         assertTrue(actual.containsKey("workflow_session_rule"));
         assertTrue(actual.containsKey("next_action_rule"));
-        assertTrue(actual.containsKey("recovery_rule"));
-    }
-    
-    private void assertSurfaceSummary(final Map<String, Object> capabilities) {
-        Map<?, ?> actual = (Map<?, ?>) capabilities.get("surface_summary");
-        assertThat(actual.get("official_discovery_methods"), is(createOfficialDiscoveryMethods()));
-        assertThat(actual.get("argument_completion_method"), is("completion/complete"));
-        assertThat(actual.get("guidance_resource"), is("shardingsphere://guidance"));
-        assertThat(actual.get("metadata_search_tool"), is("database_gateway_search_metadata"));
-        assertThat(actual.get("preflight_validation_tool"), is("database_gateway_validate_runtime_database"));
-        assertThat(actual.get("read_only_sql_tool"), is("database_gateway_execute_query"));
-        assertThat(actual.get("explain_sql_tool"), is("database_gateway_execute_explain_query"));
-        assertThat(actual.get("side_effect_sql_tool"), is("database_gateway_execute_update"));
-    }
-    
-    private void assertFieldNamingContract(final Map<String, Object> capabilities) {
-        Map<?, ?> actual = (Map<?, ?>) capabilities.get("field_naming_contract");
-        assertThat(actual.get("official_discovery_methods"), is(List.of("tools/list", "resources/list", "resources/templates/list", "prompts/list")));
-        assertThat(actual.get("argument_completion_method"), is("completion/complete"));
-        assertThat(actual.get("catalog_fields"), is(List.of("supportedResources", "supportedTools", "supportedStatementClasses", "guidanceResource", "resourceTemplates",
-                "completionTargets", "resourceNavigation", "protocolAvailability")));
-        assertThat(actual.get("payload_fields"), is("ShardingSphere-owned structured payload fields use snake_case."));
+        assertThat(actual.get("recovery_rule"), is("When a call fails, follow top-level next_actions before inventing a new call."));
+        assertThat(actual.get("payload_field_rule"), is("ShardingSphere-owned structured payload fields use snake_case."));
+        assertFalse(actual.containsKey("official_discovery_methods"));
     }
     
     private void assertNextActionContract(final Map<String, Object> capabilities) {
@@ -228,143 +140,12 @@ class ServerCapabilitiesHandlerTest {
         Map<?, ?> actualClientSafetyPolicy = (Map<?, ?>) actual.get("client_safety_policy");
         assertThat(actualClientSafetyPolicy.get("identity_scope"), is("mcp_session"));
         assertTrue(String.valueOf(actualClientSafetyPolicy.get("transport_scope")).contains("trusted session attribution"));
-        assertThat(((Map<?, ?>) actualClientSafetyPolicy.get("tool_call_limit")).get("scope"), is("session"));
         assertThat(((Map<?, ?>) ((Map<?, ?>) actualClientSafetyPolicy.get("runtime_protection")).get("tool_call_limit")).get("scope"), is("session"));
         assertTrue(String.valueOf(actualClientSafetyPolicy.get("abuse_guard")).contains("counted before dispatch"));
     }
     
-    private void assertResourcePayloadContracts(final Map<String, Object> capabilities) {
-        Map<?, ?> capabilityCatalog = findResource(capabilities, "shardingsphere://capabilities");
-        assertThat(getResourceMeta(capabilityCatalog).get(MCPShardingSphereMetadataKeys.RESOURCE_KIND), is("capability-catalog"));
-        Map<?, ?> guidance = findResource(capabilities, "shardingsphere://guidance");
-        assertThat(getResourceMeta(guidance).get(MCPShardingSphereMetadataKeys.RESOURCE_KIND), is("guidance"));
-        Map<?, ?> runtimeStatus = findResource(capabilities, "shardingsphere://runtime");
-        assertThat(getResourceMeta(runtimeStatus).get(MCPShardingSphereMetadataKeys.RESOURCE_KIND), is("detail"));
-        Map<?, ?> databaseDetail = findResource(capabilities, "shardingsphere://databases/{database}");
-        assertThat(getResourceMeta(databaseDetail).get(MCPShardingSphereMetadataKeys.RESOURCE_KIND), is("detail"));
-        Map<?, ?> databaseCapabilities = findResource(capabilities, "shardingsphere://databases/{database}/capabilities");
-        assertThat(getResourceMeta(databaseCapabilities).get(MCPShardingSphereMetadataKeys.RELATED_TOOLS),
-                is(List.of("database_gateway_execute_query", "database_gateway_execute_explain_query", "database_gateway_execute_update")));
-        Map<?, ?> databases = findResource(capabilities, "shardingsphere://databases");
-        assertThat(getResourceMeta(databases).get(MCPShardingSphereMetadataKeys.RELATED_TOOLS),
-                is(List.of("database_gateway_search_metadata", "database_gateway_execute_query", "database_gateway_execute_explain_query")));
-        Map<?, ?> databaseVariable = findUriVariable(databaseDetail, "database");
-        assertTrue((Boolean) databaseVariable.get("required"));
-        Map<?, ?> navigation = findByKey((List<?>) capabilities.get("resourceNavigation"), "to", "shardingsphere://guidance");
-        assertThat(navigation.get("from_type"), is("resource"));
-        assertThat(navigation.get("to_type"), is("resource"));
-    }
-    
-    private Map<?, ?> getResourceMeta(final Map<?, ?> resource) {
-        assertFalse(resource.containsKey("meta"));
-        return (Map<?, ?>) resource.get("_meta");
-    }
-    
-    private Map<?, ?> findUriVariable(final Map<?, ?> resource, final String variableName) {
-        return ((List<?>) getResourceMeta(resource).get(MCPShardingSphereMetadataKeys.URI_VARIABLES)).stream()
-                .map(each -> (Map<?, ?>) each).filter(each -> variableName.equals(each.get("name"))).findFirst().orElseThrow();
-    }
-    
-    private void assertCoreToolSchemas(final Map<String, Object> capabilities) {
-        Map<?, ?> searchMetadataTool = findTool(capabilities, "database_gateway_search_metadata");
-        Map<?, ?> searchMetadataOutputProperties = (Map<?, ?>) ((Map<?, ?>) searchMetadataTool.get("outputSchema")).get("properties");
-        assertTrue(searchMetadataOutputProperties.containsKey("summary"));
-        assertTrue(searchMetadataOutputProperties.containsKey("total_match_count"));
-        assertTrue(searchMetadataOutputProperties.containsKey("returned_count"));
-        assertTrue(searchMetadataOutputProperties.containsKey("truncated"));
-        assertTrue(searchMetadataOutputProperties.containsKey("large_result_guidance"));
-        assertThat(getInputFieldNames(searchMetadataTool), is(List.of("database", "schema", "query", "object_types")));
-        Map<?, ?> objectTypesSchema = findInputSchema(searchMetadataTool, "object_types");
-        assertTrue(((List<?>) ((Map<?, ?>) objectTypesSchema.get("items")).get("enum")).containsAll(List.of("database", "schema", "table", "view", "column", "index", "storage_unit", "sequence")));
-        Map<?, ?> validateRuntimeDatabaseTool = findTool(capabilities, "database_gateway_validate_runtime_database");
-        Map<?, ?> validateRuntimeDatabaseOutputProperties = (Map<?, ?>) ((Map<?, ?>) validateRuntimeDatabaseTool.get("outputSchema")).get("properties");
-        assertThat(getInputFieldNames(validateRuntimeDatabaseTool), is(List.of("database")));
-        assertTrue(validateRuntimeDatabaseOutputProperties.containsKey("summary"));
-        assertTrue(validateRuntimeDatabaseOutputProperties.containsKey("status"));
-        assertTrue(validateRuntimeDatabaseOutputProperties.containsKey("checks"));
-        assertTrue(validateRuntimeDatabaseOutputProperties.containsKey("category"));
-        assertTrue(validateRuntimeDatabaseOutputProperties.containsKey("recovery"));
-        assertTrue(validateRuntimeDatabaseOutputProperties.containsKey("next_actions"));
-        Map<?, ?> executeExplainTool = findTool(capabilities, "database_gateway_execute_explain_query");
-        Map<?, ?> executeExplainOutputProperties = (Map<?, ?>) ((Map<?, ?>) executeExplainTool.get("outputSchema")).get("properties");
-        assertThat(getInputFieldNames(executeExplainTool), is(List.of("database", "schema", "sql", "explain_sql", "max_rows", "timeout_ms")));
-        assertTrue(executeExplainOutputProperties.containsKey("response_mode"));
-        assertTrue(executeExplainOutputProperties.containsKey("result_kind"));
-        assertTrue(executeExplainOutputProperties.containsKey("statement_class"));
-        Map<?, ?> executeUpdateTool = findTool(capabilities, "database_gateway_execute_update");
-        Map<?, ?> executeUpdateOutputProperties = (Map<?, ?>) ((Map<?, ?>) executeUpdateTool.get("outputSchema")).get("properties");
-        assertTrue(executeUpdateOutputProperties.containsKey("response_mode"));
-        assertTrue(executeUpdateOutputProperties.containsKey("summary"));
-        assertTrue(((List<?>) ((Map<?, ?>) executeUpdateOutputProperties.get("result_kind")).get("enum")).containsAll(List.of("preview", "result_set", "update_count", "statement_ack")));
-        Map<?, ?> executeUpdateStatementClass = (Map<?, ?>) executeUpdateOutputProperties.get("statement_class");
-        assertThat(executeUpdateStatementClass.get("enum"), is(List.of("dml", "ddl", "dcl", "transaction_control", "savepoint")));
-        assertFalse(((String) executeUpdateStatementClass.get("description")).contains("explain_analyze"));
-        assertTrue(executeUpdateOutputProperties.containsKey("preview_semantics"));
-        assertTrue(executeUpdateOutputProperties.containsKey("review_summary"));
-        assertTrue(executeUpdateOutputProperties.containsKey("columns"));
-        assertTrue(executeUpdateOutputProperties.containsKey("rows"));
-        assertFalse(executeUpdateOutputProperties.containsKey("approval_summary"));
-        assertThat(((Map<?, ?>) executeUpdateOutputProperties.get("normalized_sql")).get("description"),
-                is("Normalized single SQL statement accepted by MCP for the target database."));
-        Map<?, ?> executedExample = findByKey((List<?>) ((Map<?, ?>) executeUpdateTool.get("outputSchema")).get("examples"), "response_mode", "executed");
-        assertThat(executedExample.get("result_kind"), is("update_count"));
-        assertThat(executedExample.get("statement_class"), is("dml"));
-        assertThat(executedExample.get("statement_type"), is("UPDATE"));
-        assertThat(executedExample.get("summary"), is("Executed UPDATE statement and affected 1 row(s)."));
-        assertThat(executedExample.get("affected_rows"), is(1));
-        assertFalse((Boolean) executedExample.get("truncated"));
-        Map<?, ?> executedNextAction = (Map<?, ?>) ((List<?>) executedExample.get("next_actions")).get(0);
-        assertThat(executedNextAction.get("type"), is("terminal"));
-        assertThat(executedNextAction.get("reason"), is("The side-effecting statement already executed; do not replay it automatically."));
-        assertThat(executeUpdateTool.get("title"), is("Preview or Execute Side-Effecting SQL"));
-        assertTrue(((String) executeUpdateTool.get("description")).contains("Preview performs database-aware validation and classification, not a database dry run."));
-        assertThat(findInputSchema(executeUpdateTool, "execution_mode").get("description"),
-                is("Required safety gate. Use preview to classify side effects without execution; preview is not a database dry run. Use execute only after reviewing the preview."));
-        assertThat(((Map<?, ?>) executeUpdateOutputProperties.get("preview_semantics")).get("description"), is(
-                "Preview meaning. classification_only means the server parsed and classified SQL and side-effect scope without rule validation, "
-                        + "algorithm initialization, affected-row estimation, runtime execution, or database dry-run guarantees."));
-        assertThat(getInputFieldNames(executeUpdateTool), is(List.of("database", "schema", "sql", "execution_mode", "max_rows", "timeout_ms")));
-        Map<?, ?> applyWorkflowTool = findTool(capabilities, "database_gateway_apply_workflow");
-        assertThat(getInputFieldNames(applyWorkflowTool), is(List.of("plan_id", "execution_mode", "approved_steps")));
-        assertTrue(hasCompletionTarget(capabilities, "shardingsphere://workflows/{plan_id}", "plan_id"));
-        Map<?, ?> inspectMetadataPrompt = findPrompt(capabilities, "inspect_metadata");
-        Map<?, ?> schemaArgument = findPromptArgument(inspectMetadataPrompt, "schema");
-        assertThat(((Map<?, ?>) schemaArgument.get("completion")).get("required_context_arguments"), is(List.of("database")));
-    }
-    
-    private Map<?, ?> findResource(final Map<String, Object> capabilities, final String uriTemplate) {
-        List<?> resources = (List<?>) capabilities.get(uriTemplate.contains("{") ? "resourceTemplates" : "resources");
-        String uriFieldName = uriTemplate.contains("{") ? "uriTemplate" : "uri";
-        return resources.stream().map(each -> (Map<?, ?>) each).filter(each -> uriTemplate.equals(each.get(uriFieldName))).findFirst().orElseThrow();
-    }
-    
-    private Map<?, ?> findTool(final Map<String, Object> capabilities, final String toolName) {
-        return ((List<?>) capabilities.get("tools")).stream().map(each -> (Map<?, ?>) each).filter(each -> toolName.equals(each.get("name"))).findFirst().orElseThrow();
-    }
-    
     private Map<?, ?> findByKey(final List<?> values, final String key, final String expectedValue) {
         return values.stream().map(each -> (Map<?, ?>) each).filter(each -> expectedValue.equals(each.get(key))).findFirst().orElseThrow();
-    }
-    
-    private Map<?, ?> findInputSchema(final Map<?, ?> tool, final String fieldName) {
-        return (Map<?, ?>) ((Map<?, ?>) ((Map<?, ?>) tool.get("inputSchema")).get("properties")).get(fieldName);
-    }
-    
-    private List<String> getInputFieldNames(final Map<?, ?> tool) {
-        return ((Map<?, ?>) ((Map<?, ?>) tool.get("inputSchema")).get("properties")).keySet().stream().map(String::valueOf).toList();
-    }
-    
-    private boolean hasCompletionTarget(final Map<String, Object> capabilities, final String reference, final String argumentName) {
-        return ((List<?>) capabilities.get("completionTargets")).stream().map(each -> (Map<?, ?>) each)
-                .anyMatch(each -> reference.equals(each.get("reference")) && ((List<?>) each.get("arguments")).contains(argumentName));
-    }
-    
-    private Map<?, ?> findPrompt(final Map<String, Object> capabilities, final String promptName) {
-        return ((List<?>) capabilities.get("prompts")).stream().map(each -> (Map<?, ?>) each).filter(each -> promptName.equals(each.get("name"))).findFirst().orElseThrow();
-    }
-    
-    private Map<?, ?> findPromptArgument(final Map<?, ?> prompt, final String argumentName) {
-        return ((List<?>) prompt.get("arguments")).stream().map(each -> (Map<?, ?>) each).filter(each -> argumentName.equals(each.get("name"))).findFirst().orElseThrow();
     }
     
     private Map<String, Object> createOfficialDiscoveryMethods() {

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceHandlerTest.java
@@ -58,14 +58,11 @@ class MetadataResourceHandlerTest {
         assertThat(actualPayload.get("summary"), is("Returned 1 of 1 logical-database metadata entries."));
         assertThat(actualPayload.get("items"), is(List.of(Map.of("database", "logic_db"))));
         assertThat(actualPayload.get("count"), is(1));
-        assertFalse((Boolean) actualPayload.get("has_more"));
         assertThat(actualPayload.get("continuation_mode"), is("none"));
-        assertThat(actualPayload.get("self_uri"), is("shardingsphere://databases"));
         assertThat(((Map<?, ?>) actualPayload.get("self_resource")).get("uri"), is("shardingsphere://databases"));
         assertThat(((Map<?, ?>) actualPayload.get("self_resource")).get("resource_kind"), is("logical-database"));
         assertThat(((Map<?, ?>) actualPayload.get("self_resource")).get("source_field"), is("self_resource"));
         assertThat(actualPayload.get("total_count"), is(1));
-        assertThat(actualPayload.get("returned_count"), is(1));
         assertFalse((Boolean) actualPayload.get("truncated"));
     }
     
@@ -76,7 +73,9 @@ class MetadataResourceHandlerTest {
         Map<?, ?> actualEmptyState = (Map<?, ?>) actual.toPayload().get("empty_state");
         assertThat(actualEmptyState.get("category"), is("no_runtime_database"));
         assertThat(actualEmptyState.get("reason"), is("No ShardingSphere-Proxy logical database is available to MCP. Configure runtimeDatabases before reading metadata."));
-        assertThat(((Map<?, ?>) actual.toPayload().get("recovery")).get("recovery_category"), is("no_runtime_database"));
+        Map<?, ?> actualRecovery = (Map<?, ?>) actual.toPayload().get("recovery");
+        assertThat(actualRecovery.get("recovery_category"), is("unavailable_runtime"));
+        assertThat(actualRecovery.get("category"), is("no_runtime_database"));
     }
     
     @Test
@@ -86,7 +85,9 @@ class MetadataResourceHandlerTest {
         Map<?, ?> actualEmptyState = (Map<?, ?>) actual.toPayload().get("empty_state");
         assertThat(actualEmptyState.get("category"), is("unknown_database"));
         assertThat(actualEmptyState.get("reason"), is("The requested logical database is not visible to MCP. Check runtimeDatabases and ShardingSphere-Proxy connectivity."));
-        assertThat(((Map<?, ?>) actual.toPayload().get("recovery")).get("recovery_category"), is("unknown_database"));
+        Map<?, ?> actualRecovery = (Map<?, ?>) actual.toPayload().get("recovery");
+        assertThat(actualRecovery.get("recovery_category"), is("not_found"));
+        assertThat(actualRecovery.get("category"), is("unknown_database"));
     }
     
     @Test
@@ -98,7 +99,9 @@ class MetadataResourceHandlerTest {
         Map<?, ?> actualEmptyState = (Map<?, ?>) actual.toPayload().get("empty_state");
         assertThat(actualEmptyState.get("category"), is("empty_scope"));
         assertThat(actualEmptyState.get("reason"), is("No metadata items are visible in this scope. Check metadata permissions if objects are expected."));
-        assertThat(((Map<?, ?>) actual.toPayload().get("recovery")).get("recovery_category"), is("empty_scope"));
+        Map<?, ?> actualRecovery = (Map<?, ?>) actual.toPayload().get("recovery");
+        assertThat(actualRecovery.get("recovery_category"), is("empty_scope"));
+        assertThat(actualRecovery.get("category"), is("empty_scope"));
     }
     
     @Test

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceResponseFactoryTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceResponseFactoryTest.java
@@ -43,10 +43,8 @@ class MetadataResourceResponseFactoryTest {
         assertThat(((List<?>) actual.get("items")).size(), is(100));
         assertThat(actual.get("count"), is(100));
         assertThat(actual.get("total_count"), is(101));
-        assertThat(actual.get("returned_count"), is(100));
         assertThat(actual.get("summary"), is("Returned 100 of 101 logical-database metadata entries."));
         assertTrue((Boolean) actual.get("truncated"));
-        assertTrue((Boolean) actual.get("has_more"));
         assertThat(actual.get("continuation_mode"), is("metadata_search"));
         assertThat(((Map<?, ?>) actual.get("large_result_guidance")).get("state"), is("broad_metadata_list"));
         assertThat(((Map<?, ?>) actual.get("large_result_guidance")).get("threshold"), is(100));
@@ -65,10 +63,9 @@ class MetadataResourceResponseFactoryTest {
         assertThat(actual.get("summary"), is("Returned logical-database detail for this resource URI."));
         assertThat(actual.get("resource_kind"), is("detail"));
         assertThat(actual.get("object_scope"), is("logical-database"));
-        assertTrue((Boolean) actual.get("found"));
-        assertThat(actual.get("item"), is(Map.of("database", "逻辑 库/2026?")));
+        assertThat(actual.get("items"), is(List.of(Map.of("database", "逻辑 库/2026?"))));
         String expectedSelfUri = "shardingsphere://databases/%E9%80%BB%E8%BE%91%20%E5%BA%93%2F2026%3F";
-        assertThat(actual.get("self_uri"), is(expectedSelfUri));
+        assertThat(((Map<?, ?>) actual.get("self_resource")).get("uri"), is(expectedSelfUri));
         assertThat(((Map<?, ?>) actual.get("parent_resource")).get("uri"), is("shardingsphere://databases"));
         List<String> nextResourceUris = ((List<?>) actual.get("next_resources")).stream().map(each -> (String) ((Map<?, ?>) each).get("uri")).toList();
         assertThat(nextResourceUris, is(List.of(
@@ -82,7 +79,7 @@ class MetadataResourceResponseFactoryTest {
     void assertCreateMissingDetailResponse() {
         Map<String, Object> actual = createResponse("shardingsphere://databases/{database}", mock(MCPUriVariables.class), List.of()).toPayload();
         assertThat(actual.get("summary"), is("No logical-database detail item matched this resource URI."));
-        assertFalse((Boolean) actual.get("found"));
+        assertThat(actual.get("items"), is(List.of()));
         assertThat(((Map<?, ?>) actual.get("empty_state")).get("reason"), is("logical-database detail resource was not found for this URI."));
         assertThat(((Map<?, ?>) actual.get("recovery")).get("recovery_category"), is("not_found"));
         assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("type"), is("terminal"));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandlerTest.java
@@ -126,7 +126,6 @@ class ExecuteUpdateToolHandlerTest {
         assertThat(actual.toPayload().get("statement_class"), is("dml"));
         assertThat(actual.toPayload().get("side_effect_scope"), is(List.of("physical-data")));
         assertThat(actual.toPayload().get("summary"), is("Previewed UPDATE statement with side-effect scope physical-data. It has not been executed."));
-        assertThat(actual.toPayload().get("review_summary"), is("Previewed UPDATE statement with side-effect scope physical-data. It has not been executed."));
         assertThat(actual.toPayload().get("review_guidance"),
                 is("Review normalized_sql and side_effect_scope before execution. "
                         + "This preview performs database-aware validation and classification; it does not guarantee rule validation, algorithm initialization, affected rows, or runtime success."));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolHandlerTest.java
@@ -74,7 +74,7 @@ class SearchMetadataToolHandlerTest {
         assertTrue(actualProperties.containsKey("search_context"));
         assertTrue(actualProperties.containsKey("summary"));
         assertTrue(actualProperties.containsKey("total_match_count"));
-        assertTrue(actualProperties.containsKey("returned_count"));
+        assertTrue(actualProperties.containsKey("count"));
         assertTrue(actualProperties.containsKey("truncated"));
         assertTrue(actualProperties.containsKey("large_result_guidance"));
         assertTrue(actualProperties.containsKey("empty_state"));
@@ -93,10 +93,9 @@ class SearchMetadataToolHandlerTest {
             assertThat(((List<?>) actualPayload.get("items")).size(), is(1));
             assertThat(actualPayload.get("summary"), is("Metadata search returned 1 of 1 matches."));
             assertThat(actualPayload.get("total_match_count"), is(1));
-            assertThat(actualPayload.get("returned_count"), is(1));
+            assertThat(actualPayload.get("count"), is(1));
             assertFalse((Boolean) actualPayload.get("truncated"));
             assertFalse(actualPayload.containsKey("next_page_token"));
-            assertFalse((Boolean) actualPayload.get("has_more"));
             assertThat(actualPayload.get("continuation_mode"), is("none"));
             assertThat(((MetadataSearchHit) ((List<?>) actualPayload.get("items")).getFirst()).getName(), is("order_idx"));
             assertThat(((Map<?, ?>) actualPayload.get("search_context")).get("object_types"), is(List.of("index")));
@@ -157,7 +156,7 @@ class SearchMetadataToolHandlerTest {
             assertThat(actual, isA(MCPItemsPayload.class));
             assertThat(actualNames.size(), is(9));
             assertThat(actualPayload.get("total_match_count"), is(9));
-            assertThat(actualPayload.get("returned_count"), is(9));
+            assertThat(actualPayload.get("count"), is(9));
             assertFalse((Boolean) actualPayload.get("truncated"));
             assertTrue(actualNames.contains("logic_db"));
             assertTrue(actualNames.contains("order_idx"));
@@ -173,9 +172,8 @@ class SearchMetadataToolHandlerTest {
             assertThat(((List<?>) actualPayload.get("items")).size(), is(100));
             assertThat(actualPayload.get("summary"), is("Metadata search returned 100 of 101 matches."));
             assertThat(actualPayload.get("total_match_count"), is(101));
-            assertThat(actualPayload.get("returned_count"), is(100));
+            assertThat(actualPayload.get("count"), is(100));
             assertTrue((Boolean) actualPayload.get("truncated"));
-            assertFalse((Boolean) actualPayload.get("has_more"));
             assertThat(actualPayload.get("continuation_mode"), is("none"));
             Map<?, ?> actualLargeResultGuidance = (Map<?, ?>) actualPayload.get("large_result_guidance");
             assertThat(actualLargeResultGuidance.get("state"), is("metadata_search_result_truncated"));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/payload/RuntimeDatabaseValidationPayloadTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/payload/RuntimeDatabaseValidationPayloadTest.java
@@ -45,8 +45,7 @@ class RuntimeDatabaseValidationPayloadTest {
                         "status", "passed",
                         "category", "ready",
                         "message", "Resolved the configured runtime database.")),
-                "category", "ready",
-                "recovery", Map.of())));
+                "category", "ready")));
     }
     
     @Test
@@ -57,10 +56,12 @@ class RuntimeDatabaseValidationPayloadTest {
         assertThat(actual.get("summary"), is("Runtime database `logic_db` failed validation with category `invalid_configuration`."));
         assertThat(actual.get("status"), is("failed"));
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
-        assertThat(actualRecovery.get("database"), is("logic_db"));
-        assertThat(actualRecovery.get("category"), is("invalid_configuration"));
-        assertFalse(actualRecovery.containsKey("request_id"));
-        assertThat(actual.get("next_actions"), is(actualRecovery.get("next_actions")));
+        assertFalse(actualRecovery.containsKey("response_mode"));
+        assertFalse(actualRecovery.containsKey("database"));
+        assertFalse(actualRecovery.containsKey("category"));
+        assertThat(actualRecovery.get("recovery_category"), is("unavailable_runtime"));
+        assertFalse(actualRecovery.containsKey("next_actions"));
+        assertFalse(((List<?>) actual.get("next_actions")).isEmpty());
     }
     
     @Test

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/payload/SQLExecutionPayloadTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/payload/SQLExecutionPayloadTest.java
@@ -101,11 +101,11 @@ class SQLExecutionPayloadTest {
             "SAVEPOINT, RELEASE SAVEPOINT, Savepoint released.",
             "DDL, CREATE, Statement executed."
     })
-    void assertStatementAcknowledgement(final SupportedMCPStatement statementClass, final String statementType, final String expectedMessage) {
+    void assertStatementAcknowledgement(final SupportedMCPStatement statementClass, final String statementType, final String expectedSummary) {
         Map<String, Object> actual = SQLExecutionPayload.executed(SQLExecutionResult.statementAck(
                 statementClass, statementType, 100, 0, statementType)).toPayload();
-        assertThat(actual.get("message"), is(expectedMessage));
-        assertThat(actual.get("summary"), is(expectedMessage));
+        assertThat(actual.get("summary"), is(expectedSummary));
+        assertFalse(actual.containsKey("message"));
     }
     
     @Test

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyOutcomeTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyOutcomeTest.java
@@ -37,7 +37,6 @@ class WorkflowApplyOutcomeTest {
         WorkflowApplyOutcome outcome = new WorkflowApplyOutcome();
         outcome.addExecutedArtifact(new WorkflowArtifactBundle.ExecutableWorkflowArtifact("CREATE MASK RULE orders", "CREATE MASK RULE orders"));
         Map<String, Object> actual = outcome.createResponse(WorkflowLifecycle.STATUS_COMPLETED, createSnapshot(), "review-then-execute", Map.of());
-        assertThat(((List<?>) actual.get("executed_distsql")).size(), is(1));
         assertThat(((Map<?, ?>) ((List<?>) actual.get("step_results")).getFirst()).get("status"), is(WorkflowLifecycle.STATUS_PASSED));
     }
     
@@ -55,11 +54,11 @@ class WorkflowApplyOutcomeTest {
     @Test
     void assertCreateResponseWithSecretReferenceIssue() {
         WorkflowApplyOutcome outcome = new WorkflowApplyOutcome();
-        outcome.addSecretReferenceManualExecutionRequired("secret_reference_manual_execution_required", Map.of("total", 1));
+        outcome.addSecretReferenceManualExecutionRequired();
         Map<String, Object> actual = outcome.createResponse(WorkflowLifecycle.STATUS_FAILED, createSnapshot(), "review-then-execute", Map.of());
         Map<?, ?> actualIssue = (Map<?, ?>) ((List<?>) actual.get("issues")).getFirst();
         assertThat(actualIssue.get("code"), is(WorkflowIssueCode.SECRET_REFERENCE_MANUAL_EXECUTION_REQUIRED));
-        assertThat(((Map<?, ?>) actualIssue.get("details")).get("category"), is("secret_reference_manual_execution_required"));
+        assertThat(actualIssue.get("details"), is(Map.of()));
     }
     
     private WorkflowContextSnapshot createSnapshot() {

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilderTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilderTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class WorkflowApplyResponseBuilderTest {
     
@@ -37,14 +38,13 @@ class WorkflowApplyResponseBuilderTest {
         List<WorkflowArtifactBundle.ExecutableWorkflowArtifact> executableArtifacts = List.of(
                 new WorkflowArtifactBundle.ExecutableWorkflowArtifact("CREATE MASK RULE orders", "CREATE MASK RULE orders"),
                 new WorkflowArtifactBundle.ExecutableWorkflowArtifact("ALTER MASK RULE orders", "ALTER MASK RULE orders"));
-        Map<String, Object> actual = new WorkflowApplyResponseBuilder().buildPreviewResponse(createSnapshot("mask.rule"), executableArtifacts, "review-then-execute", Map.of());
+        Map<String, Object> actual = new WorkflowApplyResponseBuilder().buildPreviewResponse(createSnapshot("mask.rule"), executableArtifacts, "review-then-execute");
         assertThat(actual.get("response_mode"), is("preview"));
         assertThat(actual.get("summary"), is("Previewed 2 workflow artifacts with side-effect scope rule-metadata. Nothing has been applied."));
         assertThat(actual.get("plan_id"), is("plan-1"));
         assertThat(actual.get("status"), is("preview"));
         assertThat(actual.get("execution_mode"), is("preview"));
-        assertThat(actual.get("manual_artifacts"), is(List.of()));
-        assertThat(actual.get(WorkflowArtifactPayloadUtils.PAYLOAD_KEY_MANUAL_ARTIFACT_PACKAGE), is(Map.of()));
+        assertFalse(actual.containsKey(WorkflowArtifactPayloadUtils.PAYLOAD_KEY_MANUAL_ARTIFACT_PACKAGE));
         assertThat(((List<?>) actual.get("preview_artifacts")).size(), is(2));
         Map<?, ?> actualReviewFocus = (Map<?, ?>) actual.get("review_focus");
         assertThat(actualReviewFocus.get("artifact_categories"), is(List.of("rule_distsql")));
@@ -56,11 +56,10 @@ class WorkflowApplyResponseBuilderTest {
     @Test
     void assertBuildCompletedResponse() {
         Map<String, Object> actual = new WorkflowApplyResponseBuilder().build(createSnapshot("encrypt.rule"), WorkflowLifecycle.STATUS_COMPLETED, "review-then-execute",
-                List.of(), List.of(), List.of("CREATE ENCRYPT RULE orders"), Map.of());
+                List.of(), List.of(Map.of("artifact_type", "rule_distsql", "status", WorkflowLifecycle.STATUS_PASSED, "sql", "CREATE ENCRYPT RULE orders")), Map.of());
         assertThat(actual.get("response_mode"), is("executed"));
         assertThat(actual.get("summary"), is("Workflow apply completed for plan `plan-1` with 1 applied artifact(s)."));
-        assertThat(actual.get("executed_distsql"), is(List.of("CREATE ENCRYPT RULE orders")));
-        assertThat(actual.get("applied_artifacts"), is(List.of("CREATE ENCRYPT RULE orders")));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("step_results")).getFirst()).get("sql"), is("CREATE ENCRYPT RULE orders"));
         assertThat(((List<?>) actual.get("next_actions")).size(), is(1));
     }
     
@@ -69,14 +68,14 @@ class WorkflowApplyResponseBuilderTest {
         Map<String, Object> manualArtifactPackage = Map.of(
                 WorkflowArtifactPayloadUtils.PAYLOAD_KEY_DISTSQL_ARTIFACTS, List.of(Map.of("sql", "CREATE ENCRYPT RULE orders")));
         Map<String, Object> actual = new WorkflowApplyResponseBuilder().build(createSnapshot("encrypt.rule"), WorkflowLifecycle.STATUS_AWAITING_MANUAL_EXECUTION, "manual-only",
-                List.of(), List.of(), List.of(), manualArtifactPackage);
+                List.of(), List.of(), manualArtifactPackage);
         assertThat(actual.get("response_mode"), is("manual_only"));
         assertThat(actual.get("summary"), is("Workflow apply exported manual artifacts for plan `plan-1`; external execution is required before validation."));
-        assertThat(actual.get("manual_artifacts"), is(List.of(manualArtifactPackage)));
+        assertThat(actual.get(WorkflowArtifactPayloadUtils.PAYLOAD_KEY_MANUAL_ARTIFACT_PACKAGE), is(manualArtifactPackage));
         Map<?, ?> actualSummary = (Map<?, ?>) actual.get("manual_artifact_summary");
         assertThat(actualSummary.get("distsql_artifact_count"), is(1));
-        assertThat(actualSummary.get("total_artifact_count"), is(1));
-        assertThat(((Map<?, ?>) actual.get("manual_follow_up")).get("confirmation_field"), is("manual_artifacts_executed"));
+        assertThat(actualSummary.get("safe_independent_read_only_checks"),
+                is("database_gateway_execute_query may run before manual execution confirmation when the user asked for read-only verification."));
     }
     
     private WorkflowContextSnapshot createSnapshot(final String workflowKind) {

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionServiceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionServiceTest.java
@@ -73,10 +73,8 @@ class WorkflowExecutionServiceTest {
         List<?> actualNextActions = (List<?>) actualResponse.get("next_actions");
         assertThat(actualNextActions.size(), is(1));
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("type"), is("ask_user"));
-        assertThat(((Map<?, ?>) actualResponse.get("manual_follow_up")).get("confirmation_field"), is("manual_artifacts_executed"));
         Map<?, ?> actualManualArtifactSummary = (Map<?, ?>) actualResponse.get("manual_artifact_summary");
         assertThat(actualManualArtifactSummary.get("distsql_artifact_count"), is(1));
-        assertThat(actualManualArtifactSummary.get("total_artifact_count"), is(1));
         assertTrue((Boolean) actualManualArtifactSummary.get("external_execution_required"));
         assertTrue((Boolean) actualManualArtifactSummary.get("requires_user_confirmation"));
         assertThat(actualManualArtifactSummary.get("validation_blocked_until"), is("manual_artifacts_executed"));
@@ -199,7 +197,7 @@ class WorkflowExecutionServiceTest {
         assertFalse((Boolean) actualReviewFocus.get("manual_only"));
         assertThat(actualReviewFocus.get("approval_field"), is("approved_steps"));
         assertThat(actualReviewFocus.get("approval_values"), is(List.of("rule_distsql")));
-        assertThat(actualResponse.get("review_summary"), is("Previewed 2 workflow artifacts with side-effect scope rule-metadata. Nothing has been applied."));
+        assertThat(actualResponse.get("summary"), is("Previewed 2 workflow artifacts with side-effect scope rule-metadata. Nothing has been applied."));
         List<?> actualNextActions = (List<?>) actualResponse.get("next_actions");
         assertThat(actualNextActions.size(), is(2));
         Map<?, ?> actualNextAction = (Map<?, ?>) actualNextActions.getFirst();
@@ -221,7 +219,7 @@ class WorkflowExecutionServiceTest {
     void assertApplyPreviewWithoutArtifacts() {
         WorkflowContextSnapshot snapshot = createSnapshot();
         Map<String, Object> actualResponse = apply(snapshot, List.of(), "preview");
-        assertThat(actualResponse.get("review_summary"), is("Previewed 0 workflow artifacts. Nothing has been applied."));
+        assertThat(actualResponse.get("summary"), is("Previewed 0 workflow artifacts. Nothing has been applied."));
         assertFalse(actualResponse.containsKey("approval_question"));
         assertThat(((Map<?, ?>) ((List<?>) actualResponse.get("next_actions")).getFirst()).get("type"), is("terminal"));
     }
@@ -256,8 +254,7 @@ class WorkflowExecutionServiceTest {
         assertThat(actualResponse.get("response_mode"), is("preview"));
         assertFalse((Boolean) actualResponse.get("would_apply"));
         assertThat(((List<?>) actualResponse.get("preview_artifacts")).size(), is(0));
-        assertThat(((List<?>) actualResponse.get("manual_artifacts")).size(), is(0));
-        assertThat(actualResponse.get("manual_artifact_package"), is(Map.of()));
+        assertFalse(actualResponse.containsKey("manual_artifact_package"));
         assertThat(((List<?>) actualResponse.get("issues")).size(), is(1));
         Map<?, ?> actualIssue = (Map<?, ?>) ((List<?>) actualResponse.get("issues")).getFirst();
         assertThat(actualIssue.get("code"), is(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED));
@@ -291,8 +288,7 @@ class WorkflowExecutionServiceTest {
                 List.of("rule_distsql"), "review-then-execute");
         assertThat(actualResponse.get("status"), is("completed"));
         assertThat(actualResponse.get("response_mode"), is("executed"));
-        assertThat(((List<?>) actualResponse.get("applied_artifacts")).size(), is(2));
-        assertThat(((List<?>) actualResponse.get("executed_distsql")).size(), is(2));
+        assertThat(((List<?>) actualResponse.get("step_results")).size(), is(2));
         assertThat(workflowSessionContext.getRequired("plan-1").getStatus(), is("executed"));
         verify(executionFacade).execute(argThat(each -> each.getSql().startsWith("CREATE MASK RULE")));
         verify(executionFacade).execute(argThat(each -> each.getSql().startsWith("ALTER MASK RULE")));
@@ -309,7 +305,6 @@ class WorkflowExecutionServiceTest {
         when(executionFacade.execute(any())).thenReturn(mock(SQLExecutionResult.class));
         Map<String, Object> actualResponse = apply(snapshot, executionFacade, NO_OP_APPLY_SYNCHRONIZATION_HANDLER, List.of("rule_distsql"), "review-then-execute");
         assertThat(actualResponse.get("status"), is("completed"));
-        assertThat(((List<?>) actualResponse.get("executed_distsql")).getFirst(), is("CREATE ENCRYPT RULE orders (PROPERTIES('aes-key-value'='******'))"));
         assertThat(((Map<?, ?>) ((List<?>) actualResponse.get("step_results")).getFirst()).get("sql"),
                 is("CREATE ENCRYPT RULE orders (PROPERTIES('aes-key-value'='******'))"));
         assertFalse(String.valueOf(actualResponse).contains("123456"));
@@ -324,8 +319,10 @@ class WorkflowExecutionServiceTest {
         assertThat(actualResponse.get("status"), is("failed"));
         assertThat(actualResponse.get("response_mode"), is("recovery"));
         assertThat(actualResponse.get("category"), is(MCPDiagnosticCategory.SECRET_REFERENCE_MANUAL_EXECUTION_REQUIRED));
+        assertThat(actualResponse.get("summary"), is("This workflow contains sensitive placeholders that must be filled outside MCP before execution."));
+        assertFalse(actualResponse.containsKey("message"));
         assertThat(((Map<?, ?>) ((List<?>) actualResponse.get("issues")).getFirst()).get("code"), is(WorkflowIssueCode.SECRET_REFERENCE_MANUAL_EXECUTION_REQUIRED));
-        assertThat(((List<?>) actualResponse.get("step_results")).size(), is(0));
+        assertFalse(actualResponse.containsKey("step_results"));
         assertTrue(String.valueOf(actualResponse).contains("<SECRET_VALUE_PRIMARY_AES_KEY_VALUE>"));
         assertFalse(String.valueOf(actualResponse).contains("placeholder://secret-value-1"));
         assertFalse(String.valueOf(actualResponse).contains("secret_reference:primary.aes-key-value"));

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRuleCountHandlerTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRuleCountHandlerTest.java
@@ -50,7 +50,7 @@ class BroadcastRuleCountHandlerTest {
             MCPSuccessPayload actual = handler.handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db")));
             verify(ruleInspectionService).queryBroadcastRuleCount(queryFacade, "logic_db");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/broadcast/databases/logic_db/rule-count"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/broadcast/databases/logic_db/rule-count"));
             assertThat(((Map<?, ?>) actual.toPayload().get("parent_resource")).get("uri"), is("shardingsphere://features/broadcast/databases/logic_db/rules"));
         }
     }

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRulesHandlerTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRulesHandlerTest.java
@@ -51,7 +51,7 @@ class BroadcastRulesHandlerTest {
             MCPSuccessPayload actual = handler.handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db")));
             verify(ruleInspectionService).queryBroadcastRules(queryFacade, "logic_db");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(2));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/broadcast/databases/logic_db/rules"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/broadcast/databases/logic_db/rules"));
         }
     }
 }

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastTableRuleHandlerTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastTableRuleHandlerTest.java
@@ -54,7 +54,7 @@ class BroadcastTableRuleHandlerTest {
             List<?> items = (List<?>) actual.toPayload().get("items");
             assertThat(items.size(), is(1));
             assertThat(((Map<?, ?>) items.getFirst()).get("broadcast_table"), is("t_order"));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/broadcast/databases/logic_db/tables/t_order/rule"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/broadcast/databases/logic_db/tables/t_order/rule"));
             assertThat(((Map<?, ?>) actual.toPayload().get("parent_resource")).get("uri"), is("shardingsphere://features/broadcast/databases/logic_db/rules"));
         }
     }

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowValidationServiceTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowValidationServiceTest.java
@@ -86,7 +86,7 @@ class BroadcastWorkflowValidationServiceTest {
         Map<String, Object> actual = service.validate(workflowSessionContext, metadataQueryFacade, queryFacade, executionFacade, "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
         assertThat(actual.get("overall_status"), is("passed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("passed"));
         verifyNoInteractions(metadataQueryFacade);
         verifyNoInteractions(executionFacade);
     }
@@ -101,7 +101,7 @@ class BroadcastWorkflowValidationServiceTest {
         Map<String, Object> actual = service.validate(
                 workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("passed"));
     }
     
     @Test
@@ -114,7 +114,7 @@ class BroadcastWorkflowValidationServiceTest {
         Map<String, Object> actual = service.validate(
                 workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("failed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("failed"));
     }
     
     private BroadcastRuleInspectionService getRuleInspectionService() {
@@ -144,5 +144,9 @@ class BroadcastWorkflowValidationServiceTest {
         clarifiedIntent.setOperationType(operationType);
         result.setClarifiedIntent(clarifiedIntent);
         return result;
+    }
+    
+    private Map<?, ?> getValidationSection(final Map<String, Object> payload, final String layer) {
+        return ((List<?>) payload.get("sections")).stream().map(each -> (Map<?, ?>) each).filter(each -> layer.equals(each.get("layer"))).findFirst().orElse(Map.of());
     }
 }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptAlgorithmsHandlerTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptAlgorithmsHandlerTest.java
@@ -49,7 +49,7 @@ class EncryptAlgorithmsHandlerTest {
             MCPSuccessPayload actual = new EncryptAlgorithmsHandler().handle(requestContext, new MCPUriVariables(Map.of()));
             verify(mockedConstruction.constructed().getFirst()).queryEncryptAlgorithms(queryFacade);
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/encrypt/algorithms"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/encrypt/algorithms"));
         }
     }
 }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRuleHandlerTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRuleHandlerTest.java
@@ -49,7 +49,7 @@ class EncryptRuleHandlerTest {
             MCPSuccessPayload actual = new EncryptRuleHandler().handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db", "table", "orders")));
             verify(mockedConstruction.constructed().getFirst()).queryEncryptRules(queryFacade, "logic_db", "orders");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/encrypt/databases/logic_db/tables/orders/rules"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/encrypt/databases/logic_db/tables/orders/rules"));
             assertThat(((Map<?, ?>) actual.toPayload().get("parent_resource")).get("uri"), is("shardingsphere://features/encrypt/databases/logic_db/rules"));
         }
     }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRulesHandlerTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRulesHandlerTest.java
@@ -49,7 +49,7 @@ class EncryptRulesHandlerTest {
             MCPSuccessPayload actual = new EncryptRulesHandler().handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db")));
             verify(mockedConstruction.constructed().getFirst()).queryEncryptRules(queryFacade, "logic_db");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/encrypt/databases/logic_db/rules"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/encrypt/databases/logic_db/rules"));
         }
     }
 }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowValidationServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowValidationServiceTest.java
@@ -98,10 +98,10 @@ class EncryptWorkflowValidationServiceTest {
                 .validate(workflowSessionContext, metadataQueryFacade, queryFacade, executionFacade, "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
         assertThat(actual.get("overall_status"), is("passed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("passed"));
         assertFalse(actual.containsKey("ddl_validation"));
-        assertFalse(actual.containsKey("logical_metadata_validation"));
-        assertFalse(actual.containsKey("sql_executability_validation"));
+        assertTrue(getValidationSection(actual, "logical_metadata").isEmpty());
+        assertTrue(getValidationSection(actual, "sql_executability").isEmpty());
         verifyNoInteractions(metadataQueryFacade);
         verifyNoInteractions(executionFacade);
     }
@@ -176,7 +176,7 @@ class EncryptWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(ruleInspectionService)
                 .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("passed"));
     }
     
     @Test
@@ -206,7 +206,7 @@ class EncryptWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(ruleInspectionService)
                 .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("failed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("failed"));
         assertThat(((Map<?, ?>) ((List<?>) actual.get("mismatches")).getFirst()).get("expected"), is("cipher_column=phone_cipher"));
     }
     
@@ -376,5 +376,9 @@ class EncryptWorkflowValidationServiceTest {
     
     private ExecutableWorkflowArtifact createRuleDistSQLArtifact(final String sql, final String displaySql) {
         return new ExecutableWorkflowArtifact(sql, displaySql);
+    }
+    
+    private Map<?, ?> getValidationSection(final Map<String, Object> payload, final String layer) {
+        return ((List<?>) payload.get("sections")).stream().map(each -> (Map<?, ?>) each).filter(each -> layer.equals(each.get("layer"))).findFirst().orElse(Map.of());
     }
 }

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskAlgorithmsHandlerTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskAlgorithmsHandlerTest.java
@@ -49,7 +49,7 @@ class MaskAlgorithmsHandlerTest {
             MCPSuccessPayload actual = new MaskAlgorithmsHandler().handle(requestContext, new MCPUriVariables(Map.of()));
             verify(mockedConstruction.constructed().getFirst()).queryMaskAlgorithms(queryFacade);
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/mask/algorithms"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/mask/algorithms"));
         }
     }
 }

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRuleHandlerTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRuleHandlerTest.java
@@ -49,7 +49,7 @@ class MaskRuleHandlerTest {
             MCPSuccessPayload actual = new MaskRuleHandler().handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db", "table", "orders")));
             verify(mockedConstruction.constructed().getFirst()).queryMaskRules(queryFacade, "logic_db", "orders");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/mask/databases/logic_db/tables/orders/rules"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/mask/databases/logic_db/tables/orders/rules"));
             assertThat(((Map<?, ?>) actual.toPayload().get("parent_resource")).get("uri"), is("shardingsphere://features/mask/databases/logic_db/rules"));
         }
     }

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRulesHandlerTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRulesHandlerTest.java
@@ -49,7 +49,7 @@ class MaskRulesHandlerTest {
             MCPSuccessPayload actual = new MaskRulesHandler().handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db")));
             verify(mockedConstruction.constructed().getFirst()).queryMaskRules(queryFacade, "logic_db");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/mask/databases/logic_db/rules"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/mask/databases/logic_db/rules"));
         }
     }
 }

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationServiceTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationServiceTest.java
@@ -98,10 +98,10 @@ class MaskWorkflowValidationServiceTest {
                 .validate(workflowSessionContext, metadataQueryFacade, queryFacade, executionFacade, "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
         assertThat(actual.get("overall_status"), is("passed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("passed"));
         assertFalse(actual.containsKey("ddl_validation"));
-        assertFalse(actual.containsKey("logical_metadata_validation"));
-        assertFalse(actual.containsKey("sql_executability_validation"));
+        assertTrue(getValidationSection(actual, "logical_metadata").isEmpty());
+        assertTrue(getValidationSection(actual, "sql_executability").isEmpty());
         verifyNoInteractions(metadataQueryFacade);
         verifyNoInteractions(executionFacade);
     }
@@ -154,7 +154,7 @@ class MaskWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(ruleInspectionService)
                 .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("passed"));
     }
     
     @Test
@@ -168,7 +168,7 @@ class MaskWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(ruleInspectionService)
                 .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("failed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("failed"));
     }
     
     @Test
@@ -307,5 +307,9 @@ class MaskWorkflowValidationServiceTest {
     
     private ExecutableWorkflowArtifact createRuleDistSQLArtifact(final String sql) {
         return new ExecutableWorkflowArtifact(sql, sql);
+    }
+    
+    private Map<?, ?> getValidationSection(final Map<String, Object> payload, final String layer) {
+        return ((List<?>) payload.get("sections")).stream().map(each -> (Map<?, ?>) each).filter(each -> layer.equals(each.get("layer"))).findFirst().orElse(Map.of());
     }
 }

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/LoadBalanceAlgorithmPluginsHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/LoadBalanceAlgorithmPluginsHandlerTest.java
@@ -50,7 +50,7 @@ class LoadBalanceAlgorithmPluginsHandlerTest {
             MCPSuccessPayload actual = handler.handle(requestContext, new MCPUriVariables(Map.of()));
             verify(inspectionService).queryLoadBalanceAlgorithmPlugins(queryFacade);
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins"));
         }
     }
 }

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleCountHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleCountHandlerTest.java
@@ -50,7 +50,7 @@ class ReadwriteSplittingRuleCountHandlerTest {
             MCPSuccessPayload actual = handler.handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db")));
             verify(inspectionService).queryRuleCount(queryFacade, "logic_db");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rule-count"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rule-count"));
             assertThat(((Map<?, ?>) actual.toPayload().get("parent_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rules"));
         }
     }

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleHandlerTest.java
@@ -50,7 +50,7 @@ class ReadwriteSplittingRuleHandlerTest {
             MCPSuccessPayload actual = handler.handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db", "rule", "readwrite_ds")));
             verify(inspectionService).queryRule(queryFacade, "logic_db", "readwrite_ds");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rules/readwrite_ds"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rules/readwrite_ds"));
             assertThat(((Map<?, ?>) actual.toPayload().get("parent_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rules"));
         }
     }

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleStatusHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleStatusHandlerTest.java
@@ -50,7 +50,7 @@ class ReadwriteSplittingRuleStatusHandlerTest {
             MCPSuccessPayload actual = handler.handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db", "rule", "readwrite_ds")));
             verify(inspectionService).queryRuleStatus(queryFacade, "logic_db", "readwrite_ds");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rules/readwrite_ds/status"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rules/readwrite_ds/status"));
             assertThat(((Map<?, ?>) actual.toPayload().get("parent_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/status"));
         }
     }

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRulesHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRulesHandlerTest.java
@@ -50,7 +50,7 @@ class ReadwriteSplittingRulesHandlerTest {
             MCPSuccessPayload actual = handler.handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db")));
             verify(inspectionService).queryRules(queryFacade, "logic_db");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rules"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rules"));
         }
     }
 }

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingStatusHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingStatusHandlerTest.java
@@ -50,7 +50,7 @@ class ReadwriteSplittingStatusHandlerTest {
             MCPSuccessPayload actual = handler.handle(requestContext, new MCPUriVariables(Map.of("database", "logic_db")));
             verify(inspectionService).queryStatuses(queryFacade, "logic_db");
             assertThat(((Collection<?>) actual.toPayload().get("items")).size(), is(1));
-            assertThat(actual.toPayload().get("self_uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/status"));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/status"));
             assertThat(((Map<?, ?>) actual.toPayload().get("parent_resource")).get("uri"), is("shardingsphere://features/readwrite-splitting/databases/logic_db/rules"));
         }
     }

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowValidationServicesTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowValidationServicesTest.java
@@ -78,7 +78,7 @@ class ReadwriteSplittingWorkflowValidationServicesTest {
         MCPFeatureExecutionFacade executionFacade = mock(MCPFeatureExecutionFacade.class);
         Map<String, Object> actual = createRuleService(inspectionService).validate(workflowSessionContext, metadataQueryFacade, queryFacade, executionFacade, "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("passed"));
         verifyNoInteractions(metadataQueryFacade);
         verifyNoInteractions(executionFacade);
     }
@@ -121,7 +121,7 @@ class ReadwriteSplittingWorkflowValidationServicesTest {
         Map<String, Object> actual = createRuleService(inspectionService)
                 .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("failed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("failed"));
     }
     
     @Test
@@ -199,7 +199,7 @@ class ReadwriteSplittingWorkflowValidationServicesTest {
         Map<String, Object> actual = createStatusService(inspectionService).validate(
                 workflowSessionContext, mock(MCPMetadataQueryFacade.class), queryFacade, mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("passed"));
     }
     
     @Test
@@ -212,7 +212,7 @@ class ReadwriteSplittingWorkflowValidationServicesTest {
         Map<String, Object> actual = createStatusService(inspectionService).validate(
                 workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("failed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("failed"));
         assertThat(((Map<?, ?>) ((List<?>) actual.get("mismatches")).getFirst()).get("code"), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
     }
     
@@ -323,5 +323,9 @@ class ReadwriteSplittingWorkflowValidationServicesTest {
     private ExecutableWorkflowArtifact createRuleDistSQLArtifact() {
         String sql = "CREATE READWRITE_SPLITTING RULE `readwrite_ds` (WRITE_STORAGE_UNIT=`write_ds`, READ_STORAGE_UNITS(`read_ds_0`), TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC')";
         return new ExecutableWorkflowArtifact(sql, sql);
+    }
+    
+    private Map<?, ?> getValidationSection(final Map<String, Object> payload, final String layer) {
+        return ((List<?>) payload.get("sections")).stream().map(each -> (Map<?, ?>) each).filter(each -> layer.equals(each.get("layer"))).findFirst().orElse(Map.of());
     }
 }

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/resource/handler/ShadowResourceHandlerTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/resource/handler/ShadowResourceHandlerTest.java
@@ -60,7 +60,7 @@ class ShadowResourceHandlerTest {
             when(requestContext.getQueryFacade()).thenReturn(mock(MCPFeatureQueryFacade.class));
             MCPSuccessPayload actual = handlerSupplier.get().handle(requestContext, uriVariables);
             assertThat(actual.toPayload().get("items"), is(createRows(expectedKind)));
-            assertThat(actual.toPayload().get("self_uri"), is(expectedSelfUri));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is(expectedSelfUri));
         }
     }
     

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/ShardingAlgorithmResourceHandlerTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/ShardingAlgorithmResourceHandlerTest.java
@@ -53,7 +53,7 @@ class ShardingAlgorithmResourceHandlerTest {
             when(requestContext.getQueryFacade()).thenReturn(mock(MCPFeatureQueryFacade.class));
             MCPSuccessPayload actual = handlerSupplier.get().handle(requestContext, uriVariables);
             assertThat(((List<?>) actual.toPayload().get("items")).size(), is(rows.size()));
-            assertThat(actual.toPayload().get("self_uri"), is(expectedSelfUri));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is(expectedSelfUri));
         }
     }
     

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/ShardingGovernanceResourceHandlerTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/ShardingGovernanceResourceHandlerTest.java
@@ -53,7 +53,7 @@ class ShardingGovernanceResourceHandlerTest {
             when(requestContext.getQueryFacade()).thenReturn(mock(MCPFeatureQueryFacade.class));
             MCPSuccessPayload actual = handlerSupplier.get().handle(requestContext, uriVariables);
             assertThat(((List<?>) actual.toPayload().get("items")).size(), is(rows.size()));
-            assertThat(actual.toPayload().get("self_uri"), is(expectedSelfUri));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is(expectedSelfUri));
         }
     }
     

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/ShardingStrategyResourceHandlerTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/ShardingStrategyResourceHandlerTest.java
@@ -53,7 +53,7 @@ class ShardingStrategyResourceHandlerTest {
             when(requestContext.getQueryFacade()).thenReturn(mock(MCPFeatureQueryFacade.class));
             MCPSuccessPayload actual = handlerSupplier.get().handle(requestContext, uriVariables);
             assertThat(((List<?>) actual.toPayload().get("items")).size(), is(rows.size()));
-            assertThat(actual.toPayload().get("self_uri"), is(expectedSelfUri));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is(expectedSelfUri));
         }
     }
     

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/ShardingTableResourceHandlerTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/ShardingTableResourceHandlerTest.java
@@ -53,7 +53,7 @@ class ShardingTableResourceHandlerTest {
             when(requestContext.getQueryFacade()).thenReturn(mock(MCPFeatureQueryFacade.class));
             MCPSuccessPayload actual = handlerSupplier.get().handle(requestContext, uriVariables);
             assertThat(((List<?>) actual.toPayload().get("items")).size(), is(rows.size()));
-            assertThat(actual.toPayload().get("self_uri"), is(expectedSelfUri));
+            assertThat(((Map<?, ?>) actual.toPayload().get("self_resource")).get("uri"), is(expectedSelfUri));
         }
     }
     

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationServiceTest.java
@@ -82,7 +82,7 @@ class ShardingWorkflowValidationServiceTest {
         MCPFeatureExecutionFacade executionFacade = mock(MCPFeatureExecutionFacade.class);
         Map<String, Object> actual = createService(inspectionService).validate(workflowSessionContext, metadataQueryFacade, queryFacade, executionFacade, "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("passed"));
         verifyNoInteractions(metadataQueryFacade);
         verifyNoInteractions(executionFacade);
     }
@@ -148,7 +148,7 @@ class ShardingWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(inspectionService).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class),
                 createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("failed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("failed"));
     }
     
     @Test
@@ -239,7 +239,7 @@ class ShardingWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(inspectionService).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class),
                 createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("failed"));
+        assertThat(getValidationSection(actual, "rule").get("status"), is("failed"));
         assertThat(((Map<?, ?>) ((List<?>) actual.get("mismatches")).getFirst()).get("code"), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
     }
     
@@ -503,5 +503,9 @@ class ShardingWorkflowValidationServiceTest {
     
     private ExecutableWorkflowArtifact createRuleDistSQLArtifact(final String sql) {
         return new ExecutableWorkflowArtifact(sql, sql);
+    }
+    
+    private Map<?, ?> getValidationSection(final Map<String, Object> payload, final String layer) {
+        return ((List<?>) payload.get("sections")).stream().map(each -> (Map<?, ?>) each).filter(each -> layer.equals(each.get("layer"))).findFirst().orElse(Map.of());
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndex.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndex.java
@@ -275,13 +275,11 @@ public final class MCPDescriptorCatalogIndex {
     /**
      * Create capability catalog payload.
      *
-     * @param supportedResources supported resource URI templates
-     * @param supportedTools supported tool names
      * @param supportedStatements supported statement classes
      * @return capability catalog payload
      */
-    public static Map<String, Object> createCapabilityPayload(final Collection<String> supportedResources, final Collection<String> supportedTools, final Collection<?> supportedStatements) {
-        return MCPDescriptorCatalogPayloadBuilder.build(CATALOG, supportedResources, supportedTools, supportedStatements);
+    public static Map<String, Object> createCapabilityPayload(final Collection<?> supportedStatements) {
+        return MCPDescriptorCatalogPayloadBuilder.build(CATALOG, supportedStatements);
     }
     
     /**
@@ -290,6 +288,6 @@ public final class MCPDescriptorCatalogIndex {
      * @return guidance payload
      */
     public static Map<String, Object> createGuidancePayload() {
-        return MCPGuidancePayloadBuilder.build(CATALOG);
+        return MCPGuidancePayloadBuilder.build();
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
@@ -19,115 +19,30 @@ package org.apache.shardingsphere.mcp.support.descriptor;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptArgumentDescriptor;
-import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptDescriptor;
-import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceAnnotations;
-import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceDescriptor;
-import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolAnnotations;
-import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
-import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 import org.apache.shardingsphere.mcp.support.protocol.MCPResponseMode;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 final class MCPDescriptorCatalogPayloadBuilder {
     
     private final MCPDescriptorCatalog catalog;
     
-    static Map<String, Object> build(final MCPDescriptorCatalog catalog, final Collection<String> supportedResources, final Collection<String> supportedTools,
-                                     final Collection<?> supportedStatements) {
-        return new MCPDescriptorCatalogPayloadBuilder(catalog).build(supportedResources, supportedTools, supportedStatements);
+    static Map<String, Object> build(final MCPDescriptorCatalog catalog, final Collection<?> supportedStatements) {
+        return new MCPDescriptorCatalogPayloadBuilder(catalog).build(supportedStatements);
     }
     
-    private Map<String, Object> build(final Collection<String> supportedResources, final Collection<String> supportedTools, final Collection<?> supportedStatements) {
-        Map<String, Object> result = new LinkedHashMap<>(16, 1F);
-        List<Map<String, Object>> resources = catalog.getProtocolDescriptors().getResourceDescriptors().stream().map(this::toResourcePayload).toList();
-        List<Map<String, Object>> resourceTemplates = catalog.getProtocolDescriptors().getResourceTemplateDescriptors().stream().map(this::toResourceTemplatePayload).toList();
-        List<Map<String, Object>> tools = catalog.getProtocolDescriptors().getToolDescriptors().stream().map(this::toToolPayload).toList();
-        List<Map<String, Object>> prompts = catalog.getProtocolDescriptors().getPromptDescriptors().stream().map(this::toPromptPayload).toList();
+    private Map<String, Object> build(final Collection<?> supportedStatements) {
+        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
         List<Map<String, Object>> completionTargets = catalog.getShardingSphereDescriptors().getCompletionTargetDescriptors().stream().map(this::toCompletionTargetPayload).toList();
         List<Map<String, Object>> resourceNavigation = catalog.getShardingSphereDescriptors().getResourceNavigationDescriptors().stream().map(this::toResourceNavigationPayload).toList();
         result.put("response_mode", MCPResponseMode.CATALOG);
-        result.put("supportedResources", supportedResources);
-        result.put("supportedTools", supportedTools);
         result.put("supportedStatementClasses", supportedStatements);
-        result.put("guidanceResource", "shardingsphere://guidance");
-        result.put("resources", resources);
-        result.put("resourceTemplates", resourceTemplates);
-        result.put("tools", tools);
-        result.put("prompts", prompts);
         result.put("completionTargets", completionTargets);
         result.put("resourceNavigation", resourceNavigation);
-        result.put("protocolAvailability", createProtocolAvailability(!resourceNavigation.isEmpty()));
-        return result;
-    }
-    
-    private Map<String, Object> toResourcePayload(final MCPResourceDescriptor descriptor) {
-        return createResourcePayload(descriptor, MCPPayloadFieldNames.URI);
-    }
-    
-    private Map<String, Object> toResourceTemplatePayload(final MCPResourceDescriptor descriptor) {
-        return createResourcePayload(descriptor, "uriTemplate");
-    }
-    
-    private Map<String, Object> createResourcePayload(final MCPResourceDescriptor descriptor, final String uriFieldName) {
-        Map<String, Object> result = new LinkedHashMap<>(8, 1F);
-        result.put(uriFieldName, descriptor.getUriTemplate());
-        result.put("name", descriptor.getName());
-        result.put("title", descriptor.getTitle());
-        result.put("description", descriptor.getDescription());
-        result.put("mimeType", descriptor.getMimeType());
-        if (!descriptor.getAnnotations().isEmpty()) {
-            result.put("annotations", toResourceAnnotationsPayload(descriptor.getAnnotations()));
-        }
-        if (!descriptor.getMeta().isEmpty()) {
-            result.put("_meta", descriptor.getMeta());
-        }
-        return result;
-    }
-    
-    private Map<String, Object> toToolPayload(final MCPToolDescriptor descriptor) {
-        Map<String, Object> result = new LinkedHashMap<>(8, 1F);
-        result.put("name", descriptor.getName());
-        result.put("title", descriptor.getTitle());
-        result.put("description", descriptor.getDescription());
-        result.put("inputSchema", descriptor.getInputSchema());
-        result.put("outputSchema", descriptor.getOutputSchema());
-        result.put("annotations", toToolAnnotationsPayload(descriptor.getAnnotations()));
-        if (!descriptor.getMeta().isEmpty()) {
-            result.put("meta", descriptor.getMeta());
-        }
-        return result;
-    }
-    
-    private Map<String, Object> toPromptPayload(final MCPPromptDescriptor descriptor) {
-        Map<String, Object> result = new LinkedHashMap<>(7, 1F);
-        result.put("name", descriptor.getName());
-        result.put("title", descriptor.getTitle());
-        result.put("description", descriptor.getDescription());
-        result.put("arguments", descriptor.getArguments().stream().map(this::toPromptArgumentPayload).toList());
-        if (!descriptor.getMeta().isEmpty()) {
-            result.put("meta", descriptor.getMeta());
-        }
-        return result;
-    }
-    
-    private Map<String, Object> toPromptArgumentPayload(final MCPPromptArgumentDescriptor descriptor) {
-        Map<String, Object> result = new LinkedHashMap<>(5, 1F);
-        result.put("name", descriptor.getName());
-        result.put("title", descriptor.getTitle());
-        result.put("description", descriptor.getDescription());
-        result.put("required", descriptor.isRequired());
-        Map<String, Object> completionHint = createCompletionHint(descriptor.getName());
-        if (!completionHint.isEmpty()) {
-            result.put("completion", completionHint);
-        }
         return result;
     }
     
@@ -155,46 +70,6 @@ final class MCPDescriptorCatalogPayloadBuilder {
         return result;
     }
     
-    private Map<String, Object> createCompletionHint(final String argumentName) {
-        List<MCPCompletionTargetDescriptor> descriptors = catalog.getShardingSphereDescriptors().getCompletionTargetDescriptors().stream()
-                .filter(each -> each.getArguments().contains(argumentName)).toList();
-        List<Map<String, Object>> references = descriptors.stream().map(this::createCompletionReferenceHint).toList();
-        if (references.isEmpty()) {
-            return Map.of();
-        }
-        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        result.put("available", true);
-        result.put("references", references);
-        List<String> requiredContextArguments = createCompletionRequiredContextArguments(descriptors, argumentName);
-        if (!requiredContextArguments.isEmpty()) {
-            result.put("required_context_arguments", requiredContextArguments);
-        }
-        return result;
-    }
-    
-    private Map<String, Object> createCompletionReferenceHint(final MCPCompletionTargetDescriptor descriptor) {
-        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        result.put("referenceType", descriptor.getReferenceType());
-        result.put("reference", descriptor.getReference());
-        result.put("maxValues", descriptor.getMaxValues());
-        return result;
-    }
-    
-    private List<String> createCompletionRequiredContextArguments(final Collection<MCPCompletionTargetDescriptor> descriptors, final String argumentName) {
-        Set<String> result = new LinkedHashSet<>();
-        for (MCPCompletionTargetDescriptor each : descriptors) {
-            Object requiredContextArguments = each.getMeta().get(MCPShardingSphereMetadataKeys.REQUIRED_CONTEXT_ARGUMENTS);
-            if (!(requiredContextArguments instanceof Map)) {
-                continue;
-            }
-            Object arguments = ((Map<?, ?>) requiredContextArguments).get(argumentName);
-            if (arguments instanceof Collection) {
-                ((Collection<?>) arguments).stream().map(String::valueOf).forEach(result::add);
-            }
-        }
-        return result.stream().toList();
-    }
-    
     private String resolveReferenceType(final String reference) {
         if (catalog.getProtocolDescriptors().getAllResourceDescriptors().stream().anyMatch(each -> each.getUriTemplate().equals(reference))) {
             return reference.contains("{") ? "resource_template" : "resource";
@@ -208,46 +83,4 @@ final class MCPDescriptorCatalogPayloadBuilder {
         return "unknown";
     }
     
-    private Map<String, Object> toResourceAnnotationsPayload(final MCPResourceAnnotations annotations) {
-        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        if (!annotations.getAudience().isEmpty()) {
-            result.put("audience", annotations.getAudience());
-        }
-        if (null != annotations.getPriority()) {
-            result.put("priority", annotations.getPriority());
-        }
-        if (null != annotations.getLastModified() && !annotations.getLastModified().isBlank()) {
-            result.put("lastModified", annotations.getLastModified());
-        }
-        return result;
-    }
-    
-    private Map<String, Object> toToolAnnotationsPayload(final MCPToolAnnotations annotations) {
-        Map<String, Object> result = new LinkedHashMap<>(6, 1F);
-        putIfPresent(result, "title", annotations.getTitle());
-        result.put("readOnlyHint", annotations.isReadOnlyHint());
-        result.put("destructiveHint", annotations.isDestructiveHint());
-        result.put("idempotentHint", annotations.isIdempotentHint());
-        result.put("openWorldHint", annotations.isOpenWorldHint());
-        return result;
-    }
-    
-    private void putIfPresent(final Map<String, Object> target, final String key, final Object value) {
-        if (null != value) {
-            target.put(key, value);
-        }
-    }
-    
-    private Map<String, Object> createProtocolAvailability(final boolean hasResourceNavigation) {
-        Map<String, Object> result = new LinkedHashMap<>(12, 1F);
-        result.put("resources", true);
-        result.put("resourceTemplates", true);
-        result.put("tools", true);
-        result.put("toolAnnotations", true);
-        result.put("toolOutputSchemas", true);
-        result.put("prompts", !catalog.getProtocolDescriptors().getPromptDescriptors().isEmpty());
-        result.put("completions", !catalog.getShardingSphereDescriptors().getCompletionTargetDescriptors().isEmpty());
-        result.put("resourceNavigation", hasResourceNavigation);
-        return result;
-    }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPGuidancePayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPGuidancePayloadBuilder.java
@@ -18,12 +18,9 @@
 package org.apache.shardingsphere.mcp.support.descriptor;
 
 import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
-import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.protocol.MCPResponseMode;
 import org.apache.shardingsphere.mcp.support.security.MCPClientSafetyPolicy;
-import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowToolDescriptors;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -32,92 +29,32 @@ import java.util.Map;
 /**
  * MCP guidance payload builder.
  */
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class MCPGuidancePayloadBuilder {
-    
-    private static final String PLANNING_TOOL_NAME_PREFIX = "database_gateway_plan_";
-    
-    private static final String PREFLIGHT_TOOL_NAME = "database_gateway_validate_runtime_database";
     
     private static final String GUIDANCE_RESOURCE_URI = "shardingsphere://guidance";
     
-    private static final String ARGUMENT_COMPLETION_METHOD = "completion/complete";
-    
-    private static final String MCP_LIST_METHODS_SOURCE = "MCP list methods expose the protocol surface: tools/list, resources/list, resources/templates/list, prompts/list.";
-    
-    private final MCPDescriptorCatalog catalog;
-    
-    static Map<String, Object> build(final MCPDescriptorCatalog catalog) {
-        return new MCPGuidancePayloadBuilder(catalog).build();
-    }
-    
-    private Map<String, Object> build() {
-        Map<String, Object> result = new LinkedHashMap<>(9, 1F);
+    static Map<String, Object> build() {
+        Map<String, Object> result = new LinkedHashMap<>(6, 1F);
         result.put("response_mode", MCPResponseMode.GUIDANCE);
-        result.put("guidance_resource", GUIDANCE_RESOURCE_URI);
-        result.put("model_first_summary", createModelFirstSummary());
+        result.put("discovery", createDiscovery());
         result.put("model_contract", createModelContract());
-        result.put("surface_summary", createSurfaceSummary());
-        result.put("field_naming_contract", createFieldNamingContract());
         result.put("next_action_contract", createNextActionContract());
         result.put("common_flows", createCommonFlows());
         result.put("security_hints", createSecurityHints());
         return result;
     }
     
-    Map<String, Object> createModelFirstSummary() {
-        Map<String, Object> result = new LinkedHashMap<>(12, 1F);
+    static Map<String, Object> createDiscovery() {
+        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
         result.put("official_discovery_methods", createOfficialDiscoveryMethods());
-        result.put("argument_completion_method", ARGUMENT_COMPLETION_METHOD);
+        result.put("argument_completion_method", "completion/complete");
         result.put("guidance_resource_role", GUIDANCE_RESOURCE_URI + " complements MCP list methods with ShardingSphere domain guidance, workflow guidance, and side-effect notes.");
-        result.put("guidance_resource", GUIDANCE_RESOURCE_URI);
-        result.put("first_call_routes", createFirstCallRoutes());
-        result.put("metadata_rule", createMetadataRule());
-        result.put("preflight_rule", createPreflightRule());
-        result.put("sql_tool_selection", createSqlToolSelection());
-        result.put("side_effect_rule", "Preview side effects first; execute only when the requested side effect is still intended.");
-        result.put("workflow_rule", createWorkflowRule());
-        result.put("completion_rule", "Use MCP completion for missing database, schema, table, column, index, sequence, or storage unit values before guessing identifiers.");
-        result.put("recovery_rule", "Follow structured recovery.next_actions before inventing a replacement call.");
         return result;
     }
     
-    private List<Map<String, Object>> createFirstCallRoutes() {
-        return List.of(
-                createFirstCallRoute("inspect_metadata", "read_resource shardingsphere://databases", "call_tool database_gateway_search_metadata or read returned resource.uri",
-                        "Stop after the requested detail resource is read."),
-                createFirstCallRoute("validate_runtime", "read_resource shardingsphere://runtime", "call_tool database_gateway_validate_runtime_database with a configured database",
-                        "Follow top-level next_actions when validation fails."),
-                createFirstCallRoute("read_only_sql", "read_resource shardingsphere://databases/{database}/capabilities", "call_tool database_gateway_execute_query",
-                        "Stop after reporting the result rows."),
-                createFirstCallRoute("explain_query", "read_resource shardingsphere://databases/{database}/capabilities",
-                        "generate database-native EXPLAIN SQL, then call_tool database_gateway_execute_explain_query", "Stop after reporting the execution plan rows."),
-                createFirstCallRoute("rule_workflow", "call_tool matching database_gateway_plan_* workflow tool without plan_id for a new plan",
-                        "call_tool database_gateway_apply_workflow execution_mode=preview with the returned plan_id",
-                        "Use workflow apply and validation for natural-language rule changes before considering raw side-effect SQL."),
-                createFirstCallRoute("side_effect_sql", "call_tool database_gateway_execute_update execution_mode=preview", "call_tool database_gateway_execute_update execution_mode=execute",
-                        "Execute only after preview review confirms the intended side effect."),
-                createFirstCallRoute("complete_uncertain_argument", "call completion/complete for one uncertain argument",
-                        "follow completion meta.next_actions when context is missing or no candidates match", "Stop after the argument is selected or the nearest resource proves it is unavailable."),
-                createFirstCallRoute("recover_error", "follow top-level next_actions", "fallback to recovery.next_actions when top-level actions are absent",
-                        "Ask the user only when no deterministic resource, completion, or tool action is available."));
-    }
-    
-    private Map<String, Object> createFirstCallRoute(final String intent, final String firstAction, final String nextStep, final String stopRule) {
-        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
-        result.put("intent", intent);
-        result.put("first_action", firstAction);
-        result.put("next_step", nextStep);
-        result.put("stop_rule", stopRule);
-        return result;
-    }
-    
-    Map<String, Object> createModelContract() {
+    static Map<String, Object> createModelContract() {
         Map<String, Object> result = new LinkedHashMap<>(12, 1F);
-        result.put("public_surface_source", MCP_LIST_METHODS_SOURCE);
-        result.put("official_discovery_methods", createOfficialDiscoveryMethods());
-        result.put("argument_completion_method", ARGUMENT_COMPLETION_METHOD);
-        result.put("guidance_resource", GUIDANCE_RESOURCE_URI);
         result.put("metadata_first_resource", "shardingsphere://databases");
         result.put("preflight_rule", "Use database_gateway_validate_runtime_database with a configured database name before onboarding or troubleshooting runtime connectivity.");
         Map<String, Object> sqlToolSelection = new LinkedHashMap<>(3, 1F);
@@ -131,39 +68,13 @@ final class MCPGuidancePayloadBuilder {
         result.put("resource_template_rule", "Use resources/templates/list to discover URI variables, then read the nearest concrete resource before filling dependent completion context.");
         result.put("next_action_rule", "Use canonical next_actions fields: type, tool_name, resource_uri, and arguments.");
         result.put("detail_resource_rule", "Use resource descriptors, outputSchema, and returned payload keys before assuming detail fields.");
-        result.put("recovery_rule", "When a call fails with recovery.next_actions, follow those structured actions before inventing a new call.");
+        result.put("recovery_rule", "When a call fails, follow top-level next_actions before inventing a new call.");
+        result.put("payload_field_rule", "ShardingSphere-owned structured payload fields use snake_case.");
+        result.put("descriptor_field_rule", "Descriptor-derived MCP schema fields keep the protocol or JSON Schema field names required by MCP clients.");
         return result;
     }
     
-    Map<String, Object> createSurfaceSummary() {
-        Map<String, Object> result = new LinkedHashMap<>(11, 1F);
-        result.put("official_discovery_methods", createOfficialDiscoveryMethods());
-        result.put("argument_completion_method", ARGUMENT_COMPLETION_METHOD);
-        result.put("guidance_resource", GUIDANCE_RESOURCE_URI);
-        result.put("metadata_resource", "shardingsphere://databases");
-        result.put("metadata_search_tool", "database_gateway_search_metadata");
-        result.put("preflight_validation_tool", PREFLIGHT_TOOL_NAME);
-        result.put("read_only_sql_tool", "database_gateway_execute_query");
-        result.put("explain_sql_tool", "database_gateway_execute_explain_query");
-        result.put("side_effect_sql_tool", "database_gateway_execute_update");
-        result.put("workflow_tools", List.of(WorkflowToolDescriptors.APPLY_TOOL_NAME, WorkflowToolDescriptors.VALIDATE_TOOL_NAME));
-        result.put("side_effect_rule", "Preview first and continue only when the requested side effect is still intended.");
-        result.put("completion_rule", "Use local completion hints on fields, prompts, and resources before guessing identifiers.");
-        return result;
-    }
-    
-    Map<String, Object> createFieldNamingContract() {
-        Map<String, Object> result = new LinkedHashMap<>(5, 1F);
-        result.put("official_discovery_methods", List.of("tools/list", "resources/list", "resources/templates/list", "prompts/list"));
-        result.put("argument_completion_method", ARGUMENT_COMPLETION_METHOD);
-        result.put("catalog_fields", List.of("supportedResources", "supportedTools", "supportedStatementClasses", "guidanceResource", "resourceTemplates", "completionTargets",
-                "resourceNavigation", "protocolAvailability"));
-        result.put("payload_fields", "ShardingSphere-owned structured payload fields use snake_case.");
-        result.put("descriptor_fields", "Descriptor-derived MCP schema fields keep the protocol or JSON Schema field names required by MCP clients.");
-        return result;
-    }
-    
-    List<Map<String, Object>> createNextActionContract() {
+    static List<Map<String, Object>> createNextActionContract() {
         return List.of(
                 createNextActionContractEntry("resource_read", List.of("order", "type", "title", "resource_uri"),
                         List.of("reason", "depends_on"), "Read an MCP resource before choosing another call."),
@@ -174,44 +85,39 @@ final class MCPGuidancePayloadBuilder {
                         List.of("context", "missing_context_arguments", "resume_ref", "resume_arguments", "reason", "depends_on"),
                         "Use MCP completion for one argument before retrying."),
                 createNextActionContractEntry("ask_user", List.of("order", "type", "title", "question"),
-                        List.of("required_inputs", "reason", "depends_on"), "Ask the user for missing input."),
+                        List.of("required_inputs", "depends_on"), "Ask the user for missing input."),
                 createNextActionContractEntry("terminal", List.of("order", "type", "title"),
                         List.of("reason", "depends_on"), "Stop the current MCP flow and report the result."));
     }
     
-    List<Map<String, Object>> createCommonFlows() {
+    static List<Map<String, Object>> createCommonFlows() {
         return List.of(
                 createCommonFlow("inspect_metadata", List.of("resources/list", "resources/templates/list", "read_resource shardingsphere://databases",
                         "call_tool database_gateway_search_metadata", "read_resource returned resource.uri"),
-                        "Stop when the requested metadata detail resource is read.",
-                        List.of("database_gateway_search_metadata"), List.of("shardingsphere://databases")),
+                        "Stop when the requested metadata detail resource is read."),
                 createCommonFlow("validate_runtime_database", List.of("read_resource shardingsphere://databases", "call_tool database_gateway_validate_runtime_database"),
-                        "Stop after the configured runtime database reports ready or returns structured recovery guidance.",
-                        List.of(PREFLIGHT_TOOL_NAME), List.of("shardingsphere://databases")),
+                        "Stop after the configured runtime database reports ready or returns structured recovery guidance."),
                 createCommonFlow("read_only_sql", List.of("read_resource shardingsphere://databases/{database}/capabilities", "call_tool database_gateway_execute_query"),
-                        "Use one SELECT statement and stop after the result is reported.",
-                        List.of("database_gateway_execute_query"), List.of("shardingsphere://databases/{database}/capabilities")),
+                        "Use one SELECT statement and stop after the result is reported."),
                 createCommonFlow("explain_query", List.of("read_resource shardingsphere://databases/{database}/capabilities",
                         "generate database-native EXPLAIN SQL without ANALYZE", "call_tool database_gateway_execute_explain_query"),
-                        "Use the original SELECT as sql, the generated EXPLAIN as explain_sql, and stop after the plan rows are reported.",
-                        List.of("database_gateway_execute_explain_query"), List.of("shardingsphere://databases/{database}/capabilities")),
+                        "Use the original SELECT as sql, the generated EXPLAIN as explain_sql, and stop after the plan rows are reported."),
                 createCommonFlow("side_effecting_sql", List.of("call_tool database_gateway_execute_update execution_mode=preview",
                         "call_tool database_gateway_execute_update execution_mode=execute"),
-                        "Execute only after reviewing the previewed SQL and side-effect scope.", List.of("database_gateway_execute_update"), List.of()),
+                        "Execute only after reviewing the previewed SQL and side-effect scope."),
                 createCommonFlow("complete_uncertain_argument", List.of("resources/templates/list", "call completion/complete for one argument",
                         "follow completion meta.next_actions when diagnostic is missing_context, prefix_filtered_all_candidates, or no_candidates"),
-                        "Stop when a completion value is selected or the nearest resource proves the argument is unavailable.", List.of(), List.of()),
+                        "Stop when a completion value is selected or the nearest resource proves the argument is unavailable."),
                 createCommonFlow("workflow_plan_apply_validate", List.of("call_tool descriptor-backed feature planning tool", "call_tool database_gateway_apply_workflow execution_mode=preview",
                         "call_tool database_gateway_apply_workflow execution_mode=review-then-execute approved_steps=<preview_artifacts.approval_step>",
                         "call_tool database_gateway_validate_workflow"),
-                        "Reuse the same current-session plan_id and stop after validation succeeds.",
-                        List.of(WorkflowToolDescriptors.APPLY_TOOL_NAME, WorkflowToolDescriptors.VALIDATE_TOOL_NAME), List.of()),
-                createCommonFlow("recover_from_error", List.of("follow recovery.next_actions", "prefer official list discovery methods when surface information is needed",
+                        "Reuse the same current-session plan_id and stop after validation succeeds."),
+                createCommonFlow("recover_from_error", List.of("follow top-level next_actions", "prefer official list discovery methods when surface information is needed",
                         "read_resource shardingsphere://guidance only when the server suggests the guidance resource", "ask_user only when uncertain"),
-                        "Do not invent replacement calls while structured recovery actions are present.", List.of(), List.of(GUIDANCE_RESOURCE_URI)));
+                        "Do not invent replacement calls while structured recovery actions are present."));
     }
     
-    Map<String, Object> createSecurityHints() {
+    static Map<String, Object> createSecurityHints() {
         Map<String, Object> result = new LinkedHashMap<>(4, 1F);
         result.put("http_transport", "Streamable HTTP is unauthenticated by default; prefer loopback binding or put remote exposure behind a trusted gateway.");
         result.put("origin_header", "Present Origin headers must be valid loopback origins for loopback HTTP bindings; missing Origin is accepted.");
@@ -220,7 +126,7 @@ final class MCPGuidancePayloadBuilder {
         return result;
     }
     
-    private Map<String, Object> createOfficialDiscoveryMethods() {
+    private static Map<String, Object> createOfficialDiscoveryMethods() {
         Map<String, Object> result = new LinkedHashMap<>(4, 1F);
         result.put("tools", "tools/list");
         result.put("resources", "resources/list");
@@ -229,7 +135,7 @@ final class MCPGuidancePayloadBuilder {
         return result;
     }
     
-    private Map<String, Object> createNextActionContractEntry(final String actionType, final List<String> requiredFields, final List<String> optionalFields, final String description) {
+    private static Map<String, Object> createNextActionContractEntry(final String actionType, final List<String> requiredFields, final List<String> optionalFields, final String description) {
         Map<String, Object> result = new LinkedHashMap<>(4, 1F);
         result.put("type", actionType);
         result.put("required_fields", requiredFields);
@@ -238,72 +144,11 @@ final class MCPGuidancePayloadBuilder {
         return result;
     }
     
-    private Map<String, Object> createMetadataRule() {
+    private static Map<String, Object> createCommonFlow(final String flowId, final List<String> steps, final String stopCondition) {
         Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        result.put("first_resource", "shardingsphere://databases");
-        result.put("search_tool", "database_gateway_search_metadata");
-        result.put("detail_rule", "Read the returned resource.uri when the list or search response points to a detail resource.");
-        return result;
-    }
-    
-    private Map<String, Object> createPreflightRule() {
-        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        result.put("tool", PREFLIGHT_TOOL_NAME);
-        result.put("input_rule", "Pass only a configured runtime database name.");
-        result.put("secret_rule", "Connection details stay in administrator runtime configuration and are not tool arguments.");
-        return result;
-    }
-    
-    private Map<String, Object> createSqlToolSelection() {
-        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        Map<String, Object> readOnly = new LinkedHashMap<>(2, 1F);
-        readOnly.put("tool", "database_gateway_execute_query");
-        readOnly.put("statement_rule", "Use for one SELECT statement.");
-        result.put("read_only", readOnly);
-        Map<String, Object> explain = new LinkedHashMap<>(3, 1F);
-        explain.put("tool", "database_gateway_execute_explain_query");
-        explain.put("statement_rule", "Use for an execution plan of one SELECT statement.");
-        explain.put("candidate_rule", "Generate database-native EXPLAIN SQL in explain_sql and never use EXPLAIN ANALYZE.");
-        result.put("explain", explain);
-        Map<String, Object> sideEffecting = new LinkedHashMap<>(4, 1F);
-        sideEffecting.put("tool", "database_gateway_execute_update");
-        sideEffecting.put("first_mode", "preview");
-        sideEffecting.put("execute_requires", "execution_mode=execute");
-        sideEffecting.put("rule_change_preference",
-                "For natural-language rule changes, use the matching database_gateway_plan_* workflow tool before raw SQL execution; "
-                        + "omit plan_id for a new plan.");
-        result.put("side_effecting", sideEffecting);
-        return result;
-    }
-    
-    private Map<String, Object> createWorkflowRule() {
-        Map<String, Object> result = new LinkedHashMap<>(5, 1F);
-        result.put("selection_rule",
-                "For natural-language rule changes, use the matching database_gateway_plan_* workflow tool before raw side-effect SQL; "
-                        + "omit plan_id for a new plan and reuse only returned plan_id values.");
-        result.put("planning_tools", catalog.getProtocolDescriptors().getToolDescriptors().stream()
-                .map(MCPToolDescriptor::getName).filter(each -> each.startsWith(PLANNING_TOOL_NAME_PREFIX)).toList());
-        Map<String, Object> previewTool = new LinkedHashMap<>(2, 1F);
-        previewTool.put("tool", WorkflowToolDescriptors.APPLY_TOOL_NAME);
-        previewTool.put(MCPPayloadFieldNames.EXECUTION_MODE, "preview");
-        result.put("preview_tool", previewTool);
-        Map<String, Object> executeTool = new LinkedHashMap<>(3, 1F);
-        executeTool.put("tool", WorkflowToolDescriptors.APPLY_TOOL_NAME);
-        executeTool.put(MCPPayloadFieldNames.EXECUTION_MODE, "review-then-execute");
-        executeTool.put("execute_requires", "execution_mode=review-then-execute and explicit approved_steps copied from preview_artifacts.approval_step");
-        result.put("execute_tool", executeTool);
-        result.put("validate_tool", WorkflowToolDescriptors.VALIDATE_TOOL_NAME);
-        return result;
-    }
-    
-    private Map<String, Object> createCommonFlow(final String flowId, final List<String> steps, final String stopCondition, final List<String> referencedTools,
-                                                 final List<String> referencedResources) {
-        Map<String, Object> result = new LinkedHashMap<>(5, 1F);
         result.put("flow_id", flowId);
         result.put("steps", steps);
         result.put("stop_condition", stopCondition);
-        result.put("referenced_tools", referencedTools);
-        result.put("referenced_resources", referencedResources);
         return result;
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationPayloadBuilder.java
@@ -56,7 +56,9 @@ public final class MCPResourceNavigationPayloadBuilder {
      */
     public static Map<String, Object> create(final MCPResourceDescriptor descriptor, final MCPUriVariables uriVariables, final String parentUriTemplate) {
         Map<String, Object> result = new LinkedHashMap<>(2, 1F);
-        new MCPUriTemplate(descriptor.getUriTemplate()).expandIfComplete(uriVariables).ifPresent(optional -> result.put("self_uri", optional));
+        new MCPUriTemplate(descriptor.getUriTemplate()).expandIfComplete(uriVariables)
+                .ifPresent(optional -> result.put(MCPPayloadFieldNames.SELF_RESOURCE, MCPResourceHintUtils.create(optional, resolveResourceKind(optional), "inspect_self",
+                        "Read this resource.", MCPPayloadFieldNames.SELF_RESOURCE)));
         Optional<String> parentUri = new MCPUriTemplate(parentUriTemplate).expandIfComplete(uriVariables);
         parentUri.filter(optional -> !optional.isEmpty()).ifPresent(optional -> result.put(MCPPayloadFieldNames.PARENT_RESOURCE, createParentResourceHint(optional)));
         return result;

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPShardingSphereMetadataKeys.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPShardingSphereMetadataKeys.java
@@ -85,10 +85,6 @@ public final class MCPShardingSphereMetadataKeys {
     
     public static final String CANDIDATE_COUNT = PREFIX + "candidate-count";
     
-    public static final String MATCHED_CANDIDATE_COUNT = PREFIX + "matched-candidate-count";
-    
-    public static final String RETURNED_CANDIDATE_COUNT = PREFIX + "returned-candidate-count";
-    
     public static final String MISSING_CONTEXT_ARGUMENTS = PREFIX + "missing-context-arguments";
     
     public static final String DIAGNOSTIC = PREFIX + "diagnostic";

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
@@ -265,7 +265,7 @@ public final class MCPToolDescriptorCatalogValidator {
     private static void validateApplyWorkflowDescriptor(final MCPToolDescriptor descriptor) {
         MCPToolDescriptorValidationUtils.validateRequiredOutputFields(descriptor,
                 List.of("response_mode", MCPPayloadFieldNames.SUMMARY, WorkflowFieldNames.PLAN_ID, "status", WorkflowFieldNames.EXECUTION_MODE, MCPPayloadFieldNames.NEXT_ACTIONS,
-                        "manual_artifact_summary", "category", "message", "secret_reference_summary"));
+                        "manual_artifact_summary", "category", "secret_reference_summary"));
     }
     
     private static void validateValidateWorkflowDescriptor(final MCPToolDescriptor descriptor) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContract.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContract.java
@@ -47,14 +47,14 @@ public final class MCPModelFacingPayloadContract {
             "resource_read", Set.of("order", "type", "title", "resource_uri", "reason", "depends_on"),
             "tool_call", Set.of("order", "type", "title", "tool_name", "arguments", "reason", "depends_on"),
             "completion", Set.of("order", "type", "title", "ref", "argument", "context", "missing_context_arguments", "resume_ref", "resume_arguments", "reason", "depends_on"),
-            "ask_user", Set.of("order", "type", "title", "question", "required_inputs", "reason", "depends_on"),
+            "ask_user", Set.of("order", "type", "title", "question", "required_inputs", "depends_on"),
             "terminal", Set.of("order", "type", "title", "reason", "depends_on"));
     
     private static final Collection<String> NEXT_ACTION_SCHEMA_ALLOWED_FIELDS = createNextActionSchemaAllowedFields();
     
     private static final Collection<String> MODEL_CRITICAL_FIELD_NAMES = List.of(
             MCPPayloadFieldNames.SUMMARY, MCPPayloadFieldNames.NEXT_ACTIONS, MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.RESOURCE,
-            MCPPayloadFieldNames.SELF_RESOURCE, MCPPayloadFieldNames.PARENT_RESOURCE, MCPPayloadFieldNames.NEXT_RESOURCES, "manual_artifact_summary", "manual_follow_up",
+            MCPPayloadFieldNames.SELF_RESOURCE, MCPPayloadFieldNames.PARENT_RESOURCE, MCPPayloadFieldNames.NEXT_RESOURCES, "manual_artifact_summary",
             "empty_state", "ambiguity_state", MCPPayloadFieldNames.RECOVERY, "recovery_guidance", "remediation");
     
     private static Collection<String> createNextActionSchemaAllowedFields() {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPNextActionUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPNextActionUtils.java
@@ -123,13 +123,13 @@ public final class MCPNextActionUtils {
     /**
      * Create an ask-user action.
      *
-     * @param reason action reason
+     * @param question question for the user
      * @param requiredInputs required user inputs
      * @return action payload
      */
-    public static Map<String, Object> askUser(final String reason, final List<String> requiredInputs) {
-        Map<String, Object> result = createBaseAction("ask_user", "Ask user", reason);
-        result.put("question", reason);
+    public static Map<String, Object> askUser(final String question, final List<String> requiredInputs) {
+        Map<String, Object> result = createBaseAction("ask_user", "Ask user");
+        result.put("question", question);
         result.put("required_inputs", requiredInputs);
         return result;
     }
@@ -145,11 +145,16 @@ public final class MCPNextActionUtils {
     }
     
     private static Map<String, Object> createBaseAction(final String type, final String title, final String reason) {
-        Map<String, Object> result = new LinkedHashMap<>(10, 1F);
+        Map<String, Object> result = createBaseAction(type, title);
+        result.put(MCPPayloadFieldNames.REASON, reason);
+        return result;
+    }
+    
+    private static Map<String, Object> createBaseAction(final String type, final String title) {
+        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
         result.put("order", 1);
         result.put("type", type);
         result.put("title", title);
-        result.put(MCPPayloadFieldNames.REASON, reason);
         return result;
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/payload/MCPItemsPayload.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/payload/MCPItemsPayload.java
@@ -68,16 +68,14 @@ public final class MCPItemsPayload implements MCPSuccessPayload {
     
     @Override
     public Map<String, Object> toPayload() {
-        String continuationMode = resolveContinuationMode();
-        Map<String, Object> result = new LinkedHashMap<>(items.size() + navigation.size() + 5, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(items.size() + navigation.size() + 4, 1F);
         result.put("response_mode", responseMode);
         result.put(MCPPayloadFieldNames.ITEMS, items);
         result.put("count", items.size());
-        result.put("has_more", !CONTINUATION_MODE_NONE.equals(continuationMode));
         if (null != nextPageToken && !nextPageToken.isEmpty()) {
             result.put("next_page_token", nextPageToken);
         }
-        result.put(CONTINUATION_MODE, continuationMode);
+        result.put(CONTINUATION_MODE, resolveContinuationMode());
         result.putAll(navigation);
         return result;
     }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicy.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicy.java
@@ -48,13 +48,12 @@ public final class MCPClientSafetyPolicy {
      * @return model-facing safety policy payload
      */
     public static Map<String, Object> createModelFacingPayload() {
-        Map<String, Object> result = new LinkedHashMap<>(6, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(5, 1F);
         result.put("identity_scope", "mcp_session");
         result.put("transport_scope",
                 "HTTP transport can bind trusted session attribution when configured; "
                         + "the MCP runtime does not provide built-in authentication or authorization. "
                         + "STDIO inherits the local process boundary.");
-        result.put("tool_call_limit", MCPRuntimeProtectionPolicy.createToolCallLimitPayload());
         result.put("runtime_protection", MCPRuntimeProtectionPolicy.createRuntimeProtectionPayload());
         result.put("abuse_guard", "Every tool call is counted before dispatch, including invalid calls, so runaway model loops stop at the session quota.");
         result.put("external_model_boundary", "The MCP runtime never calls external model providers; live LLM E2E clients call configured endpoints outside the server.");

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/ValidationReport.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/ValidationReport.java
@@ -48,18 +48,27 @@ public final class ValidationReport {
      * @return map representation
      */
     public Map<String, Object> toMap() {
-        Map<String, Object> result = new LinkedHashMap<>(8, 1F);
-        putValidationSection(result, "rule_validation", ruleValidation);
-        putValidationSection(result, "logical_metadata_validation", logicalMetadataValidation);
-        putValidationSection(result, "sql_executability_validation", sqlExecutabilityValidation);
+        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
         result.put("overall_status", overallStatus);
         result.put("mismatches", mismatches);
+        result.put("sections", createSections());
         return result;
     }
     
-    private void putValidationSection(final Map<String, Object> target, final String key, final ValidationSection section) {
+    private List<Map<String, Object>> createSections() {
+        List<Map<String, Object>> result = new LinkedList<>();
+        addSection(result, "rule", ruleValidation);
+        addSection(result, "logical_metadata", logicalMetadataValidation);
+        addSection(result, "sql_executability", sqlExecutabilityValidation);
+        return result;
+    }
+    
+    private void addSection(final List<Map<String, Object>> sections, final String layer, final ValidationSection section) {
         if (null != section) {
-            target.put(key, section.toMap());
+            Map<String, Object> sectionPayload = new LinkedHashMap<>(4, 1F);
+            sectionPayload.put("layer", layer);
+            sectionPayload.putAll(section.toMap());
+            sections.add(sectionPayload);
         }
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactMaskUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactMaskUtils.java
@@ -127,16 +127,7 @@ public final class WorkflowArtifactMaskUtils {
         result.put("marker", "******");
         result.put("redacted_properties", redactedProperties);
         result.put("redacted_count", redactedProperties.size());
-        result.put("redaction_summary", createRedactionSummary(redactedProperties));
-        result.put("secret_reference_summary", createSecretReferenceSummary(propertySource));
-        return result;
-    }
-    
-    private static Map<String, Object> createRedactionSummary(final List<String> redactedProperties) {
-        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
         result.put("categories", redactedProperties.stream().map(WorkflowArtifactMaskUtils::createRedactedCategory).distinct().toList());
-        result.put("marker", "******");
-        result.put("redacted_count", redactedProperties.size());
         return result;
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
@@ -89,7 +89,7 @@ public final class WorkflowGuidancePayloadBuilder {
         }
         if (WorkflowLifecycle.STATUS_FAILED.equals(status) && isSecretReferenceRecovery(payload)) {
             nextActions.add(createUserAction("Review the manual artifacts, replace neutral secret placeholders outside MCP, and execute them through the normal operational channel.",
-                    List.of("manual_artifacts")));
+                    List.of("manual_artifacts_executed")));
         } else if (WorkflowLifecycle.STATUS_FAILED.equals(status)) {
             nextActions.add(createUserAction("Inspect issues and retry database_gateway_apply_workflow only after the failed artifact is corrected.", List.of("issues")));
         }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowValidationSupport.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowValidationSupport.java
@@ -29,7 +29,6 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
 
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -114,7 +113,6 @@ public final class WorkflowValidationSupport {
         result.put("status", validationStatus);
         result.put("issues", createValidationIssues(validationReport));
         result.putAll(validationReport.toMap());
-        result.put("sections", createValidationSections(validationReport));
         WorkflowGuidancePayloadBuilder.appendValidationGuidance(result, snapshot, validationReport);
         return result;
     }
@@ -148,24 +146,6 @@ public final class WorkflowValidationSupport {
         }
         return List.of(new WorkflowIssue(resolveValidationIssueCode(validationReport), "error", WorkflowLifecycle.STEP_VALIDATING,
                 "Validation detected mismatches between the plan and the current state.", "Inspect mismatches and re-run the workflow after fixes.", true, Map.of()).toMap());
-    }
-    
-    private List<Map<String, Object>> createValidationSections(final ValidationReport validationReport) {
-        List<Map<String, Object>> result = new LinkedList<>();
-        addValidationSection(result, "rule", validationReport.getRuleValidation());
-        addValidationSection(result, "logical_metadata", validationReport.getLogicalMetadataValidation());
-        addValidationSection(result, "sql_executability", validationReport.getSqlExecutabilityValidation());
-        return result;
-    }
-    
-    private void addValidationSection(final List<Map<String, Object>> sections, final String layer, final ValidationSection section) {
-        if (null == section) {
-            return;
-        }
-        Map<String, Object> sectionPayload = new LinkedHashMap<>(4, 1F);
-        sectionPayload.put("layer", layer);
-        sectionPayload.putAll(section.toMap());
-        sections.add(sectionPayload);
     }
     
     private String resolveValidationStatus(final ValidationReport validationReport) {

--- a/mcp/support/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-support.yaml
+++ b/mcp/support/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-support.yaml
@@ -242,9 +242,6 @@ tools:
             - secret_reference_malformed
             - secret_reference_missing
             - secret_reference_manual_execution_required
-        message:
-          type: string
-          description: "Recovery or execution message. Secret-placeholder failures never include raw secret_ref identifiers or real sensitive values."
         issues:
           type: array
           description: "Workflow issues reported while checking or applying artifacts."
@@ -287,12 +284,6 @@ tools:
               sql:
                 type: string
                 description: "Artifact SQL or DistSQL."
-        executed_distsql:
-          type: array
-          description: "DistSQL statements executed by the server."
-        applied_artifacts:
-          type: array
-          description: "Rule DistSQL artifacts executed by the server."
         preview_artifacts:
           type: array
           description: "Artifacts that would be applied when execution_mode=preview."
@@ -317,21 +308,12 @@ tools:
         would_apply:
           type: boolean
           description: "False when execution_mode=preview, proving workflow artifacts were not applied."
-        review_summary:
-          type: string
-          description: "Preview-only natural-language summary that confirms workflow artifacts were not applied."
-        manual_artifacts:
-          type: array
-          description: "Artifacts returned for manual execution."
         manual_artifact_package:
           type: object
           description: "Manual-only artifact package returned when execution_mode=manual-only; contains generated rule DistSQL needed for operator execution."
         manual_artifact_summary:
           type: object
           description: "Manual-only compact artifact summary with counts, external execution requirement, confirmation gate, and validation arguments to use after manual execution."
-        manual_follow_up:
-          type: object
-          description: "Manual-only confirmation contract; database_gateway_validate_workflow is blocked until manual_artifacts_executed is confirmed, while independent query checks remain allowed."
         secret_reference_summary:
           type: object
           description: "Safe summary returned for sensitive placeholders. It contains role/property labels, manual placeholders, and counts only, never raw secret_ref identifiers or real sensitive values."
@@ -376,11 +358,8 @@ tools:
           summary: Previewed 0 workflow artifacts. Nothing has been applied.
           plan_id: encrypt-rule-20260505-001
           execution_mode: preview
-          applied_artifacts: []
           preview_artifacts: []
           would_apply: false
-          manual_artifacts: []
-          review_summary: Previewed 0 workflow artifacts. Nothing has been applied.
           next_actions:
             - order: 1
               type: terminal

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndexTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndexTest.java
@@ -149,10 +149,12 @@ class MCPDescriptorCatalogIndexTest {
     
     @Test
     void assertCreateCapabilityPayload() {
-        Map<String, Object> actual = MCPDescriptorCatalogIndex.createCapabilityPayload(List.of("shardingsphere://workflows/{plan_id}"), List.of("database_gateway_apply_workflow"), List.of("SELECT"));
-        assertThat(actual.get("supportedResources"), is(List.of("shardingsphere://workflows/{plan_id}")));
-        assertThat(actual.get("supportedTools"), is(List.of("database_gateway_apply_workflow")));
+        Map<String, Object> actual = MCPDescriptorCatalogIndex.createCapabilityPayload(List.of("SELECT"));
         assertThat(actual.get("supportedStatementClasses"), is(List.of("SELECT")));
+        assertTrue(actual.containsKey("completionTargets"));
+        assertTrue(actual.containsKey("resourceNavigation"));
+        assertFalse(actual.containsKey("resources"));
+        assertFalse(actual.containsKey("tools"));
         assertFalse(actual.containsKey("fingerprints"));
     }
     
@@ -160,7 +162,7 @@ class MCPDescriptorCatalogIndexTest {
     void assertCreateGuidancePayload() {
         Map<String, Object> actual = MCPDescriptorCatalogIndex.createGuidancePayload();
         assertThat(actual.get("response_mode"), is("guidance"));
-        assertThat(actual.get("guidance_resource"), is("shardingsphere://guidance"));
+        assertTrue(actual.containsKey("discovery"));
         assertTrue(actual.containsKey("model_contract"));
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogLoaderTest.java
@@ -45,8 +45,8 @@ class MCPDescriptorCatalogLoaderTest {
         Set<String> actualToolNames = actual.getProtocolDescriptors().getToolDescriptors().stream().map(MCPToolDescriptor::getName).collect(Collectors.toSet());
         assertToolNames(actualToolNames);
         assertOutputProperties(actual, "database_gateway_apply_workflow", Set.of(
-                "response_mode", "summary", "plan_id", "execution_mode", "next_actions", "manual_artifact_package", "manual_artifact_summary", "manual_follow_up", "argument_provenance",
-                "review_summary", "review_focus", "category", "message", "secret_reference_summary"));
+                "response_mode", "summary", "plan_id", "execution_mode", "next_actions", "manual_artifact_package", "manual_artifact_summary", "argument_provenance",
+                "review_focus", "category", "secret_reference_summary"));
         assertOutputProperties(actual, "database_gateway_validate_workflow", Set.of("response_mode", "summary", "plan_id", "status", "recovery_guidance", "next_actions", "sections", "mismatches"));
         assertPublicToolAnnotations(actual);
         assertPlanningToolAnnotations(actual);
@@ -158,9 +158,8 @@ class MCPDescriptorCatalogLoaderTest {
     }
     
     private void assertNoToolExecutionPayload(final MCPDescriptorCatalog catalog) {
-        Map<String, Object> payload = MCPDescriptorCatalogPayloadBuilder.build(catalog, List.of(), List.of(), List.of());
-        for (Object each : (List<?>) payload.get("tools")) {
-            assertFalse(((Map<?, ?>) each).containsKey("execution"));
+        for (MCPToolDescriptor each : catalog.getProtocolDescriptors().getToolDescriptors()) {
+            assertFalse(each.getMeta().containsKey("execution"));
         }
     }
     

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilderTest.java
@@ -17,16 +17,14 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
-import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptArgumentDescriptor;
-import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptDescriptor;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceAnnotations;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceDescriptor;
-import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolAnnotations;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -35,102 +33,29 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class MCPDescriptorCatalogPayloadBuilderTest {
     
     @Test
-    void assertBuildCatalogMetadataContractPayload() {
-        List<MCPResourceDescriptor> resourceDescriptors = List.of(
-                createResourceDescriptor("shardingsphere://capabilities", MCPResourceAnnotations.EMPTY),
-                createResourceDescriptor("shardingsphere://databases", MCPResourceAnnotations.EMPTY));
-        Map<String, Object> payload = MCPDescriptorCatalogPayloadBuilder.build(
-                createCatalog(resourceDescriptors, List.of(createToolDescriptor(MCPToolAnnotations.builder()
-                        .title(null).readOnlyHint(false).destructiveHint(true).idempotentHint(false).openWorldHint(true).build()))),
-                List.of("shardingsphere://capabilities"), List.of("database_gateway_test_tool"), List.of("SelectStatement"));
-        assertThat(payload.get("response_mode"), is("catalog"));
-        assertThat(payload.get("guidanceResource"), is("shardingsphere://guidance"));
-        assertFalse(payload.containsKey("model_first_summary"));
-        assertFalse(payload.containsKey("model_contract"));
-        assertFalse(payload.containsKey("common_flows"));
-        assertFalse(payload.containsKey("security_hints"));
-    }
-    
-    @Test
     @SuppressWarnings("unchecked")
-    void assertBuildResourceAnnotationsPayload() {
-        MCPResourceDescriptor emptyAnnotationsResource = createResourceDescriptor("shardingsphere://empty", MCPResourceAnnotations.EMPTY);
-        MCPResourceAnnotations priorityZeroAnnotations = new MCPResourceAnnotations(List.of("assistant"), 0D, null);
-        MCPResourceDescriptor priorityZeroResource = createResourceDescriptor("shardingsphere://priority-zero", priorityZeroAnnotations);
-        Map<String, Object> payload = MCPDescriptorCatalogPayloadBuilder.build(createCatalog(List.of(emptyAnnotationsResource, priorityZeroResource), List.of()), List.of(), List.of(), List.of());
-        List<Map<String, Object>> actualResources = (List<Map<String, Object>>) payload.get("resources");
-        assertFalse(actualResources.get(0).containsKey("annotations"));
-        assertThat((Map<String, Object>) actualResources.get(1).get("annotations"), is(Map.of("audience", List.of("assistant"), "priority", 0D)));
+    void assertBuildShardingSphereCapabilityPayload() {
+        MCPResourceDescriptor resourceTemplate = new MCPResourceDescriptor("shardingsphere://databases/{database}", "database", "Database", "Read a database.",
+                "application/json", MCPResourceAnnotations.EMPTY, Map.of());
+        MCPToolDescriptor tool = new MCPToolDescriptor("database_gateway_test_tool", "Test Tool", "Run a test tool.", Map.of(), Map.of(), null, Map.of());
+        MCPCompletionTargetDescriptor completionTarget = new MCPCompletionTargetDescriptor("resource_template", resourceTemplate.getUriTemplate(), List.of("database"), 50,
+                Map.of(MCPShardingSphereMetadataKeys.REQUIRED_CONTEXT_ARGUMENTS, Map.of("database", List.of())));
+        MCPResourceNavigationDescriptor navigation = new MCPResourceNavigationDescriptor(resourceTemplate.getUriTemplate(), tool.getName(), List.of("database"), List.of("database"),
+                "Call the test tool after reading the database.");
+        MCPDescriptorCatalog catalog = new MCPDescriptorCatalog(new MCPProtocolDescriptorCatalog(List.of(), List.of(resourceTemplate), List.of(tool), List.of()),
+                new MCPShardingSphereDescriptorCatalog(List.of(), List.of(), List.of(completionTarget), List.of(navigation), List.of()));
+        Map<String, Object> actual = MCPDescriptorCatalogPayloadBuilder.build(catalog, List.of("SelectStatement"));
+        assertThat(actual.keySet(), is(Set.of("response_mode", "supportedStatementClasses", "completionTargets", "resourceNavigation")));
+        assertThat(actual.get("response_mode"), is("catalog"));
+        assertThat(actual.get("supportedStatementClasses"), is(List.of("SelectStatement")));
+        Map<String, Object> actualCompletionTarget = ((List<Map<String, Object>>) actual.get("completionTargets")).getFirst();
+        assertThat(actualCompletionTarget.get("reference"), is(resourceTemplate.getUriTemplate()));
+        assertThat(actualCompletionTarget.get("meta"), is(completionTarget.getMeta()));
+        Map<String, Object> actualNavigation = ((List<Map<String, Object>>) actual.get("resourceNavigation")).getFirst();
+        assertThat(actualNavigation.get("from_type"), is("resource_template"));
+        assertThat(actualNavigation.get("to_type"), is("tool"));
+        assertFalse(actual.containsKey("resources"));
+        assertFalse(actual.containsKey("tools"));
+        assertFalse(actual.containsKey("protocolAvailability"));
     }
-    
-    @Test
-    @SuppressWarnings("unchecked")
-    void assertBuildResourceMetaPayload() {
-        Map<String, Object> meta = Map.of(MCPShardingSphereMetadataKeys.RESOURCE_KIND, "detail");
-        MCPResourceDescriptor resource = createResourceDescriptor("shardingsphere://runtime", MCPResourceAnnotations.EMPTY, meta);
-        MCPResourceDescriptor resourceTemplate = createResourceDescriptor("shardingsphere://databases/{database}", MCPResourceAnnotations.EMPTY, meta);
-        MCPDescriptorCatalog catalog = createCatalog(List.of(resource), List.of(resourceTemplate), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
-        Map<String, Object> payload = MCPDescriptorCatalogPayloadBuilder.build(catalog, List.of(), List.of(), List.of());
-        Map<String, Object> actualResource = ((List<Map<String, Object>>) payload.get("resources")).get(0);
-        Map<String, Object> actualResourceTemplate = ((List<Map<String, Object>>) payload.get("resourceTemplates")).get(0);
-        assertFalse(actualResource.containsKey("meta"));
-        assertFalse(actualResourceTemplate.containsKey("meta"));
-        assertThat((Map<String, Object>) actualResource.get("_meta"), is(meta));
-        assertThat((Map<String, Object>) actualResourceTemplate.get("_meta"), is(meta));
-    }
-    
-    @Test
-    @SuppressWarnings("unchecked")
-    void assertBuildToolAnnotationsPayload() {
-        MCPToolDescriptor toolDescriptor = createToolDescriptor(MCPToolAnnotations.builder()
-                .title(null).readOnlyHint(false).destructiveHint(true).idempotentHint(false).openWorldHint(true).build());
-        Map<String, Object> payload = MCPDescriptorCatalogPayloadBuilder.build(createCatalog(List.of(), List.of(toolDescriptor)), List.of(), List.of(), List.of());
-        List<Map<String, Object>> actualTools = (List<Map<String, Object>>) payload.get("tools");
-        assertThat((Map<String, Object>) actualTools.get(0).get("annotations"), is(Map.of(
-                "readOnlyHint", false,
-                "destructiveHint", true,
-                "idempotentHint", false,
-                "openWorldHint", true)));
-    }
-    
-    @Test
-    @SuppressWarnings("unchecked")
-    void assertBuildPromptCompletionRequiredContextFromDescriptorMeta() {
-        MCPPromptDescriptor prompt = new MCPPromptDescriptor("test_prompt", "Test Prompt", "Guide a test prompt.", List.of(
-                new MCPPromptArgumentDescriptor("database", "Database", "Logical database.", false),
-                new MCPPromptArgumentDescriptor("schema", "Schema", "Schema.", false)), Map.of());
-        MCPCompletionTargetDescriptor completionTarget = new MCPCompletionTargetDescriptor("prompt", "test_prompt", List.of("database", "schema"), 50,
-                Map.of(MCPShardingSphereMetadataKeys.REQUIRED_CONTEXT_ARGUMENTS, Map.of("schema", List.of("database"))));
-        MCPDescriptorCatalog catalog = createCatalog(List.of(), List.of(), List.of(), List.of(), List.of(prompt), List.of(), List.of(completionTarget), List.of(), List.of());
-        Map<String, Object> payload = MCPDescriptorCatalogPayloadBuilder.build(catalog, List.of(), List.of(), List.of());
-        Map<String, Object> actualPrompt = ((List<Map<String, Object>>) payload.get("prompts")).get(0);
-        Map<String, Object> actualSchemaArgument = ((List<Map<String, Object>>) actualPrompt.get("arguments")).get(1);
-        assertThat(((Map<String, Object>) actualSchemaArgument.get("completion")).get("required_context_arguments"), is(List.of("database")));
-    }
-    
-    private MCPDescriptorCatalog createCatalog(final List<MCPResourceDescriptor> resourceDescriptors, final List<MCPToolDescriptor> toolDescriptors) {
-        return createCatalog(resourceDescriptors, List.of(), List.of(), toolDescriptors, List.of(), List.of(), List.of(), List.of(), List.of());
-    }
-    
-    private MCPDescriptorCatalog createCatalog(final List<MCPResourceDescriptor> resourceDescriptors, final List<MCPResourceDescriptor> resourceTemplateDescriptors,
-                                               final List<ShardingSphereMCPResourceMetadata> resourceMetadata, final List<MCPToolDescriptor> toolDescriptors,
-                                               final List<MCPPromptDescriptor> promptDescriptors, final List<MCPPromptTemplateBinding> promptTemplateBindings,
-                                               final List<MCPCompletionTargetDescriptor> completionTargetDescriptors,
-                                               final List<MCPResourceNavigationDescriptor> resourceNavigationDescriptors, final List<MCPToolRuntimeDescriptor> toolRuntimeDescriptors) {
-        return new MCPDescriptorCatalog(new MCPProtocolDescriptorCatalog(resourceDescriptors, resourceTemplateDescriptors, toolDescriptors, promptDescriptors),
-                new MCPShardingSphereDescriptorCatalog(resourceMetadata, promptTemplateBindings, completionTargetDescriptors, resourceNavigationDescriptors, toolRuntimeDescriptors));
-    }
-    
-    private MCPResourceDescriptor createResourceDescriptor(final String uri, final MCPResourceAnnotations annotations) {
-        return createResourceDescriptor(uri, annotations, Map.of());
-    }
-    
-    private MCPResourceDescriptor createResourceDescriptor(final String uri, final MCPResourceAnnotations annotations, final Map<String, Object> meta) {
-        return new MCPResourceDescriptor(uri, "test-resource", "Test Resource", "Read a test resource.", "application/json", annotations, meta);
-    }
-    
-    private MCPToolDescriptor createToolDescriptor(final MCPToolAnnotations annotations) {
-        return new MCPToolDescriptor("database_gateway_test_tool", "Test Tool", "Run a test tool.", Map.of(), Map.of(), annotations, Map.of());
-    }
-    
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPGuidancePayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPGuidancePayloadBuilderTest.java
@@ -30,59 +30,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MCPGuidancePayloadBuilderTest {
     
-    private final MCPGuidancePayloadBuilder builder = new MCPGuidancePayloadBuilder(MCPDescriptorCatalogLoader.load());
-    
     @Test
     void assertBuild() {
-        Map<String, Object> actual = MCPGuidancePayloadBuilder.build(MCPDescriptorCatalogLoader.load());
+        Map<String, Object> actual = MCPGuidancePayloadBuilder.build();
         assertThat(actual.get("response_mode"), is("guidance"));
-        assertThat(actual.get("guidance_resource"), is("shardingsphere://guidance"));
-        assertTrue(actual.containsKey("model_first_summary"));
+        assertTrue(actual.containsKey("discovery"));
         assertTrue(actual.containsKey("model_contract"));
         assertTrue(actual.containsKey("security_hints"));
+        assertFalse(actual.containsKey("model_first_summary"));
+        assertFalse(actual.containsKey("surface_summary"));
+        assertFalse(actual.containsKey("field_naming_contract"));
     }
     
     @Test
-    void assertCreateModelFirstSummary() {
-        Map<String, Object> actual = builder.createModelFirstSummary();
+    void assertCreateDiscovery() {
+        Map<String, Object> actual = MCPGuidancePayloadBuilder.createDiscovery();
         assertThat(castToMap(actual.get("official_discovery_methods")), is(createOfficialDiscoveryMethods()));
         assertThat(actual.get("argument_completion_method"), is("completion/complete"));
         assertThat(actual.get("guidance_resource_role"),
                 is("shardingsphere://guidance complements MCP list methods with ShardingSphere domain guidance, workflow guidance, and side-effect notes."));
-        assertThat(actual.get("guidance_resource"), is("shardingsphere://guidance"));
-        assertFalse(actual.containsKey("safe_first_resource"));
-        Map<?, ?> actualMetadataRoute = findByKey(castToRouteList(actual.get("first_call_routes")), "intent", "inspect_metadata");
-        assertThat(actualMetadataRoute.get("first_action"), is("read_resource shardingsphere://databases"));
-        Map<?, ?> actualCompletionRoute = findByKey(castToRouteList(actual.get("first_call_routes")), "intent", "complete_uncertain_argument");
-        assertThat(actualCompletionRoute.get("first_action"), is("call completion/complete for one uncertain argument"));
-        Map<?, ?> actualRuleWorkflowRoute = findByKey(castToRouteList(actual.get("first_call_routes")), "intent", "rule_workflow");
-        assertThat(actualRuleWorkflowRoute.get("first_action"), is("call_tool matching database_gateway_plan_* workflow tool without plan_id for a new plan"));
-        Map<?, ?> actualRecoveryRoute = findByKey(castToRouteList(actual.get("first_call_routes")), "intent", "recover_error");
-        assertThat(actualRecoveryRoute.get("first_action"), is("follow top-level next_actions"));
-        assertThat(((Map<?, ?>) actual.get("preflight_rule")).get("tool"), is("database_gateway_validate_runtime_database"));
-        Map<?, ?> actualSideEffectingSelection = castToMap(castToMap(actual.get("sql_tool_selection")).get("side_effecting"));
-        assertThat(actualSideEffectingSelection.get("execute_requires"), is("execution_mode=execute"));
-        assertThat(actualSideEffectingSelection.get("rule_change_preference"),
-                is("For natural-language rule changes, use the matching database_gateway_plan_* workflow tool before raw SQL execution; "
-                        + "omit plan_id for a new plan."));
-        Map<?, ?> actualWorkflowRule = castToMap(actual.get("workflow_rule"));
-        assertThat(actualWorkflowRule.get("selection_rule"),
-                is("For natural-language rule changes, use the matching database_gateway_plan_* workflow tool before raw side-effect SQL; "
-                        + "omit plan_id for a new plan and reuse only returned plan_id values."));
-        assertThat(actualWorkflowRule.get("planning_tools"), is(List.of("database_gateway_plan_encrypt_rule")));
-        assertThat(castToMap(actualWorkflowRule.get("preview_tool")).get("execution_mode"), is("preview"));
-        assertThat(castToMap(actualWorkflowRule.get("execute_tool")).get("execute_requires"),
-                is("execution_mode=review-then-execute and explicit approved_steps copied from preview_artifacts.approval_step"));
-        assertThat(actualWorkflowRule.get("validate_tool"), is("database_gateway_validate_workflow"));
     }
     
     @Test
     void assertCreateModelContract() {
-        Map<String, Object> actual = builder.createModelContract();
-        assertThat(actual.get("public_surface_source"), is("MCP list methods expose the protocol surface: tools/list, resources/list, resources/templates/list, prompts/list."));
-        assertThat(castToMap(actual.get("official_discovery_methods")), is(createOfficialDiscoveryMethods()));
-        assertThat(actual.get("argument_completion_method"), is("completion/complete"));
-        assertThat(actual.get("guidance_resource"), is("shardingsphere://guidance"));
+        Map<String, Object> actual = MCPGuidancePayloadBuilder.createModelContract();
         assertThat(actual.get("metadata_first_resource"), is("shardingsphere://databases"));
         assertTrue(String.valueOf(actual.get("preflight_rule")).contains("database_gateway_validate_runtime_database"));
         Map<?, ?> actualSqlToolSelection = castToMap(actual.get("sql_tool_selection"));
@@ -93,11 +64,14 @@ class MCPGuidancePayloadBuilderTest {
         assertThat(actual.get("resource_template_rule"),
                 is("Use resources/templates/list to discover URI variables, then read the nearest concrete resource before filling dependent completion context."));
         assertThat(actual.get("detail_resource_rule"), is("Use resource descriptors, outputSchema, and returned payload keys before assuming detail fields."));
+        assertThat(actual.get("recovery_rule"), is("When a call fails, follow top-level next_actions before inventing a new call."));
+        assertThat(actual.get("payload_field_rule"), is("ShardingSphere-owned structured payload fields use snake_case."));
+        assertFalse(actual.containsKey("official_discovery_methods"));
     }
     
     @Test
     void assertCreateNextActionContract() {
-        List<Map<String, Object>> actual = builder.createNextActionContract();
+        List<Map<String, Object>> actual = MCPGuidancePayloadBuilder.createNextActionContract();
         assertThat(actual.size(), is(5));
         Map<?, ?> actualToolCall = findByType(actual, "tool_call");
         assertTrue(((Collection<?>) actualToolCall.get("required_fields")).contains("tool_name"));
@@ -110,34 +84,32 @@ class MCPGuidancePayloadBuilderTest {
     
     @Test
     void assertCreateCommonFlows() {
-        List<Map<String, Object>> actual = builder.createCommonFlows();
+        List<Map<String, Object>> actual = MCPGuidancePayloadBuilder.createCommonFlows();
         Map<?, ?> actualInspectMetadata = findByKey(actual, "flow_id", "inspect_metadata");
         assertTrue(((Collection<?>) actualInspectMetadata.get("steps")).contains("resources/list"));
         Map<?, ?> actualValidateRuntimeDatabase = findByKey(actual, "flow_id", "validate_runtime_database");
         assertTrue(((Collection<?>) actualValidateRuntimeDatabase.get("steps")).contains("call_tool database_gateway_validate_runtime_database"));
-        assertThat(actualValidateRuntimeDatabase.get("referenced_tools"), is(List.of("database_gateway_validate_runtime_database")));
         Map<?, ?> actualExplainQuery = findByKey(actual, "flow_id", "explain_query");
-        assertThat(actualExplainQuery.get("referenced_tools"), is(List.of("database_gateway_execute_explain_query")));
         assertTrue(((Collection<?>) actualExplainQuery.get("steps")).contains("call_tool database_gateway_execute_explain_query"));
         Map<?, ?> actualCompleteArgument = findByKey(actual, "flow_id", "complete_uncertain_argument");
         assertTrue(((Collection<?>) actualCompleteArgument.get("steps")).contains("call completion/complete for one argument"));
         Map<?, ?> actualSideEffectingSql = findByKey(actual, "flow_id", "side_effecting_sql");
-        assertThat(actualSideEffectingSql.get("referenced_tools"), is(List.of("database_gateway_execute_update")));
         assertTrue(((Collection<?>) actualSideEffectingSql.get("steps")).contains("call_tool database_gateway_execute_update execution_mode=preview"));
         Map<?, ?> actualWorkflow = findByKey(actual, "flow_id", "workflow_plan_apply_validate");
         assertTrue(((Collection<?>) actualWorkflow.get("steps")).contains(
                 "call_tool database_gateway_apply_workflow execution_mode=review-then-execute approved_steps=<preview_artifacts.approval_step>"));
+        Map<?, ?> actualRecovery = findByKey(actual, "flow_id", "recover_from_error");
+        assertThat(((Collection<?>) actualRecovery.get("steps")).iterator().next(), is("follow top-level next_actions"));
     }
     
     @Test
     void assertCreateSecurityHints() {
-        Map<String, Object> actual = builder.createSecurityHints();
+        Map<String, Object> actual = MCPGuidancePayloadBuilder.createSecurityHints();
         assertTrue(String.valueOf(actual.get("http_transport")).contains("unauthenticated by default"));
         assertTrue(String.valueOf(actual.get("origin_header")).contains("loopback origins"));
         Map<?, ?> actualClientSafetyPolicy = castToMap(actual.get("client_safety_policy"));
         assertThat(actualClientSafetyPolicy.get("identity_scope"), is("mcp_session"));
         assertTrue(String.valueOf(actualClientSafetyPolicy.get("transport_scope")).contains("trusted session attribution"));
-        assertThat(castToMap(actualClientSafetyPolicy.get("tool_call_limit")).get("scope"), is("session"));
         assertThat(castToMap(castToMap(actualClientSafetyPolicy.get("runtime_protection")).get("tool_call_limit")).get("scope"), is("session"));
         assertTrue(String.valueOf(actualClientSafetyPolicy.get("external_model_boundary")).contains("never calls external model providers"));
     }
@@ -152,11 +124,6 @@ class MCPGuidancePayloadBuilderTest {
     
     private Map<?, ?> castToMap(final Object value) {
         return (Map<?, ?>) value;
-    }
-    
-    @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> castToRouteList(final Object value) {
-        return (List<Map<String, Object>>) value;
     }
     
     private Map<String, Object> createOfficialDiscoveryMethods() {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContractTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContractTest.java
@@ -63,6 +63,6 @@ class MCPModelFacingPayloadContractTest {
         assertTrue(actual.contains(MCPPayloadFieldNames.SUMMARY));
         assertTrue(actual.contains(MCPPayloadFieldNames.NEXT_ACTIONS));
         assertTrue(actual.contains(MCPPayloadFieldNames.SELF_RESOURCE));
-        assertTrue(actual.contains("manual_follow_up"));
+        assertTrue(actual.contains("manual_artifact_summary"));
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/MCPNextActionUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/MCPNextActionUtilsTest.java
@@ -109,6 +109,7 @@ class MCPNextActionUtilsTest {
         assertThat(actual.get("title"), is("Ask user"));
         assertThat(actual.get("question"), is("Choose execution mode."));
         assertThat(actual.get("required_inputs"), is(List.of("execution_mode")));
+        assertFalse(actual.containsKey("reason"));
     }
     
     @Test

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/payload/MCPItemsPayloadTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/payload/MCPItemsPayloadTest.java
@@ -40,18 +40,19 @@ class MCPItemsPayloadTest {
     private static Stream<Arguments> assertToPayloadCases() {
         return Stream.of(
                 Arguments.of("without page token", new MCPItemsPayload(List.of("foo_item")),
-                        Map.of("response_mode", "list", "items", List.of("foo_item"), "count", 1, "has_more", false, "continuation_mode", "none")),
+                        Map.of("response_mode", "list", "items", List.of("foo_item"), "count", 1, "continuation_mode", "none")),
                 Arguments.of("with null page token", new MCPItemsPayload(List.of("foo_item"), (String) null),
-                        Map.of("response_mode", "list", "items", List.of("foo_item"), "count", 1, "has_more", false, "continuation_mode", "none")),
+                        Map.of("response_mode", "list", "items", List.of("foo_item"), "count", 1, "continuation_mode", "none")),
                 Arguments.of("with page token", new MCPItemsPayload(List.of("foo_item"), "foo_token"),
-                        Map.of("response_mode", "list", "items", List.of("foo_item"), "count", 1, "has_more", true, "next_page_token", "foo_token",
+                        Map.of("response_mode", "list", "items", List.of("foo_item"), "count", 1, "next_page_token", "foo_token",
                                 "continuation_mode", "pagination")),
                 Arguments.of("with null items", new MCPItemsPayload(null),
-                        Map.of("response_mode", "list", "items", List.of(), "count", 0, "has_more", false, "continuation_mode", "none")),
-                Arguments.of("with navigation", new MCPItemsPayload(List.of("foo_item"), Map.of("self_uri", "shardingsphere://foo", "next_resources",
+                        Map.of("response_mode", "list", "items", List.of(), "count", 0, "continuation_mode", "none")),
+                Arguments.of("with navigation", new MCPItemsPayload(List.of("foo_item"), Map.of("self_resource", Map.of("uri", "shardingsphere://foo"), "next_resources",
                         List.of(Map.of("uri", "shardingsphere://foo/bar", "resource_kind", "resource", "purpose", "inspect_detail", "reason", "Read child.",
                                 "source_field", "next_resources")))),
-                        Map.of("response_mode", "list", "items", List.of("foo_item"), "count", 1, "has_more", false, "continuation_mode", "none", "self_uri", "shardingsphere://foo",
+                        Map.of("response_mode", "list", "items", List.of("foo_item"), "count", 1, "continuation_mode", "none",
+                                "self_resource", Map.of("uri", "shardingsphere://foo"),
                                 "next_resources", List.of(Map.of("uri", "shardingsphere://foo/bar", "resource_kind", "resource", "purpose", "inspect_detail",
                                         "reason", "Read child.", "source_field", "next_resources")))));
     }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicyTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicyTest.java
@@ -53,11 +53,10 @@ class MCPClientSafetyPolicyTest {
         assertThat(actual.get("identity_scope"), is("mcp_session"));
         assertTrue(String.valueOf(actual.get("transport_scope")).contains("trusted session attribution"));
         assertTrue(String.valueOf(actual.get("external_model_boundary")).contains("never calls external model providers"));
-        Map<?, ?> actualToolCallLimit = (Map<?, ?>) actual.get("tool_call_limit");
+        Map<?, ?> actualRuntimeProtection = (Map<?, ?>) actual.get("runtime_protection");
+        Map<?, ?> actualToolCallLimit = (Map<?, ?>) actualRuntimeProtection.get("tool_call_limit");
         assertThat(actualToolCallLimit.get("scope"), is("session"));
         assertThat(actualToolCallLimit.get("property"), is(MCPClientSafetyPolicy.MAX_TOOL_CALLS_PER_SESSION_PROPERTY));
-        Map<?, ?> actualRuntimeProtection = (Map<?, ?>) actual.get("runtime_protection");
-        assertThat(((Map<?, ?>) actualRuntimeProtection.get("tool_call_limit")).get("scope"), is("session"));
         Map<?, ?> actualSQLExecutionLimits = (Map<?, ?>) actualRuntimeProtection.get("sql_execution_limits");
         assertThat(((Map<?, ?>) actualSQLExecutionLimits.get("max_rows")).get("applied_field"), is("applied_max_rows"));
         assertThat(((Map<?, ?>) actualSQLExecutionLimits.get("timeout_ms")).get("applied_field"), is("applied_timeout_ms"));

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/model/ValidationReportTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/model/ValidationReportTest.java
@@ -19,11 +19,11 @@ package org.apache.shardingsphere.mcp.support.workflow.model;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class ValidationReportTest {
     
@@ -33,10 +33,10 @@ class ValidationReportTest {
         validationReport.setRuleValidation(new ValidationSection("passed", Map.of(), "ok"));
         validationReport.setOverallStatus("passed");
         Map<String, Object> actual = validationReport.toMap();
-        assertFalse(actual.containsKey("ddl_validation"));
-        assertFalse(actual.containsKey("logical_metadata_validation"));
-        assertFalse(actual.containsKey("sql_executability_validation"));
-        assertThat(((Map<?, ?>) actual.get("rule_validation")).get("status"), is("passed"));
+        List<?> sections = (List<?>) actual.get("sections");
+        assertThat(sections.size(), is(1));
+        assertThat(((Map<?, ?>) sections.getFirst()).get("layer"), is("rule"));
+        assertThat(((Map<?, ?>) sections.getFirst()).get("status"), is("passed"));
         assertThat(actual.get("overall_status"), is("passed"));
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactMaskUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactMaskUtilsTest.java
@@ -48,6 +48,8 @@ class WorkflowArtifactMaskUtilsTest {
         assertTrue((Boolean) actualRedaction.get("applied"));
         assertThat(actualRedaction.get("redacted_count"), is(3));
         assertThat(actualRedaction.get("redacted_properties"), is(List.of("primary.aes-key-value", "assisted_query.salt", "like_query.token")));
+        assertThat(actualRedaction.get("categories"), is(List.of("aes-key-value", "salt", "token")));
+        assertFalse(actualRedaction.containsKey("secret_reference_summary"));
     }
     
     @Test

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilderTest.java
@@ -37,7 +37,7 @@ class WorkflowGuidancePayloadBuilderTest {
         WorkflowGuidancePayloadBuilder.appendApplyGuidance(payload, WorkflowLifecycle.STATUS_FAILED);
         Map<?, ?> actual = (Map<?, ?>) ((List<?>) payload.get("next_actions")).getFirst();
         assertThat(actual.get("type"), is("ask_user"));
-        assertThat(actual.get("required_inputs"), is(List.of("manual_artifacts")));
+        assertThat(actual.get("required_inputs"), is(List.of("manual_artifacts_executed")));
     }
     
     @Test

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationInstructionFactory.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationInstructionFactory.java
@@ -161,7 +161,7 @@ final class LLMMCPConversationInstructionFactory {
     private boolean shouldPromptExactResourceRead(final MCPInteractionTraceRecord traceRecord) {
         return MCPInteractionActionNames.LIST_RESOURCES.equals(traceRecord.getTargetName())
                 || MCPInteractionActionNames.READ_RESOURCE.equals(traceRecord.getTargetName())
-                        && (traceRecord.getStructuredContent().containsKey("error_code") || Boolean.FALSE.equals(traceRecord.getStructuredContent().get("found")));
+                        && (traceRecord.getStructuredContent().containsKey("error_code") || traceRecord.getStructuredContent().containsKey("empty_state"));
     }
     
     private boolean hasReadResource(final String resourceUri, final List<MCPInteractionTraceRecord> interactionTrace) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerNextActionTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerNextActionTest.java
@@ -201,7 +201,7 @@ class LLMMCPConversationRunnerNextActionTest extends AbstractLLMMCPConversationR
                 createToolCallCompletion("tool-2", MCPInteractionActionNames.READ_RESOURCE, readResourceArguments, "resource-response"),
                 createToolCallCompletion("tool-3", "database_gateway_execute_query", executeQueryArguments, "query-response"));
         when(getMCPInteractionClient().listResources()).thenReturn(Map.of("resources", List.of(Map.of("uri", RESOURCE_URI))));
-        when(getMCPInteractionClient().readResource(tableResourceUri)).thenReturn(Map.of("found", true));
+        when(getMCPInteractionClient().readResource(tableResourceUri)).thenReturn(Map.of("items", List.of(Map.of("table", "orders"))));
         when(getMCPInteractionClient().call("database_gateway_execute_query", executeQueryArguments)).thenReturn(createResultSetPayload(2));
         when(getLLMChatClient().complete(anyList(), eq(List.of()), eq("none"), eq(true))).thenReturn(
                 createFinalAnswerCompletion(toolNames, 2, "final-answer-response"));
@@ -230,11 +230,12 @@ class LLMMCPConversationRunnerNextActionTest extends AbstractLLMMCPConversationR
                 createToolCallCompletion("tool-2", MCPInteractionActionNames.READ_RESOURCE, liveReadArguments, "live-response"),
                 createToolCallCompletion("tool-3", "database_gateway_execute_query", executeQueryArguments, "query-response"));
         when(getMCPInteractionClient().readResource(staleResourceUri)).thenReturn(Map.of(
-                "found", false,
+                "items", List.of(),
+                "empty_state", Map.of("state", "not_found"),
                 "next_actions", List.of(Map.of(
                         "type", "resource_read",
                         "resource_uri", "shardingsphere://databases/unknown/schemas/unknown/tables"))));
-        when(getMCPInteractionClient().readResource(tableResourceUri)).thenReturn(Map.of("found", true));
+        when(getMCPInteractionClient().readResource(tableResourceUri)).thenReturn(Map.of("items", List.of(Map.of("table", "orders"))));
         when(getMCPInteractionClient().call("database_gateway_execute_query", executeQueryArguments)).thenReturn(createResultSetPayload(2));
         when(getLLMChatClient().complete(anyList(), eq(List.of()), eq("none"), eq(true))).thenReturn(
                 createFinalAnswerCompletion(toolNames, 2, "final-answer-response"));
@@ -387,8 +388,8 @@ class LLMMCPConversationRunnerNextActionTest extends AbstractLLMMCPConversationR
                 createToolCallCompletion("tool-1", "database_gateway_plan_mask_rule", planArguments, "plan-response"),
                 createToolCallCompletion("tool-2", MCPInteractionActionNames.COMPLETE, completionArguments, "completion-response"),
                 createToolCallCompletion("tool-3", "database_gateway_execute_query", executeQueryArguments, "query-response"));
-        when(getMCPInteractionClient().call("database_gateway_plan_mask_rule", planArguments)).thenReturn(Map.of("response_mode", "recovery", "recovery", Map.of(
-                "next_actions", List.of(Map.of("type", "completion", "ref", reference, "argument", argument)))));
+        when(getMCPInteractionClient().call("database_gateway_plan_mask_rule", planArguments)).thenReturn(Map.of("response_mode", "recovery",
+                "next_actions", List.of(Map.of("type", "completion", "ref", reference, "argument", argument))));
         when(getMCPInteractionClient().complete(reference, "plan_id", "", Map.of())).thenReturn(Map.of("completion", Map.of("values", List.of())));
         when(getMCPInteractionClient().call("database_gateway_execute_query", executeQueryArguments)).thenReturn(createResultSetPayload(2));
         when(getLLMChatClient().complete(anyList(), eq(List.of()), eq("none"), eq(true))).thenReturn(
@@ -416,10 +417,12 @@ class LLMMCPConversationRunnerNextActionTest extends AbstractLLMMCPConversationR
         when(getMCPInteractionClient().call("database_gateway_apply_workflow", manualArguments)).thenReturn(Map.of(
                 "response_mode", "manual_only",
                 "manual_artifact_summary", Map.of("distsql_artifact_count", 1),
-                "manual_artifacts", List.of(Map.of("distsql_artifacts", List.of(Map.of("sql", "CREATE MASK RULE orders SECRET")))),
+                "manual_artifact_package", Map.of("distsql_artifacts", List.of(Map.of("sql", "CREATE MASK RULE orders SECRET"))),
                 "next_actions", List.of(Map.of(
+                        "order", 1,
                         "type", "ask_user",
-                        "reason", "Confirm manual artifacts were executed."))));
+                        "title", "Ask user",
+                        "question", "Confirm manual artifacts were executed."))));
         when(getMCPInteractionClient().call("database_gateway_execute_query", executeQueryArguments)).thenReturn(createResultSetPayload(2));
         when(getLLMChatClient().complete(anyList(), eq(List.of()), eq("none"), eq(true))).thenReturn(
                 createFinalAnswerCompletion(toolNames, 2, "final-answer-response"));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerTest.java
@@ -194,7 +194,7 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         when(getMCPInteractionClient().listTools()).thenReturn(List.of(Map.of("name", "database_gateway_execute_query")));
         when(getMCPInteractionClient().listResources()).thenReturn(Map.of("resources", List.of(Map.of("uri", RESOURCE_URI))));
         when(getMCPInteractionClient().listResourceTemplates()).thenReturn(Map.of("resourceTemplates", List.of(Map.of("uriTemplate", "shardingsphere://databases/{database}"))));
-        when(getMCPInteractionClient().readResource(RESOURCE_URI)).thenReturn(Map.of("supportedTools", List.of("database_gateway_search_metadata", "database_gateway_execute_query")));
+        when(getMCPInteractionClient().readResource(RESOURCE_URI)).thenReturn(Map.of("supportedStatementClasses", List.of("QUERY")));
         when(getMCPInteractionClient().call("database_gateway_execute_query", executeQueryArguments)).thenReturn(createResultSetPayload("2"));
         when(getLLMChatClient().complete(anyList(), eq(List.of()), eq("none"), eq(true))).thenReturn(
                 createFinalAnswerCompletion(actualToolNames, "2", "final-answer-response"));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlannerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlannerTest.java
@@ -48,7 +48,7 @@ class LLMMCPConversationTurnPlannerTest {
         List<String> actual = planner.createTurnToolNames(createScenario(List.of("database_gateway_plan_mask_rule", "database_gateway_execute_query"),
                 List.of("database_gateway_plan_mask_rule", "database_gateway_execute_query")),
                 List.of(createTraceRecord("database_gateway_plan_mask_rule",
-                        Map.of("recovery", Map.of("next_actions", List.of(Map.of("type", "completion")))))));
+                        Map.of("next_actions", List.of(Map.of("type", "completion"))))));
         assertThat(actual, is(List.of(MCPInteractionActionNames.COMPLETE)));
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatter.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatter.java
@@ -34,16 +34,16 @@ import java.util.Objects;
 final class LLMMCPModelFacingToolResponseFormatter {
     
     private static final List<String> GENERAL_FIELD_NAMES = List.of(
-            "response_mode", "error_code", "message", "recovery_category", "result_kind", "status", "statement_type", "normalized_sql", "rows", "row_objects",
+            "response_mode", "error_code", "error_id", "summary", "message", "recovery_category", "result_kind", "status", "statement_type", "normalized_sql", "rows", "row_objects",
             "returned_row_count", "plan_id", "workflow_resource");
     
     private static final List<String> POST_ACTION_FIELD_NAMES = List.of(
-            "completion", "count", "has_more", "total_match_count", "returned_count", "truncated", "large_result_guidance", "search_context");
+            "completion", "count", "total_match_count", "truncated", "large_result_guidance", "search_context");
     
     static String format(final Map<String, Object> response) {
         Map<String, Object> result = new LinkedHashMap<>(16, 1F);
         copyFields(response, result, GENERAL_FIELD_NAMES);
-        copyCompactArtifactList(response, result, "manual_artifacts");
+        copyCompactArtifactPackage(response, result, "manual_artifact_package");
         copyCompactArtifactList(response, result, "exported_artifacts");
         copyModelCriticalFields(response, result);
         copyModelFacingNextActions(response, result);
@@ -150,6 +150,19 @@ final class LLMMCPModelFacingToolResponseFormatter {
         }
     }
     
+    private static void copyCompactArtifactPackage(final Map<String, Object> source, final Map<String, Object> target, final String fieldName) {
+        Object value = source.get(fieldName);
+        if (!(value instanceof Map)) {
+            return;
+        }
+        Map<String, Object> artifactPackage = LLMMCPJsonValues.castToMap(value);
+        Map<String, Object> summary = new LinkedHashMap<>(1, 1F);
+        putArtifactCount(artifactPackage, summary, "distsql_artifacts", "distsql_artifact_count");
+        if (!summary.isEmpty()) {
+            target.put(fieldName, summary);
+        }
+    }
+    
     private static void putArtifactCount(final Map<String, Object> source, final Map<String, Object> target, final String sourceFieldName, final String targetFieldName) {
         List<Object> artifacts = LLMMCPJsonValues.castToList(source.get(sourceFieldName));
         if (!artifacts.isEmpty()) {
@@ -173,7 +186,6 @@ final class LLMMCPModelFacingToolResponseFormatter {
         copyIfPresent(recovery, compactRecovery, "completion_first");
         copyIfPresent(recovery, compactRecovery, "suggested_arguments");
         copyModelCriticalFields(recovery, compactRecovery);
-        copyModelFacingNextActions(recovery, compactRecovery);
         target.put("recovery", compactRecovery);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatterTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatterTest.java
@@ -78,10 +78,10 @@ class LLMMCPModelFacingToolResponseFormatterTest {
     @Test
     void assertFormatWithArtifactSummaries() {
         Map<String, Object> actual = format(Map.of(
-                "manual_artifacts", List.of(Map.of("distsql_artifacts", List.of("d", "e", "f"))),
+                "manual_artifact_package", Map.of("distsql_artifacts", List.of("d", "e", "f")),
                 "exported_artifacts", List.of(Map.of("distsql_artifacts", List.of("g")))));
         assertThat(actual, is(Map.of(
-                "manual_artifacts", List.of(Map.of("distsql_artifact_count", 3)),
+                "manual_artifact_package", Map.of("distsql_artifact_count", 3),
                 "exported_artifacts", List.of(Map.of("distsql_artifact_count", 1)))));
     }
     
@@ -95,7 +95,6 @@ class LLMMCPModelFacingToolResponseFormatterTest {
                 Map.entry("parent_resource", Map.of("uri", "shardingsphere://databases")),
                 Map.entry("next_resources", List.of(Map.of("uri", "shardingsphere://databases/logic_db/schemas"))),
                 Map.entry("manual_artifact_summary", "Review DistSQL."),
-                Map.entry("manual_follow_up", "Validate runtime state."),
                 Map.entry("empty_state", Map.of("state", "no_match")),
                 Map.entry("recovery_guidance", "Read metadata before retrying."),
                 Map.entry("remediation", "Fix the mismatch."),
@@ -108,7 +107,6 @@ class LLMMCPModelFacingToolResponseFormatterTest {
                 Map.entry("parent_resource", Map.of("uri", "shardingsphere://databases")),
                 Map.entry("next_resources", List.of(Map.of("uri", "shardingsphere://databases/logic_db/schemas"))),
                 Map.entry("manual_artifact_summary", "Review DistSQL."),
-                Map.entry("manual_follow_up", "Validate runtime state."),
                 Map.entry("empty_state", Map.of("state", "no_match")),
                 Map.entry("recovery_guidance", "Read metadata before retrying."),
                 Map.entry("remediation", "Fix the mismatch."))));
@@ -125,9 +123,6 @@ class LLMMCPModelFacingToolResponseFormatterTest {
                         "recovery_category", "missing_context",
                         "model_action", "retry",
                         "suggested_arguments", Map.of("database", "logic_db"),
-                        "next_actions", List.of(
-                                Map.of("type", "tool_call", "tool_name", "database_gateway_execute_update", "arguments", Map.of("execution_mode", "execute")),
-                                Map.of("type", "resource_read", "resource_uri", "shardingsphere://databases")),
                         "resources_to_read", List.of(Map.of("uri", "shardingsphere://databases")),
                         "recovery_guidance", "Read metadata.",
                         "remediation", "Fix the request.",
@@ -141,8 +136,7 @@ class LLMMCPModelFacingToolResponseFormatterTest {
                         "suggested_arguments", Map.of("database", "logic_db"),
                         "resources_to_read", List.of(Map.of("uri", "shardingsphere://databases")),
                         "recovery_guidance", "Read metadata.",
-                        "remediation", "Fix the request.",
-                        "next_actions", List.of(Map.of("type", "resource_read", "resource_uri", "shardingsphere://databases"))))));
+                        "remediation", "Fix the request."))));
     }
     
     @Test

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPNextActions.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPNextActions.java
@@ -42,10 +42,6 @@ public final class LLMMCPNextActions {
     public static List<Map<?, ?>> getNextActions(final Map<String, Object> structuredContent) {
         List<Map<?, ?>> result = new LinkedList<>();
         appendActions(result, structuredContent.get("next_actions"));
-        Object recovery = structuredContent.get("recovery");
-        if (recovery instanceof Map) {
-            appendActions(result, ((Map<?, ?>) recovery).get("next_actions"));
-        }
         return result;
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPNextActionsTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPNextActionsTest.java
@@ -30,15 +30,12 @@ class LLMMCPNextActionsTest {
     @Test
     void assertGetNextActions() {
         Map<String, Object> topLevelAction = Map.of("type", "resource_read", "resource_uri", "shardingsphere://databases");
-        Map<String, Object> recoveryAction = Map.of("type", "tool_call", "tool_name", "database_gateway_search_metadata");
-        assertThat(LLMMCPNextActions.getNextActions(Map.of(
-                "next_actions", List.of(topLevelAction, "ignored"),
-                "recovery", Map.of("next_actions", List.of(recoveryAction)))), is(List.of(topLevelAction, recoveryAction)));
+        assertThat(LLMMCPNextActions.getNextActions(Map.of("next_actions", List.of(topLevelAction, "ignored"))), is(List.of(topLevelAction)));
     }
     
     @Test
     void assertGetNextActionsWithNoActions() {
-        assertThat(LLMMCPNextActions.getNextActions(Map.of("next_actions", "ignored", "recovery", Map.of("next_actions", "ignored"))), is(List.of()));
+        assertThat(LLMMCPNextActions.getNextActions(Map.of("next_actions", "ignored")), is(List.of()));
     }
     
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityMetricCalculatorTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityMetricCalculatorTest.java
@@ -61,11 +61,11 @@ class LLMUsabilityMetricCalculatorTest {
     }
     
     @Test
-    void assertEvaluateScenarioWithNestedRecoveryNextAction() {
+    void assertEvaluateScenarioWithRecoveryNextAction() {
         List<MCPInteractionTraceRecord> trace = List.of(
-                createToolCall(1, "database_gateway_execute_query", Map.of("recovery", Map.of("next_actions", List.of(Map.of(
+                createToolCall(1, "database_gateway_execute_query", Map.of("next_actions", List.of(Map.of(
                         "type", "resource_read",
-                        "resource_uri", "shardingsphere://databases"))))),
+                        "resource_uri", "shardingsphere://databases")))),
                 MCPInteractionTraceRecord.createResourceRead(2, "shardingsphere://databases", Map.of(), 0L));
         LLMUsabilityScenarioResult actual = new LLMUsabilityMetricCalculator().evaluateScenario(createScenario(), createArtifactBundle(trace));
         assertTrue(actual.isNextActionFollowed());
@@ -90,11 +90,11 @@ class LLMUsabilityMetricCalculatorTest {
     }
     
     @Test
-    void assertEvaluateScenarioWithNestedToolCallNextActionFollowed() {
+    void assertEvaluateScenarioWithRecoveryToolCallNextActionFollowed() {
         List<MCPInteractionTraceRecord> trace = List.of(
-                createToolCall(1, "database_gateway_apply_workflow", Map.of("recovery", Map.of("next_actions", List.of(Map.of(
+                createToolCall(1, "database_gateway_apply_workflow", Map.of("next_actions", List.of(Map.of(
                         "type", "tool_call",
-                        "tool_name", "database_gateway_apply_workflow"))))),
+                        "tool_name", "database_gateway_apply_workflow")))),
                 createToolCall(2, "database_gateway_apply_workflow", Map.of()));
         LLMUsabilityScenarioResult actual = new LLMUsabilityMetricCalculator().evaluateScenario(createScenario(), createArtifactBundle(trace));
         assertTrue(actual.isNextActionFollowed());
@@ -124,12 +124,12 @@ class LLMUsabilityMetricCalculatorTest {
     void assertEvaluateRecoveryScenarioWithCorrectedResource() {
         List<MCPInteractionTraceRecord> trace = List.of(
                 MCPInteractionTraceRecord.createResourceRead(1, "shardingsphere://databases/unknown/schemas/unknown/tables/orders",
-                        Map.of("found", false, "empty_state", Map.of("state", "not_found"), "next_actions", List.of(Map.of(
+                        Map.of("items", List.of(), "empty_state", Map.of("state", "not_found"), "next_actions", List.of(Map.of(
                                 "type", "resource_read",
                                 "resource_uri", "shardingsphere://databases/unknown/schemas/unknown/tables"))),
                         0L),
                 MCPInteractionTraceRecord.createResourceRead(2, "shardingsphere://databases/logic_db/schemas/public/tables/orders",
-                        Map.of("found", true), 0L));
+                        Map.of("items", List.of(Map.of("table", "orders"))), 0L));
         LLMUsabilityScenarioResult actual = new LLMUsabilityMetricCalculator().evaluateScenario(createRecoveryScenario(), createArtifactBundle(trace));
         assertTrue(actual.isSuccess());
         assertTrue(actual.isRecoveredAfterError());

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityTraceMetrics.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityTraceMetrics.java
@@ -183,8 +183,7 @@ final class LLMUsabilityTraceMetrics {
     }
     
     private boolean isRecoverableEmptyState(final MCPInteractionTraceRecord interactionTraceRecord) {
-        return Boolean.FALSE.equals(interactionTraceRecord.getStructuredContent().get("found"))
-                || interactionTraceRecord.getStructuredContent().containsKey("empty_state")
+        return interactionTraceRecord.getStructuredContent().containsKey("empty_state")
                 || interactionTraceRecord.getStructuredContent().containsKey("ambiguity_state");
     }
     
@@ -234,7 +233,8 @@ final class LLMUsabilityTraceMetrics {
     }
     
     private boolean isRecoverableResourceCorrection(final MCPInteractionTraceRecord current, final MCPInteractionTraceRecord next) {
-        return isRecoverableEmptyState(current) && Boolean.TRUE.equals(next.getStructuredContent().get("found"));
+        Object items = next.getStructuredContent().get("items");
+        return isRecoverableEmptyState(current) && items instanceof List && !((List<?>) items).isEmpty();
     }
     
     private boolean hasUnsafeApprovalError(final MCPInteractionTraceRecord interactionTraceRecord) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
@@ -210,12 +210,12 @@ abstract class AbstractProductionMySQLRuntimeE2ETest extends AbstractTransportPa
     
     protected void assertRecoveryResponse(final Map<String, Object> actual) {
         assertThat(String.valueOf(actual.get("response_mode")), is("recovery"));
-        assertFalse(String.valueOf(actual.get("message")).isBlank());
+        assertFalse(String.valueOf(actual.get("summary")).isBlank());
     }
     
     protected void assertRecoveryResponse(final Map<String, Object> actual, final String expectedMessage) {
         assertRecoveryResponse(actual);
-        assertThat(String.valueOf(actual.get("message")), is(expectedMessage));
+        assertThat(String.valueOf(actual.get("summary")), is(expectedMessage));
     }
     
     protected void assertRecoveryResponse(final Map<String, Object> actual, final String expectedMessage, final String expectedCategory) {
@@ -224,26 +224,22 @@ abstract class AbstractProductionMySQLRuntimeE2ETest extends AbstractTransportPa
     }
     
     protected void assertAiNativeGuidance(final Map<String, Object> guidance) {
-        assertTrue(guidance.containsKey("model_first_summary"));
+        assertTrue(guidance.containsKey("discovery"));
         assertTrue(guidance.containsKey("model_contract"));
-        assertTrue(guidance.containsKey("surface_summary"));
-        assertTrue(guidance.containsKey("field_naming_contract"));
         assertTrue(guidance.containsKey("next_action_contract"));
         assertTrue(guidance.containsKey("common_flows"));
         assertTrue(guidance.containsKey("security_hints"));
+        assertFalse(guidance.containsKey("model_first_summary"));
+        assertFalse(guidance.containsKey("surface_summary"));
         assertFalse(guidance.containsKey("fingerprints"));
         assertFalse(((List<?>) guidance.get("common_flows")).isEmpty());
-        Map<String, Object> modelFirstSummary = getObjectOrEmpty(guidance.get("model_first_summary"));
-        assertThat(getObjectOrEmpty(modelFirstSummary.get("official_discovery_methods")).get("tools"), is("tools/list"));
-        assertThat(modelFirstSummary.get("guidance_resource"), is("shardingsphere://guidance"));
-        assertThat(getObjectOrEmpty(modelFirstSummary.get("preflight_rule")).get("tool"), is("database_gateway_validate_runtime_database"));
-        assertThat(getObjectOrEmpty(getObjectOrEmpty(modelFirstSummary.get("sql_tool_selection")).get("read_only")).get("tool"), is("database_gateway_execute_query"));
-        assertThat(getObjectOrEmpty(getObjectOrEmpty(modelFirstSummary.get("workflow_rule")).get("preview_tool")).get("tool"), is("database_gateway_apply_workflow"));
-        Map<String, Object> surfaceSummary = getObjectOrEmpty(guidance.get("surface_summary"));
-        assertThat(getObjectOrEmpty(surfaceSummary.get("official_discovery_methods")).get("resources"), is("resources/list"));
-        assertThat(surfaceSummary.get("preflight_validation_tool"), is("database_gateway_validate_runtime_database"));
-        assertThat(surfaceSummary.get("read_only_sql_tool"), is("database_gateway_execute_query"));
-        assertThat(surfaceSummary.get("side_effect_sql_tool"), is("database_gateway_execute_update"));
+        Map<String, Object> discovery = getObjectOrEmpty(guidance.get("discovery"));
+        assertThat(getObjectOrEmpty(discovery.get("official_discovery_methods")).get("tools"), is("tools/list"));
+        assertThat(discovery.get("argument_completion_method"), is("completion/complete"));
+        Map<String, Object> modelContract = getObjectOrEmpty(guidance.get("model_contract"));
+        assertTrue(String.valueOf(modelContract.get("preflight_rule")).contains("database_gateway_validate_runtime_database"));
+        assertTrue(String.valueOf(getObjectOrEmpty(modelContract.get("sql_tool_selection")).get("read_only")).contains("database_gateway_execute_query"));
+        assertThat(modelContract.get("recovery_rule"), is("When a call fails, follow top-level next_actions before inventing a new call."));
     }
     
     protected void assertAiNativeDiscovery(final MCPInteractionClient interactionClient) throws IOException, InterruptedException {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionProxyWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionProxyWorkflowE2ETest.java
@@ -169,4 +169,8 @@ abstract class AbstractProductionProxyWorkflowE2ETest extends AbstractProduction
     protected final Map<String, Object> getObjectOrEmpty(final Object value) {
         return null == value ? Map.of() : MCPInteractionPayloads.getRequiredObjectValue(value, "payload");
     }
+    
+    protected final Map<String, Object> getValidationSection(final Map<String, Object> payload, final String layer) {
+        return getObjectListOrEmpty(payload.get("sections")).stream().filter(each -> layer.equals(each.get("layer"))).findFirst().orElse(Map.of());
+    }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
@@ -97,13 +97,12 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
             Map<String, Object> applyResponse = applyReviewedWorkflow(interactionClient, planId, TEMPLATE_SECRET_VALUE);
             assertApplyCompleted(applyResponse);
             assertThat(getObjectListOrEmpty(applyResponse.get("step_results")).size(), is(1));
-            assertThat(getStringListOrEmpty(applyResponse.get("executed_distsql")).size(), is(1));
             Map<String, Object> validationResponse = interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId));
             assertValidationPassed(validationResponse);
             assertSecretRedacted(validationResponse, TEMPLATE_SECRET_VALUE);
-            assertFalse(validationResponse.containsKey("logical_metadata_validation"));
-            assertFalse(validationResponse.containsKey("sql_executability_validation"));
-            Map<String, Object> ruleValidation = getObjectOrEmpty(validationResponse.get("rule_validation"));
+            assertTrue(getValidationSection(validationResponse, "logical_metadata").isEmpty());
+            assertTrue(getValidationSection(validationResponse, "sql_executability").isEmpty());
+            Map<String, Object> ruleValidation = getValidationSection(validationResponse, "rule");
             assertThat(String.valueOf(ruleValidation.get("status")), is("passed"));
             Map<String, Object> ruleEvidence = getObjectListOrEmpty(ruleValidation.get("evidence")).getFirst();
             assertThat(String.valueOf(ruleEvidence.get("logic_column")), is("status"));
@@ -144,10 +143,9 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
             Map<String, Object> actualApplyResponse = applyReviewedWorkflow(interactionClient, planId);
             assertApplyCompleted(actualApplyResponse);
             assertThat(getObjectListOrEmpty(actualApplyResponse.get("step_results")).size(), is(1));
-            assertThat(getStringListOrEmpty(actualApplyResponse.get("executed_distsql")).size(), is(1));
             Map<String, Object> actualValidationResponse = interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId));
             assertValidationPassed(actualValidationResponse);
-            assertFalse(actualValidationResponse.containsKey("sql_executability_validation"));
+            assertTrue(getValidationSection(actualValidationResponse, "sql_executability").isEmpty());
         }
     }
     
@@ -219,7 +217,6 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
             assertThat(String.valueOf(actualApplyResponse.get("status")), is("awaiting-manual-execution"));
             assertThat(getIssueCodes(actualApplyResponse), is(List.of(WorkflowIssueCode.MANUAL_EXECUTION_PENDING)));
             assertThat(getObjectListOrEmpty(actualApplyResponse.get("step_results")).size(), is(0));
-            assertThat(getStringListOrEmpty(actualApplyResponse.get("executed_distsql")).size(), is(0));
             Map<String, Object> actualManualArtifactPackage = getObjectOrEmpty(actualApplyResponse.get("manual_artifact_package"));
             assertThat(getObjectListOrEmpty(actualManualArtifactPackage.get("distsql_artifacts")).size(), is(1));
             assertThat(String.valueOf(getObjectListOrEmpty(actualManualArtifactPackage.get("distsql_artifacts")).getFirst().get("sql")),
@@ -242,7 +239,7 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
             assertThat(String.valueOf(actualPreviewArtifacts.getFirst().get("approval_step")), is("rule_distsql"));
             Map<String, Object> actualRuleApplyResponse = interactionClient.call(APPLY_TOOL_NAME, createReviewThenExecuteArguments(planId, List.of("rule_distsql")));
             assertThat(String.valueOf(actualRuleApplyResponse.get("status")), is("completed"));
-            assertThat(getStringListOrEmpty(actualRuleApplyResponse.get("executed_distsql")).size(), is(1));
+            assertThat(getObjectListOrEmpty(actualRuleApplyResponse.get("step_results")).size(), is(1));
             assertValidationPassed(interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId)));
         }
     }
@@ -275,10 +272,10 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
             String planId = String.valueOf(actualDropPlanResponse.get("plan_id"));
             Map<String, Object> actualApplyResponse = applyReviewedWorkflow(interactionClient, planId);
             assertApplyCompleted(actualApplyResponse);
-            assertThat(getStringListOrEmpty(actualApplyResponse.get("executed_distsql")).size(), is(1));
+            assertThat(getObjectListOrEmpty(actualApplyResponse.get("step_results")).size(), is(1));
             Map<String, Object> actualValidationResponse = interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId));
             assertValidationPassed(actualValidationResponse);
-            assertThat(String.valueOf(getObjectOrEmpty(actualValidationResponse.get("rule_validation")).get("status")), is("passed"));
+            assertThat(String.valueOf(getValidationSection(actualValidationResponse, "rule").get("status")), is("passed"));
         }
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
@@ -104,7 +104,7 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
             String planId = String.valueOf(actualPlanResponse.get("plan_id"));
             Map<String, Object> actualManualApplyResponse = interactionClient.call(APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "manual-only"));
             assertThat(String.valueOf(actualManualApplyResponse.get("status")), is("awaiting-manual-execution"));
-            assertThat(getStringListOrEmpty(actualManualApplyResponse.get("executed_distsql")).size(), is(0));
+            assertThat(getObjectListOrEmpty(actualManualApplyResponse.get("step_results")).size(), is(0));
             assertNoForbiddenArtifacts(actualManualApplyResponse);
             assertModelFacingPayloadContract(actualManualApplyResponse);
             Map<String, Object> actualValidationResponse = interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId));
@@ -125,7 +125,7 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
             Map<String, Object> actualApplyResponse = interactionClient.call(APPLY_TOOL_NAME,
                     createReviewThenExecuteArguments(planId, getApprovedSteps(previewWorkflow(interactionClient, planId))));
             assertApplyCompleted(actualApplyResponse);
-            assertThat(getStringListOrEmpty(actualApplyResponse.get("executed_distsql")).size(), is(1));
+            assertThat(getObjectListOrEmpty(actualApplyResponse.get("step_results")).size(), is(1));
             assertValidationPassed(interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId)));
             List<Map<String, Object>> actualRules = getPayloadItems(interactionClient.readResource(String.format(BROADCAST_RULES_RESOURCE_URI, getLogicalDatabaseName())));
             assertThat(actualRules.stream().map(each -> String.valueOf(each.get("broadcast_table"))).toList(), hasItem("orders"));
@@ -328,7 +328,7 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
         String planId = String.valueOf(actualPlanResponse.get("plan_id"));
         Map<String, Object> actualApplyResponse = applyReviewedWorkflow(interactionClient, planId);
         assertApplyCompleted(actualApplyResponse);
-        assertThat(getStringListOrEmpty(actualApplyResponse.get("executed_distsql")).size(), is(1));
+        assertThat(getObjectListOrEmpty(actualApplyResponse.get("step_results")).size(), is(1));
         assertValidationPassed(interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId)));
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
@@ -77,7 +77,7 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
             Map<String, Object> actualCreateValidationResponse = interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", createPlanId));
             assertValidationPassed(actualCreateValidationResponse);
             assertThat(
-                    String.valueOf(getObjectListOrEmpty(getObjectOrEmpty(actualCreateValidationResponse.get("rule_validation")).get("evidence")).getFirst().get("algorithm_type"))
+                    String.valueOf(getObjectListOrEmpty(getValidationSection(actualCreateValidationResponse, "rule").get("evidence")).getFirst().get("algorithm_type"))
                             .toUpperCase(Locale.ENGLISH),
                     is("KEEP_FIRST_N_LAST_M"));
             Map<String, Object> actualUnsupportedPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
@@ -103,7 +103,7 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
             assertApplyCompleted(applyReviewedWorkflow(interactionClient, planId));
             Map<String, Object> actualValidationResponse = interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId));
             assertValidationPassed(actualValidationResponse);
-            assertThat(String.valueOf(getObjectOrEmpty(actualValidationResponse.get("rule_validation")).get("details")), is("Mask table rule state matches the planned state."));
+            assertThat(String.valueOf(getValidationSection(actualValidationResponse, "rule").get("details")), is("Mask table rule state matches the planned state."));
         }
     }
     
@@ -141,7 +141,7 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
             Map<String, Object> actualValidationResponse = interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId));
             assertValidationPassed(actualValidationResponse);
             assertThat(
-                    String.valueOf(getObjectListOrEmpty(getObjectOrEmpty(actualValidationResponse.get("rule_validation")).get("evidence")).getFirst().get("algorithm_type"))
+                    String.valueOf(getObjectListOrEmpty(getValidationSection(actualValidationResponse, "rule").get("evidence")).getFirst().get("algorithm_type"))
                             .toUpperCase(Locale.ENGLISH),
                     is("MASK_FROM_X_TO_Y"));
         }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxySecretReferenceWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxySecretReferenceWorkflowE2ETest.java
@@ -62,8 +62,6 @@ class HttpProductionProxySecretReferenceWorkflowE2ETest extends AbstractProducti
             assertThat(String.valueOf(applyResponse.get("category")), is(MCPDiagnosticCategory.SECRET_REFERENCE_MANUAL_EXECUTION_REQUIRED));
             assertModelFacingPayloadContract(applyResponse);
             assertThat(getObjectListOrEmpty(applyResponse.get("step_results")).size(), is(0));
-            assertThat(getStringListOrEmpty(applyResponse.get("executed_distsql")).size(), is(0));
-            assertThat(getStringListOrEmpty(applyResponse.get("applied_artifacts")).size(), is(0));
             MCPWorkflowSecretReferenceFixture.assertSecretReferenceRedacted(applyResponse);
             assertTrue(getPayloadItems(interactionClient.readResource(String.format(RULES_RESOURCE_URI, getLogicalDatabaseName()))).isEmpty());
         }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/PackagedDistributionE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/PackagedDistributionE2ETest.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -76,14 +77,6 @@ class PackagedDistributionE2ETest {
             "database_gateway_apply_workflow", "database_gateway_validate_workflow");
     
     private static final List<String> REMOVED_FEATURE_TOOL_NAMES = OfficialMCPToolNames.getAll().stream().filter(each -> !CORE_TOOL_NAMES.contains(each)).toList();
-    
-    private static final List<String> REMOVED_FEATURE_RESOURCE_URIS = List.of(
-            "shardingsphere://features/encrypt/algorithms",
-            "shardingsphere://features/mask/algorithms",
-            "shardingsphere://features/broadcast/databases/{database}/rules",
-            "shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins",
-            "shardingsphere://features/shadow/algorithm-plugins",
-            "shardingsphere://features/sharding/algorithm-plugins");
     
     private static final String FIXTURE_RESOURCE_URI = "shardingsphere://features/test-fixture/status";
     
@@ -211,14 +204,12 @@ class PackagedDistributionE2ETest {
         assertOfficialFeatureJarsPackaged(distributionHome);
         assertRuntimeDiagnostics(interactionClient.readResource("shardingsphere://runtime"), transport);
         assertDatabaseNames(interactionClient.readResource("shardingsphere://databases"));
-        assertSupportedTools(interactionClient.readResource("shardingsphere://capabilities").get("supportedTools"));
         assertOfficialToolNames(interactionClient.listTools().stream().map(each -> String.valueOf(each.get("name"))).toList());
     }
     
     private void assertContainerRuntime(final RuntimeTransport transport, final MCPInteractionClient interactionClient) throws IOException, InterruptedException {
         assertRuntimeDiagnostics(interactionClient.readResource("shardingsphere://runtime"), transport);
         assertDatabaseNames(interactionClient.readResource("shardingsphere://databases"));
-        assertSupportedTools(interactionClient.readResource("shardingsphere://capabilities").get("supportedTools"));
         assertOfficialToolNames(interactionClient.listTools().stream().map(each -> String.valueOf(each.get("name"))).toList());
         assertMySQLMetadata(interactionClient);
         assertExecuteQuery(interactionClient);
@@ -237,8 +228,6 @@ class PackagedDistributionE2ETest {
     private void assertRuntimeDiagnostics(final Map<String, Object> runtimeStatus, final RuntimeTransport transport) {
         assertThat(runtimeStatus.get("status"), is("available"));
         assertThat(runtimeStatus.get("active_transport"), is(getTransportName(transport)));
-        Map<String, Object> actualRedactionSummary = MCPInteractionPayloads.getRequiredObject(runtimeStatus, "redaction_summary");
-        assertThat(actualRedactionSummary.get("marker"), is("******"));
         Map<String, Object> actualDiagnostics = MCPInteractionPayloads.getRequiredObject(runtimeStatus, "diagnostics");
         assertThat(actualDiagnostics.get("current_category"), is("ready"));
         assertTrue(((List<?>) actualDiagnostics.get("safe_categories")).contains("invalid_configuration"));
@@ -271,10 +260,6 @@ class PackagedDistributionE2ETest {
     private void assertDatabaseNames(final Map<String, Object> payload) {
         List<String> actualDatabaseNames = getPayloadItems(payload).stream().map(each -> String.valueOf(each.get("database"))).toList();
         assertThat(actualDatabaseNames, containsInAnyOrder(LOGICAL_DATABASE_NAME));
-    }
-    
-    private void assertSupportedTools(final Object supportedTools) {
-        assertOfficialToolNames(((List<?>) supportedTools).stream().map(String::valueOf).toList());
     }
     
     private void assertOfficialToolNames(final List<String> actualToolNames) {
@@ -320,17 +305,12 @@ class PackagedDistributionE2ETest {
     }
     
     private void assertCapabilities(final Map<String, Object> payload) {
-        List<String> actualSupportedTools = ((List<?>) payload.get("supportedTools")).stream().map(String::valueOf).toList();
-        assertThat(actualSupportedTools, hasItems("database_gateway_search_metadata", "database_gateway_validate_runtime_database", "database_gateway_execute_query",
-                "database_gateway_execute_update", "database_gateway_apply_workflow", "database_gateway_validate_workflow", "fixture_ping"));
-        for (String each : REMOVED_FEATURE_TOOL_NAMES) {
-            assertFalse(actualSupportedTools.contains(each));
-        }
-        List<String> actualSupportedResources = ((List<?>) payload.get("supportedResources")).stream().map(String::valueOf).toList();
-        assertTrue(actualSupportedResources.contains(FIXTURE_RESOURCE_URI));
-        for (String each : REMOVED_FEATURE_RESOURCE_URIS) {
-            assertFalse(actualSupportedResources.contains(each));
-        }
+        assertFalse(((Collection<?>) payload.get("supportedStatementClasses")).isEmpty());
+        assertFalse(((List<?>) payload.get("completionTargets")).isEmpty());
+        assertFalse(((List<?>) payload.get("resourceNavigation")).isEmpty());
+        assertFalse(payload.containsKey("supportedTools"));
+        assertFalse(payload.containsKey("supportedResources"));
+        assertFalse(payload.containsKey("protocolAvailability"));
     }
     
     private List<String> getItemNames(final Map<String, Object> payload) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLRuntimeE2ETest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -70,7 +71,11 @@ class ProductionMySQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2ETes
     void assertServiceCapabilitiesResourceWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
         useTransport(transport);
         try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            assertOfficialToolNames(((List<?>) interactionClient.readResource("shardingsphere://capabilities").get("supportedTools")).stream().map(String::valueOf).toList());
+            Map<String, Object> actual = interactionClient.readResource("shardingsphere://capabilities");
+            assertFalse(((Collection<?>) actual.get("supportedStatementClasses")).isEmpty());
+            assertFalse(((List<?>) actual.get("completionTargets")).isEmpty());
+            assertFalse(((List<?>) actual.get("resourceNavigation")).isEmpty());
+            assertFalse(actual.containsKey("supportedTools"));
         }
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLSQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLSQLRuntimeE2ETest.java
@@ -73,8 +73,8 @@ class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2E
             interactionClient.call("database_gateway_execute_update",
                     createExecuteUpdateArguments("UPDATE orders SET status = 'PENDING' WHERE order_id = 1"));
             Map<String, Object> rollbackResponse = interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("ROLLBACK"));
-            assertThat(String.valueOf(beginResponse.get("message")), is("Transaction started."));
-            assertThat(String.valueOf(rollbackResponse.get("message")), is("Transaction rolled back."));
+            assertThat(String.valueOf(beginResponse.get("summary")), is("Transaction started."));
+            assertThat(String.valueOf(rollbackResponse.get("summary")), is("Transaction rolled back."));
             assertThat(MySQLRuntimeTestSupport.querySingleString(getContainer(), String.format("SELECT status FROM %s.orders WHERE order_id = 1", getPhysicalSchemaName())), is("NEW"));
         }
     }
@@ -102,9 +102,9 @@ class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2E
                     createExecuteUpdateArguments("UPDATE orders SET status = 'DONE' WHERE order_id = 1"));
             Map<String, Object> rollbackResponse = interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("ROLLBACK TO SAVEPOINT sp_1"));
             Map<String, Object> commitResponse = interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("COMMIT"));
-            assertThat(String.valueOf(savepointResponse.get("message")), is("Savepoint created."));
-            assertThat(String.valueOf(rollbackResponse.get("message")), is("Savepoint rolled back."));
-            assertThat(String.valueOf(commitResponse.get("message")), is("Transaction committed."));
+            assertThat(String.valueOf(savepointResponse.get("summary")), is("Savepoint created."));
+            assertThat(String.valueOf(rollbackResponse.get("summary")), is("Savepoint rolled back."));
+            assertThat(String.valueOf(commitResponse.get("summary")), is("Transaction committed."));
             assertThat(MySQLRuntimeTestSupport.querySingleString(getContainer(), String.format("SELECT status FROM %s.orders WHERE order_id = 1", getPhysicalSchemaName())), is("PENDING"));
         }
     }
@@ -118,9 +118,9 @@ class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2E
             Map<String, Object> savepointResponse = interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("SAVEPOINT sp_release"));
             Map<String, Object> releaseResponse = interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("RELEASE SAVEPOINT sp_release"));
             Map<String, Object> commitResponse = interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("COMMIT"));
-            assertThat(String.valueOf(savepointResponse.get("message")), is("Savepoint created."));
-            assertThat(String.valueOf(releaseResponse.get("message")), is("Savepoint released."));
-            assertThat(String.valueOf(commitResponse.get("message")), is("Transaction committed."));
+            assertThat(String.valueOf(savepointResponse.get("summary")), is("Savepoint created."));
+            assertThat(String.valueOf(releaseResponse.get("summary")), is("Savepoint released."));
+            assertThat(String.valueOf(commitResponse.get("summary")), is("Transaction committed."));
         }
     }
     
@@ -133,7 +133,7 @@ class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2E
                     createExecuteUpdateArguments("CREATE TABLE orders_archive (order_id INT PRIMARY KEY)"));
             Map<String, Object> actualItem = MCPPayloadAssertions.getSingleItem(interactionClient.readResource(
                     "shardingsphere://databases/logic_db/schemas/logic_db/tables/orders_archive"));
-            assertThat(String.valueOf(executeResponse.get("message")), is("Statement executed."));
+            assertThat(String.valueOf(executeResponse.get("summary")), is("Statement executed."));
             assertThat(String.valueOf(actualItem.get("table")), is("orders_archive"));
         }
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionPostgreSQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionPostgreSQLRuntimeE2ETest.java
@@ -96,10 +96,10 @@ class ProductionPostgreSQLRuntimeE2ETest extends AbstractProductionPostgreSQLRun
     }
     
     private void assertTransactionRollback(final MCPInteractionClient interactionClient) throws IOException, InterruptedException {
-        assertThat(interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("public", "BEGIN")).get("message"), is("Transaction started."));
+        assertThat(interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("public", "BEGIN")).get("summary"), is("Transaction started."));
         interactionClient.call("database_gateway_execute_update",
                 createExecuteUpdateArguments("public", "UPDATE public.orders SET status = 'PENDING' WHERE order_id = 1"));
-        assertThat(interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("public", "ROLLBACK")).get("message"), is("Transaction rolled back."));
+        assertThat(interactionClient.call("database_gateway_execute_update", createExecuteUpdateArguments("public", "ROLLBACK")).get("summary"), is("Transaction rolled back."));
         Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
                 Map.of("database", LOGICAL_DATABASE_NAME, "schema", "public", "sql", "SELECT status FROM public.orders WHERE order_id = 1", "max_rows", 1));
         assertTrue(String.valueOf(actual.get("row_objects")).contains("NEW"));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryTransactionE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryTransactionE2ETest.java
@@ -57,10 +57,10 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
         HttpClient httpClient = HttpClient.newHttpClient();
         String firstSessionId = initializeSession(httpClient);
         String secondSessionId = initializeSession(httpClient);
-        assertTransactionMessage(httpClient, firstSessionId, "logic_db", "BEGIN", "Transaction started.");
-        assertTransactionMessage(httpClient, secondSessionId, "analytics_db", "BEGIN", "Transaction started.");
-        assertTransactionMessage(httpClient, firstSessionId, "logic_db", "ROLLBACK", "Transaction rolled back.");
-        assertTransactionMessage(httpClient, secondSessionId, "analytics_db", "ROLLBACK", "Transaction rolled back.");
+        assertTransactionSummary(httpClient, firstSessionId, "logic_db", "BEGIN", "Transaction started.");
+        assertTransactionSummary(httpClient, secondSessionId, "analytics_db", "BEGIN", "Transaction started.");
+        assertTransactionSummary(httpClient, firstSessionId, "logic_db", "ROLLBACK", "Transaction rolled back.");
+        assertTransactionSummary(httpClient, secondSessionId, "analytics_db", "ROLLBACK", "Transaction rolled back.");
     }
     
     @Test
@@ -68,7 +68,7 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
         launchHttpTransport();
         HttpClient httpClient = HttpClient.newHttpClient();
         String sessionId = initializeSession(httpClient);
-        assertTransactionMessage(httpClient, sessionId, "logic_db", "BEGIN", "Transaction started.");
+        assertTransactionSummary(httpClient, sessionId, "logic_db", "BEGIN", "Transaction started.");
         HttpResponse<String> update = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_update",
                 createExecuteSQLArguments("logic_db", "logic_db", "UPDATE orders SET status = 'PENDING' WHERE order_id = 1"));
         assertThat(update.statusCode(), is(200));
@@ -86,11 +86,11 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
         return Map.of("database", databaseName, "schema", schemaName, "sql", sql, "execution_mode", "execute");
     }
     
-    private void assertTransactionMessage(final HttpClient httpClient, final String sessionId, final String databaseName, final String sql,
-                                          final String expectedMessage) throws IOException, InterruptedException {
+    private void assertTransactionSummary(final HttpClient httpClient, final String sessionId, final String databaseName, final String sql,
+                                          final String expectedSummary) throws IOException, InterruptedException {
         HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_update", createExecuteSQLArguments(databaseName, databaseName, sql));
         assertThat(actual.statusCode(), is(200));
-        assertThat(String.valueOf(getToolCallPayload(actual.body()).get("message")), is(expectedMessage));
+        assertThat(String.valueOf(getToolCallPayload(actual.body()).get("summary")), is(expectedSummary));
     }
     
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryTransactionE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryTransactionE2ETest.java
@@ -48,7 +48,7 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
         assertThat(actual.statusCode(), is(200));
         Map<String, Object> payload = getToolCallPayload(actual.body());
         assertThat(String.valueOf(payload.get("response_mode")), is("recovery"));
-        assertThat(String.valueOf(payload.get("message")), is("Cross-database transaction switching is not supported."));
+        assertThat(String.valueOf(payload.get("summary")), is("Cross-database transaction switching is not supported."));
     }
     
     @Test

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/FeatureWorkflowContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/FeatureWorkflowContractE2ETest.java
@@ -114,12 +114,16 @@ class FeatureWorkflowContractE2ETest extends AbstractSharedHttpProgrammaticRunti
     }
     
     private void assertFeatureDiscovery(final HttpClient httpClient, final String sessionId, final FeatureWorkflowScenario scenario) throws IOException, InterruptedException {
-        HttpResponse<String> actual = sendResourceReadRequest(httpClient, sessionId, "shardingsphere://capabilities");
-        assertThat(actual.statusCode(), is(200));
-        Map<String, Object> payload = getFirstResourcePayload(actual.body());
-        assertTrue(((List<?>) payload.get("supportedTools")).stream().map(String::valueOf).toList().contains(scenario.toolName()));
-        assertTrue(String.valueOf(payload).contains(scenario.discoveryToken()));
-        assertModelFacingPayloadContract(payload);
+        HttpResponse<String> actualTools = sendRawPostRequest(httpClient, createSessionHeaders(sessionId), MCPInteractionProtocolSupport.createJsonRpcRequestBody(
+                scenario.toolName() + "-discovery-tools-1", "tools/list", Map.of()));
+        assertThat(actualTools.statusCode(), is(200));
+        Map<String, Object> toolsPayload = MCPInteractionPayloads.getRequiredJsonRpcResult(parseJsonBody(actualTools.body()));
+        assertTrue(MCPInteractionPayloads.getRequiredObjectList(toolsPayload, "tools").stream().anyMatch(each -> scenario.toolName().equals(each.get("name"))));
+        assertModelFacingPayloadContract(toolsPayload);
+        HttpResponse<String> actualResources = sendRawPostRequest(httpClient, createSessionHeaders(sessionId), MCPInteractionProtocolSupport.createJsonRpcRequestBody(
+                scenario.toolName() + "-discovery-resources-1", "resources/templates/list", Map.of()));
+        assertThat(actualResources.statusCode(), is(200));
+        assertTrue(actualResources.body().contains(scenario.discoveryToken()));
     }
     
     private void assertFeatureToolSchemaMatchesPlanArguments(final HttpClient httpClient, final String sessionId,
@@ -156,7 +160,7 @@ class FeatureWorkflowContractE2ETest extends AbstractSharedHttpProgrammaticRunti
         Map<String, Object> payload = MCPInteractionPayloads.getToolCallPayload(responsePayload);
         Map<String, Object> recovery = getRecoveryPayload(payload, "validation");
         assertThat(recovery.get("category"), is("unknown_argument"));
-        assertThat(recovery.get("argument_path"), is("client_hint"));
+        assertThat(recovery.get("field"), is("client_hint"));
         assertModelFacingPayloadContract(payload);
     }
     
@@ -175,7 +179,7 @@ class FeatureWorkflowContractE2ETest extends AbstractSharedHttpProgrammaticRunti
         assertThat(actual.statusCode(), is(200));
         Map<String, Object> result = getToolCallPayload(actual.body());
         assertThat(String.valueOf(result.get("response_mode")), is("recovery"));
-        assertFalse(String.valueOf(result.get("message")).isBlank());
+        assertFalse(String.valueOf(result.get("summary")).isBlank());
         assertNoForbiddenArtifacts(result);
         assertModelFacingPayloadContract(result);
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportBaselineContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportBaselineContractE2ETest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.runtime.programmatic;
 
-import org.apache.shardingsphere.mcp.support.descriptor.MCPShardingSphereMetadataKeys;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
 import org.apache.shardingsphere.mcp.api.MCPRequestContext;
 import org.apache.shardingsphere.mcp.core.resource.handler.capability.ServerCapabilitiesHandler;
@@ -31,7 +30,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
-import java.util.Comparator;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,108 +82,31 @@ class HttpTransportBaselineContractE2ETest extends AbstractSharedHttpProgrammati
     }
     
     private Map<String, Object> createCapabilitiesContract(final Map<String, Object> payload) {
-        Map<String, Object> result = new LinkedHashMap<>(8, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
         result.put("response_mode", payload.get("response_mode"));
-        result.put("guidanceResource", payload.get("guidanceResource"));
-        result.put("protocolAvailability", payload.get("protocolAvailability"));
-        result.put("resources", summarizeCapabilityResourceIdentities(MCPInteractionPayloads.getOptionalObjectList(payload, "resources")));
-        result.put("resourceTemplates", summarizeCapabilityResourceTemplateIdentities(MCPInteractionPayloads.getOptionalObjectList(payload, "resourceTemplates")));
-        result.put("tools", summarizeCapabilityTools(MCPInteractionPayloads.getOptionalObjectList(payload, "tools")));
-        result.put("prompts", summarizePrompts(MCPInteractionPayloads.getOptionalObjectList(payload, "prompts")));
-        result.put("completionTargets", payload.get("completionTargets"));
+        result.put("supportedStatementClasses", ((Collection<?>) payload.get("supportedStatementClasses")).stream().map(String::valueOf).sorted().toList());
+        result.put("completionTargets", summarizeCompletionTargets(MCPInteractionPayloads.getOptionalObjectList(payload, "completionTargets")));
+        result.put("resourceNavigation", summarizeResourceNavigation(MCPInteractionPayloads.getOptionalObjectList(payload, "resourceNavigation")));
         return result;
     }
     
     private Map<String, Object> createGuidanceContract(final Map<String, Object> payload) {
-        Map<String, Object> result = new LinkedHashMap<>(9, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(6, 1F);
         result.put("response_mode", payload.get("response_mode"));
-        result.put("guidance_resource", payload.get("guidance_resource"));
-        result.put("model_first_summary", payload.get("model_first_summary"));
+        result.put("discovery", payload.get("discovery"));
         result.put("model_contract", payload.get("model_contract"));
-        result.put("surface_summary", payload.get("surface_summary"));
-        result.put("field_naming_contract", payload.get("field_naming_contract"));
         result.put("next_action_contract", payload.get("next_action_contract"));
         result.put("common_flows", payload.get("common_flows"));
         result.put("security_hints", payload.get("security_hints"));
         return result;
     }
     
-    private List<Map<String, Object>> summarizeCapabilityResourceIdentities(final List<Map<String, Object>> resources) {
-        return resources.stream().map(this::summarizeCapabilityResourceIdentity).toList();
+    private List<String> summarizeCompletionTargets(final List<Map<String, Object>> targets) {
+        return targets.stream().map(each -> String.format("%s:%s:%s", each.get("referenceType"), each.get("reference"), each.get("arguments"))).sorted().toList();
     }
     
-    private Map<String, Object> summarizeCapabilityResourceIdentity(final Map<String, Object> resource) {
-        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
-        result.put("uri", resource.get("uri"));
-        result.put("name", resource.get("name"));
-        result.put("_meta", summarizeResourceMeta(resource));
-        return result;
-    }
-    
-    private List<Map<String, Object>> summarizeCapabilityResourceTemplateIdentities(final List<Map<String, Object>> resourceTemplates) {
-        return resourceTemplates.stream().map(this::summarizeCapabilityResourceTemplateIdentity).toList();
-    }
-    
-    private Map<String, Object> summarizeCapabilityResourceTemplateIdentity(final Map<String, Object> resourceTemplate) {
-        Map<String, Object> result = new LinkedHashMap<>(4, 1F);
-        result.put("uriTemplate", resourceTemplate.get("uriTemplate"));
-        result.put("name", resourceTemplate.get("name"));
-        result.put("_meta", summarizeResourceMeta(resourceTemplate));
-        return result;
-    }
-    
-    private Map<String, Object> summarizeResourceMeta(final Map<String, Object> resource) {
-        Map<String, Object> meta = MCPInteractionPayloads.getOptionalObject(resource, "_meta");
-        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        result.put(MCPShardingSphereMetadataKeys.RESOURCE_KIND, meta.get(MCPShardingSphereMetadataKeys.RESOURCE_KIND));
-        putIfNotEmpty(result, MCPShardingSphereMetadataKeys.RELATED_TOOLS, (List<?>) meta.get(MCPShardingSphereMetadataKeys.RELATED_TOOLS));
-        putIfNotEmpty(result, MCPShardingSphereMetadataKeys.URI_VARIABLES,
-                summarizeParameters(MCPInteractionPayloads.getOptionalObjectList(meta, MCPShardingSphereMetadataKeys.URI_VARIABLES)));
-        return removeNullValues(result);
-    }
-    
-    private void putIfNotEmpty(final Map<String, Object> target, final String key, final List<?> value) {
-        if (null != value && !value.isEmpty()) {
-            target.put(key, value);
-        }
-    }
-    
-    private List<Map<String, Object>> summarizeCapabilityTools(final List<Map<String, Object>> tools) {
-        return tools.stream().map(this::summarizeCapabilityTool).toList();
-    }
-    
-    private Map<String, Object> summarizeCapabilityTool(final Map<String, Object> tool) {
-        Map<String, Object> result = new LinkedHashMap<>(2, 1F);
-        result.put("name", tool.get("name"));
-        result.put("annotations", tool.getOrDefault("annotations", Map.of()));
-        return result;
-    }
-    
-    private List<Map<String, Object>> summarizePrompts(final List<Map<String, Object>> prompts) {
-        return prompts.stream().sorted(Comparator.comparing(each -> String.valueOf(each.get("name")))).map(this::summarizePrompt).toList();
-    }
-    
-    private Map<String, Object> summarizePrompt(final Map<String, Object> prompt) {
-        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        result.put("name", prompt.get("name"));
-        result.put("title", prompt.get("title"));
-        result.put("arguments", summarizeParameters(MCPInteractionPayloads.getOptionalObjectList(prompt, "arguments")));
-        return result;
-    }
-    
-    private Map<String, Object> removeNullValues(final Map<String, Object> value) {
-        return value.entrySet().stream().filter(entry -> null != entry.getValue()).collect(LinkedHashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), Map::putAll);
-    }
-    
-    private List<Map<String, Object>> summarizeParameters(final List<Map<String, Object>> params) {
-        return params.stream().map(this::summarizeParameter).toList();
-    }
-    
-    private Map<String, Object> summarizeParameter(final Map<String, Object> parameter) {
-        Map<String, Object> result = new LinkedHashMap<>(2, 1F);
-        result.put("name", parameter.get("name"));
-        result.put("required", parameter.get("required"));
-        return result;
+    private List<String> summarizeResourceNavigation(final List<Map<String, Object>> navigation) {
+        return navigation.stream().map(each -> String.format("%s->%s", each.get("from"), each.get("to"))).sorted().toList();
     }
     
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
@@ -82,7 +82,6 @@ class HttpTransportContractE2ETest extends AbstractSharedHttpProgrammaticRuntime
         assertTrue(((List<?>) actualDiagnostics.get("safe_categories")).contains("invalid_configuration"));
         assertTrue(MCPInteractionPayloads.getRequiredObjectList(actualDiagnostics, "operator_next_actions").stream()
                 .anyMatch(each -> "invalid_configuration".equals(each.get("category"))));
-        assertThat(MCPInteractionPayloads.getRequiredObject(actualRuntimeStatus, "redaction_summary").get("marker"), is("******"));
         assertRuntimeStatusSecretSafe(actualRuntimeStatus);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportProtocolContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportProtocolContractE2ETest.java
@@ -125,7 +125,7 @@ class HttpTransportProtocolContractE2ETest extends AbstractHttpProtocolOnlyE2ETe
         String sessionId = initializeSession(httpClient);
         HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_update", createInvalidUpdateArguments());
         Map<String, Object> actualRecovery = assertToolErrorRecovery(actual, "invalid_integer_argument");
-        assertThat(actualRecovery.get("argument_path"), is("max_rows"));
+        assertThat(actualRecovery.get("field"), is("max_rows"));
         assertThat(actualRecovery.get("minimum_value"), is(0));
         assertThat(actualRecovery.get("maximum_value"), is(5000));
         assertThat(actualRecovery.get("suggested_value"), is(100));
@@ -139,7 +139,7 @@ class HttpTransportProtocolContractE2ETest extends AbstractHttpProtocolOnlyE2ETe
         HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_plan_readwrite_splitting_rule",
                 Map.of("load_balancer_properties", Map.of("weight", 1)));
         Map<String, Object> actualRecovery = assertToolErrorRecovery(actual, "invalid_argument_type");
-        assertThat(actualRecovery.get("argument_path"), is("load_balancer_properties.weight"));
+        assertThat(actualRecovery.get("field"), is("load_balancer_properties.weight"));
         assertThat(actualRecovery.get("expected_type"), is("string"));
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportRecoveryE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportRecoveryE2ETest.java
@@ -54,8 +54,8 @@ class HttpTransportRecoveryE2ETest extends AbstractSharedHttpProgrammaticRuntime
         HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_query", Map.of("schema", "logic_db", "sql", "SELECT * FROM orders"));
         assertThat(actual.statusCode(), is(200));
         Map<String, Object> payload = getToolCallPayload(actual.body());
-        Map<String, Object> recovery = getRecoveryPayload(payload, "missing_context");
-        Map<String, Object> nextAction = getFirstNextAction(recovery);
+        getRecoveryPayload(payload, "missing_context");
+        Map<String, Object> nextAction = getFirstNextAction(payload);
         assertThat(String.valueOf(nextAction.get("type")), is("resource_read"));
         assertThat(String.valueOf(nextAction.get("resource_uri")), is("shardingsphere://databases"));
         HttpResponse<String> followUp = sendResourceReadRequest(httpClient, sessionId, String.valueOf(nextAction.get("resource_uri")));
@@ -76,8 +76,8 @@ class HttpTransportRecoveryE2ETest extends AbstractSharedHttpProgrammaticRuntime
                 Map.of("database", "logic_db", "schema", "logic_db", "sql", "UPDATE orders SET status = status WHERE order_id = -1"));
         assertThat(actual.statusCode(), is(200));
         Map<String, Object> payload = getToolCallPayload(actual.body());
-        Map<String, Object> recovery = getRecoveryPayload(payload, "unsafe_sql");
-        Map<String, Object> nextAction = getFirstNextAction(recovery);
+        getRecoveryPayload(payload, "unsafe_sql");
+        Map<String, Object> nextAction = getFirstNextAction(payload);
         assertThat(String.valueOf(nextAction.get("tool_name")), is("database_gateway_execute_update"));
         Map<String, Object> retryArguments = MCPInteractionPayloads.getRequiredObject(nextAction, "arguments");
         assertThat(String.valueOf(retryArguments.get("execution_mode")), is("preview"));
@@ -98,7 +98,7 @@ class HttpTransportRecoveryE2ETest extends AbstractSharedHttpProgrammaticRuntime
         Map<String, Object> payload = getToolCallPayload(actual.body());
         Map<String, Object> recovery = getRecoveryPayload(payload, "stale_workflow");
         assertThat(String.valueOf(recovery.get("plan_id")), is("plan-missing"));
-        Map<String, Object> nextAction = getFirstNextAction(recovery);
+        Map<String, Object> nextAction = getFirstNextAction(payload);
         assertThat(String.valueOf(nextAction.get("type")), is("completion"));
         Map<String, Object> argument = MCPInteractionPayloads.getRequiredObject(nextAction, "argument");
         assertThat(argument.get("name"), is("plan_id"));
@@ -164,8 +164,8 @@ class HttpTransportRecoveryE2ETest extends AbstractSharedHttpProgrammaticRuntime
         assertFalse(payload.contains(MCPWorkflowSecretReferenceFixture.INPUT_LABEL), payload);
     }
     
-    private Map<String, Object> getFirstNextAction(final Map<String, Object> recovery) {
-        return MCPInteractionPayloads.getRequiredObjectList(recovery, "next_actions").getFirst();
+    private Map<String, Object> getFirstNextAction(final Map<String, Object> payload) {
+        return MCPInteractionPayloads.getRequiredObjectList(payload, "next_actions").getFirst();
     }
     
     private void assertDatabaseListContains(final Map<String, Object> payload, final String expectedDatabase) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/MetadataDiscoveryE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/MetadataDiscoveryE2ETest.java
@@ -30,7 +30,6 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @EnabledIf("isEnabled")
 class MetadataDiscoveryE2ETest extends AbstractSharedHttpProgrammaticRuntimeE2ETest {
@@ -83,7 +82,7 @@ class MetadataDiscoveryE2ETest extends AbstractSharedHttpProgrammaticRuntimeE2ET
         assertThat(actual.statusCode(), is(200));
         Map<String, Object> actualPayload = getToolCallPayload(actual.body());
         assertThat(String.valueOf(actualPayload.get("response_mode")), is("recovery"));
-        assertThat(String.valueOf(actualPayload.get("message")), is("Schema cannot be provided without database."));
+        assertThat(String.valueOf(actualPayload.get("summary")), is("Schema cannot be provided without database."));
     }
     
     @Test
@@ -107,13 +106,13 @@ class MetadataDiscoveryE2ETest extends AbstractSharedHttpProgrammaticRuntimeE2ET
         String sessionId = initializeSession(httpClient);
         HttpResponse<String> databaseResource = sendResourceReadRequest(httpClient, sessionId, "shardingsphere://databases/logic%5Fdb");
         assertThat(databaseResource.statusCode(), is(200));
-        assertThat(String.valueOf(MCPInteractionPayloads.getRequiredObject(getFirstResourcePayload(databaseResource.body()), "item").get("database")), is("logic_db"));
+        assertThat(String.valueOf(MCPInteractionPayloads.getRequiredObjectList(getFirstResourcePayload(databaseResource.body()), "items").getFirst().get("database")), is("logic_db"));
         HttpResponse<String> tableResource = sendResourceReadRequest(httpClient, sessionId,
                 "shardingsphere://databases/logic_db/schemas/logic_db/tables/orders%20archive%2F2026");
         assertThat(tableResource.statusCode(), is(200));
         Map<String, Object> tablePayload = getFirstResourcePayload(tableResource.body());
-        assertFalse((Boolean) tablePayload.get("found"));
-        assertThat(String.valueOf(tablePayload.get("self_uri")),
+        assertThat(MCPInteractionPayloads.getRequiredObjectList(tablePayload, "items"), is(List.of()));
+        assertThat(String.valueOf(MCPInteractionPayloads.getRequiredObject(tablePayload, "self_resource").get("uri")),
                 is("shardingsphere://databases/logic_db/schemas/logic_db/tables/orders%20archive%2F2026"));
         assertThat(String.valueOf(MCPInteractionPayloads.getRequiredObject(tablePayload, "recovery").get("requested_token")), is("orders archive/2026"));
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/MCPInteractionPayloadsTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/MCPInteractionPayloadsTest.java
@@ -124,8 +124,8 @@ class MCPInteractionPayloadsTest {
     
     @Test
     void assertGetFirstResourcePayload() {
-        Map<String, Object> payload = Map.of("result", Map.of("contents", List.of(Map.of("text", "{\"item\":{\"database\":\"logic_db\"}}"))));
-        assertThat(MCPInteractionPayloads.getRequiredObject(MCPInteractionPayloads.getFirstResourcePayload(payload), "item").get("database"), is("logic_db"));
+        Map<String, Object> payload = Map.of("result", Map.of("contents", List.of(Map.of("text", "{\"items\":[{\"database\":\"logic_db\"}]}"))));
+        assertThat(MCPInteractionPayloads.getRequiredObjectList(MCPInteractionPayloads.getFirstResourcePayload(payload), "items").getFirst().get("database"), is("logic_db"));
     }
     
     @Test
@@ -151,13 +151,15 @@ class MCPInteractionPayloadsTest {
         Map<String, Object> actual = MCPInteractionPayloads.getJsonRpcErrorPayload(Map.of("error", Map.of(
                 "message", "Tool not found",
                 "data", Map.of(
-                        "message", "Nested recovery message",
+                        "summary", "Nested recovery message",
                         "response_mode", "recovery",
-                        "recovery", Map.of("next_actions", List.of(Map.of("type", "tool_call", "tool_name", "database_gateway_search_metadata")))))));
+                        "next_actions", List.of(Map.of("type", "tool_call", "tool_name", "database_gateway_search_metadata")),
+                        "recovery", Map.of("recovery_category", "unsupported_target")))));
         assertThat(actual.get("error_code"), is("json_rpc_error"));
         assertThat(actual.get("message"), is("Tool not found"));
         assertThat(actual.get("response_mode"), is("recovery"));
-        assertThat(actual.get("recovery"), is(Map.of("next_actions", List.of(Map.of("type", "tool_call", "tool_name", "database_gateway_search_metadata")))));
+        assertThat(actual.get("next_actions"), is(List.of(Map.of("type", "tool_call", "tool_name", "database_gateway_search_metadata"))));
+        assertThat(actual.get("recovery"), is(Map.of("recovery_category", "unsupported_target")));
     }
     
     @Test

--- a/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/capabilities.yaml
+++ b/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/capabilities.yaml
@@ -16,936 +16,107 @@
 #
 
 response_mode: catalog
-guidanceResource: shardingsphere://guidance
-protocolAvailability: {resources: true, resourceTemplates: true, tools: true, toolAnnotations: true,
-  toolOutputSchemas: true, prompts: true, completions: true, resourceNavigation: true}
-resources:
-- uri: shardingsphere://capabilities
-  name: server-capability-catalog
-  _meta: {org.apache.shardingsphere/resource-kind: capability-catalog}
-- uri: shardingsphere://guidance
-  name: server-guidance
-  _meta: {org.apache.shardingsphere/resource-kind: guidance}
-- uri: shardingsphere://runtime
-  name: runtime-status
-  _meta: {org.apache.shardingsphere/resource-kind: detail}
-- uri: shardingsphere://databases
-  name: logical-databases
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_search_metadata, database_gateway_execute_query,
-      database_gateway_execute_explain_query]
-- uri: shardingsphere://features/encrypt/algorithms
-  name: encrypt-algorithms
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_encrypt_rule]
-- uri: shardingsphere://features/mask/algorithms
-  name: mask-algorithms
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_mask_rule]
-- uri: shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins
-  name: readwrite-splitting-load-balance-algorithm-plugins
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_readwrite_splitting_rule]
-- uri: shardingsphere://features/shadow/algorithm-plugins
-  name: shadow-algorithm-plugins
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_shadow_rule, database_gateway_plan_default_shadow_algorithm]
-- uri: shardingsphere://features/sharding/algorithm-plugins
-  name: sharding-algorithm-plugins
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_table_rule,
-      database_gateway_plan_sharding_default_strategy]
-- uri: shardingsphere://features/sharding/key-generate-algorithm-plugins
-  name: sharding-key-generate-algorithm-plugins
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_key_generator,
-      database_gateway_plan_sharding_key_generate_strategy]
-resourceTemplates:
-- uriTemplate: shardingsphere://features/broadcast/databases/{database}/rules
-  name: broadcast-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_broadcast_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/broadcast/databases/{database}/tables/{table}/rule
-  name: broadcast-table-rule
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_broadcast_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://features/broadcast/databases/{database}/rule-count
-  name: broadcast-rule-count
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_broadcast_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://databases/{database}
-  name: logical-database-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://databases/{database}/capabilities
-  name: database-capabilities
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/related-tools: [database_gateway_execute_query, database_gateway_execute_explain_query,
-      database_gateway_execute_update]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://databases/{database}/storage-units
-  name: storage-units
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_search_metadata]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://databases/{database}/storage-units/{storageUnit}
-  name: storage-unit-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/related-tools: [database_gateway_search_metadata]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: storageUnit, required: true}
-- uriTemplate: shardingsphere://databases/{database}/storage-units/{storageUnit}/used-by-rules
-  name: storage-unit-used-by-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: storageUnit, required: true}
-- uriTemplate: shardingsphere://databases/{database}/single-tables
-  name: single-tables
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://databases/{database}/single-tables/{table}
-  name: single-table-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://databases/{database}/single-table/default-storage-unit
-  name: default-single-table-storage-unit
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas
-  name: schemas
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}
-  name: schema-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/sequences
-  name: sequences
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/sequences/{sequence}
-  name: sequence-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-    - {name: sequence, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/tables
-  name: tables
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_encrypt_rule,
-      database_gateway_plan_mask_rule]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}
-  name: table-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_encrypt_rule,
-      database_gateway_plan_mask_rule]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns
-  name: table-columns
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_encrypt_rule,
-      database_gateway_plan_mask_rule]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns/{column}
-  name: table-column-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_encrypt_rule,
-      database_gateway_plan_mask_rule]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-    - {name: table, required: true}
-    - {name: column, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes
-  name: table-indexes
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_encrypt_rule]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes/{index}
-  name: table-index-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-    - {name: table, required: true}
-    - {name: index, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/views
-  name: views
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/views/{view}
-  name: view-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-    - {name: view, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/views/{view}/columns
-  name: view-columns
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-    - {name: view, required: true}
-- uriTemplate: shardingsphere://databases/{database}/schemas/{schema}/views/{view}/columns/{column}
-  name: view-column-detail
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: schema, required: true}
-    - {name: view, required: true}
-    - {name: column, required: true}
-- uriTemplate: shardingsphere://features/encrypt/databases/{database}/rules
-  name: encrypt-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_encrypt_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/encrypt/databases/{database}/tables/{table}/rules
-  name: encrypt-table-rule
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_encrypt_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://features/mask/databases/{database}/rules
-  name: mask-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_mask_rule, database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/mask/databases/{database}/tables/{table}/rules
-  name: mask-table-rule
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_mask_rule, database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://features/readwrite-splitting/databases/{database}/rules
-  name: readwrite-splitting-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_readwrite_splitting_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/readwrite-splitting/databases/{database}/rules/{rule}
-  name: readwrite-splitting-rule
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_readwrite_splitting_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: rule, required: true}
-- uriTemplate: shardingsphere://features/readwrite-splitting/databases/{database}/status
-  name: readwrite-splitting-status
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_readwrite_splitting_status,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/readwrite-splitting/databases/{database}/rules/{rule}/status
-  name: readwrite-splitting-rule-status
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_readwrite_splitting_status,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: rule, required: true}
-- uriTemplate: shardingsphere://features/readwrite-splitting/databases/{database}/rule-count
-  name: readwrite-splitting-rule-count
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_readwrite_splitting_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/shadow/databases/{database}/rules
-  name: shadow-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_shadow_rule, database_gateway_plan_shadow_algorithm_cleanup,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/shadow/databases/{database}/rules/{rule}
-  name: shadow-rule
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_shadow_rule, database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: rule, required: true}
-- uriTemplate: shardingsphere://features/shadow/databases/{database}/table-rules
-  name: shadow-table-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_shadow_rule, database_gateway_plan_shadow_algorithm_cleanup,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/shadow/databases/{database}/tables/{table}/rules
-  name: shadow-table-rule
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_shadow_rule, database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://features/shadow/databases/{database}/algorithms
-  name: shadow-algorithms
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_default_shadow_algorithm,
-      database_gateway_plan_shadow_algorithm_cleanup, database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/shadow/databases/{database}/default-algorithm
-  name: default-shadow-algorithm
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_default_shadow_algorithm,
-      database_gateway_plan_shadow_algorithm_cleanup, database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/shadow/databases/{database}/rule-count
-  name: shadow-rule-count
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_shadow_rule, database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/algorithms
-  name: sharding-algorithms
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_table_rule,
-      database_gateway_plan_sharding_default_strategy, database_gateway_plan_sharding_rule_component_cleanup,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/table-rules
-  name: sharding-table-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_table_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/tables/{table}/table-rule
-  name: sharding-table-rule
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_table_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/table-nodes
-  name: sharding-table-nodes
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_table_rule]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/tables/{table}/nodes
-  name: sharding-table-node
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_table_rule]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: table, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/table-reference-rules
-  name: sharding-table-reference-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_table_reference_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/table-reference-rules/{rule}
-  name: sharding-table-reference-rule
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_table_reference_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: rule, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/default-strategy
-  name: sharding-default-strategy
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_default_strategy,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/key-generators
-  name: sharding-key-generators
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_key_generator,
-      database_gateway_plan_sharding_key_generate_strategy, database_gateway_plan_sharding_rule_component_cleanup]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/key-generators/{keyGenerator}
-  name: sharding-key-generator
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_key_generator,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: keyGenerator, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/key-generate-strategies
-  name: sharding-key-generate-strategies
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_key_generate_strategy,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/key-generate-strategies/{strategy}
-  name: sharding-key-generate-strategy
-  _meta:
-    org.apache.shardingsphere/resource-kind: rule
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_key_generate_strategy,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: strategy, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/auditors
-  name: sharding-auditors
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_rule_component_cleanup]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/unused-algorithms
-  name: unused-sharding-algorithms
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_rule_component_cleanup]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/unused-key-generators
-  name: unused-sharding-key-generators
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_rule_component_cleanup]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/unused-auditors
-  name: unused-sharding-auditors
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_rule_component_cleanup]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/algorithms/{algorithm}/table-rules
-  name: sharding-algorithm-used-table-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_rule_component_cleanup]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: algorithm, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/key-generators/{keyGenerator}/table-rules
-  name: sharding-key-generator-used-table-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_rule_component_cleanup]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: keyGenerator, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/auditors/{auditor}/table-rules
-  name: sharding-auditor-used-table-rules
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_rule_component_cleanup]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-    - {name: auditor, required: true}
-- uriTemplate: shardingsphere://features/sharding/databases/{database}/rule-count
-  name: sharding-rule-count
-  _meta:
-    org.apache.shardingsphere/resource-kind: list
-    org.apache.shardingsphere/related-tools: [database_gateway_plan_sharding_table_rule,
-      database_gateway_validate_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: database, required: true}
-- uriTemplate: shardingsphere://workflows/{plan_id}
-  name: workflow-plan
-  _meta:
-    org.apache.shardingsphere/resource-kind: detail
-    org.apache.shardingsphere/related-tools: [database_gateway_validate_workflow,
-      database_gateway_apply_workflow]
-    org.apache.shardingsphere/uri-variables:
-    - {name: plan_id, required: true}
-tools:
-- name: database_gateway_plan_broadcast_rule
-  annotations: {title: Plan Broadcast Rule, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_search_metadata
-  annotations: {title: Search Metadata, readOnlyHint: true, destructiveHint: false,
-    idempotentHint: true, openWorldHint: true}
-- name: database_gateway_validate_runtime_database
-  annotations: {title: Validate Runtime Database, readOnlyHint: true, destructiveHint: false,
-    idempotentHint: true, openWorldHint: true}
-- name: database_gateway_execute_query
-  annotations: {title: Execute Query SQL, readOnlyHint: true, destructiveHint: false,
-    idempotentHint: true, openWorldHint: true}
-- name: database_gateway_execute_explain_query
-  annotations: {title: Execute Explain Query SQL, readOnlyHint: true, destructiveHint: false,
-    idempotentHint: true, openWorldHint: true}
-- name: database_gateway_execute_update
-  annotations: {title: Preview or Execute Side-Effecting SQL, readOnlyHint: false,
-    destructiveHint: true, idempotentHint: false, openWorldHint: true}
-- name: database_gateway_plan_encrypt_rule
-  annotations: {title: Plan Encrypt Rule, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: true}
-- name: database_gateway_plan_mask_rule
-  annotations: {title: Plan Mask Rule, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: true}
-- name: database_gateway_plan_readwrite_splitting_rule
-  annotations: {title: Plan Readwrite-Splitting Rule, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_readwrite_splitting_status
-  annotations: {title: Plan Readwrite-Splitting Status, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_shadow_rule
-  annotations: {title: Plan Shadow Rule, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_default_shadow_algorithm
-  annotations: {title: Plan Default Shadow Algorithm, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_shadow_algorithm_cleanup
-  annotations: {title: Plan Shadow Algorithm Cleanup, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_sharding_table_rule
-  annotations: {title: Plan Sharding Table Rule, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_sharding_table_reference_rule
-  annotations: {title: Plan Sharding Table Reference Rule, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_sharding_default_strategy
-  annotations: {title: Plan Sharding Default Strategy, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_sharding_key_generator
-  annotations: {title: Plan Sharding Key Generator, readOnlyHint: false, destructiveHint: false,
-    idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_sharding_key_generate_strategy
-  annotations: {title: Plan Sharding Key Generate Strategy, readOnlyHint: false,
-    destructiveHint: false, idempotentHint: false, openWorldHint: false}
-- name: database_gateway_plan_sharding_rule_component_cleanup
-  annotations: {title: Plan Sharding Rule Component Cleanup, readOnlyHint: false,
-    destructiveHint: false, idempotentHint: false, openWorldHint: false}
-- name: database_gateway_apply_workflow
-  annotations: {title: Apply Workflow, readOnlyHint: false, destructiveHint: true,
-    idempotentHint: false, openWorldHint: true}
-- name: database_gateway_validate_workflow
-  annotations: {title: Validate Workflow, readOnlyHint: true, destructiveHint: false,
-    idempotentHint: true, openWorldHint: true}
-prompts:
-- name: inspect_metadata
-  title: Inspect Metadata
-  arguments:
-  - {name: database, required: false}
-  - {name: schema, required: false}
-  - {name: query, required: false}
-- name: plan_broadcast_rule
-  title: Plan Broadcast Rule
-  arguments:
-  - {name: database, required: false}
-  - {name: table, required: false}
-  - {name: tables, required: false}
-  - {name: operation_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_default_shadow_algorithm
-  title: Plan Default Shadow Algorithm
-  arguments:
-  - {name: database, required: false}
-  - {name: operation_type, required: false}
-  - {name: algorithm_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_encrypt_rule
-  title: Plan Encrypt Rule
-  arguments:
-  - {name: database, required: false}
-  - {name: schema, required: false}
-  - {name: table, required: false}
-  - {name: column, required: false}
-  - {name: algorithm_type, required: false}
-  - {name: assisted_query_algorithm_type, required: false}
-  - {name: like_query_algorithm_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_mask_rule
-  title: Plan Mask Rule
-  arguments:
-  - {name: database, required: false}
-  - {name: schema, required: false}
-  - {name: table, required: false}
-  - {name: column, required: false}
-  - {name: algorithm_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_readwrite_splitting_rule
-  title: Plan Readwrite-Splitting Rule
-  arguments:
-  - {name: database, required: false}
-  - {name: rule, required: false}
-  - {name: operation_type, required: false}
-  - {name: write_storage_unit, required: false}
-  - {name: read_storage_units, required: false}
-  - {name: transactional_read_query_strategy, required: false}
-  - {name: load_balancer_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_readwrite_splitting_status
-  title: Plan Readwrite-Splitting Status
-  arguments:
-  - {name: database, required: false}
-  - {name: rule, required: false}
-  - {name: storage_unit, required: false}
-  - {name: target_status, required: false}
-  - {name: plan_id, required: false}
-- name: plan_shadow_algorithm_cleanup
-  title: Plan Shadow Algorithm Cleanup
-  arguments:
-  - {name: database, required: false}
-  - {name: algorithm_name, required: false}
-  - {name: plan_id, required: false}
-- name: plan_shadow_rule
-  title: Plan Shadow Rule
-  arguments:
-  - {name: database, required: false}
-  - {name: rule, required: false}
-  - {name: operation_type, required: false}
-  - {name: source_storage_unit, required: false}
-  - {name: shadow_storage_unit, required: false}
-  - {name: table, required: false}
-  - {name: algorithm_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_sharding_default_strategy
-  title: Plan Sharding Default Strategy
-  arguments:
-  - {name: database, required: false}
-  - {name: operation_type, required: false}
-  - {name: algorithm_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_sharding_key_generate_strategy
-  title: Plan Sharding Key Generate Strategy
-  arguments:
-  - {name: database, required: false}
-  - {name: operation_type, required: false}
-  - {name: key_generator_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_sharding_key_generator
-  title: Plan Sharding Key Generator
-  arguments:
-  - {name: database, required: false}
-  - {name: operation_type, required: false}
-  - {name: key_generator_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_sharding_rule_component_cleanup
-  title: Plan Sharding Rule Component Cleanup
-  arguments:
-  - {name: database, required: false}
-  - {name: operation_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_sharding_table_reference_rule
-  title: Plan Sharding Table Reference Rule
-  arguments:
-  - {name: database, required: false}
-  - {name: operation_type, required: false}
-  - {name: plan_id, required: false}
-- name: plan_sharding_table_rule
-  title: Plan Sharding Table Rule
-  arguments:
-  - {name: database, required: false}
-  - {name: operation_type, required: false}
-  - {name: algorithm_type, required: false}
-  - {name: plan_id, required: false}
-- name: recover_workflow
-  title: Recover Workflow
-  arguments:
-  - {name: plan_id, required: false}
-  - {name: failure_summary, required: false}
-- name: safe_sql_execution
-  title: Safe SQL Execution
-  arguments:
-  - {name: database, required: true}
-  - {name: schema, required: false}
-  - {name: sql_intent, required: true}
-completionTargets:
-- referenceType: prompt
-  reference: plan_broadcast_rule
-  arguments: [database, table, plan_id]
-  maxValues: 50
-- referenceType: resource
-  reference: shardingsphere://databases/{database}
-  arguments: [database]
-  maxValues: 50
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas
-  arguments: [database]
-  maxValues: 50
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/storage-units
-  arguments: [database]
-  maxValues: 50
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/storage-units/{storageUnit}
-  arguments: [database, storageUnit]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      storageUnit: [database]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/storage-units/{storageUnit}/used-by-rules
-  arguments: [database, storageUnit]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      storageUnit: [database]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/single-tables
-  arguments: [database]
-  maxValues: 50
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/single-tables/{table}
-  arguments: [database, table]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      table: [database]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/single-table/default-storage-unit
-  arguments: [database]
-  maxValues: 50
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas/{schema}
-  arguments: [database, schema]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas/{schema}/tables
-  arguments: [database, schema]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}
-  arguments: [database, schema, table]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-      table: [database, schema]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns
-  arguments: [database, schema, table]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-      table: [database, schema]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns/{column}
-  arguments: [database, schema, table, column]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-      table: [database, schema]
-      column: [database, schema, table]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes
-  arguments: [database, schema, table]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-      table: [database, schema]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes/{index}
-  arguments: [database, schema, table, index]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-      table: [database, schema]
-      index: [database, schema, table]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas/{schema}/sequences
-  arguments: [database, schema]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-- referenceType: resource
-  reference: shardingsphere://databases/{database}/schemas/{schema}/sequences/{sequence}
-  arguments: [database, schema, sequence]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-      sequence: [database, schema]
-- referenceType: prompt
-  reference: plan_encrypt_rule
-  arguments: [database, schema, table, column, algorithm_type, assisted_query_algorithm_type,
-    like_query_algorithm_type, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_mask_rule
-  arguments: [database, schema, table, column, algorithm_type, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_readwrite_splitting_rule
-  arguments: [database, write_storage_unit, load_balancer_type, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_readwrite_splitting_status
-  arguments: [database, storage_unit, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_shadow_rule
-  arguments: [database, source_storage_unit, shadow_storage_unit, table, algorithm_type,
-    plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_default_shadow_algorithm
-  arguments: [database, algorithm_type, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_shadow_algorithm_cleanup
-  arguments: [database, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_sharding_table_rule
-  arguments: [database, algorithm_type, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_sharding_table_reference_rule
-  arguments: [database, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_sharding_default_strategy
-  arguments: [database, algorithm_type, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_sharding_key_generator
-  arguments: [database, key_generator_type, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_sharding_key_generate_strategy
-  arguments: [database, key_generator_type, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: plan_sharding_rule_component_cleanup
-  arguments: [database, plan_id]
-  maxValues: 50
-- referenceType: prompt
-  reference: inspect_metadata
-  arguments: [database, schema]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-- referenceType: prompt
-  reference: safe_sql_execution
-  arguments: [database, schema]
-  maxValues: 50
-  meta:
-    org.apache.shardingsphere/required-context-arguments:
-      schema: [database]
-- referenceType: prompt
-  reference: recover_workflow
-  arguments: [plan_id]
-  maxValues: 50
-- referenceType: resource
-  reference: shardingsphere://workflows/{plan_id}
-  arguments: [plan_id]
-  maxValues: 50
+supportedStatementClasses: [DCL, DDL, DML, EXPLAIN, QUERY, SAVEPOINT, TRANSACTION_CONTROL]
+completionTargets: ['prompt:inspect_metadata:[database, schema]', 'prompt:plan_broadcast_rule:[database,
+    table, plan_id]', 'prompt:plan_default_shadow_algorithm:[database, algorithm_type,
+    plan_id]', 'prompt:plan_encrypt_rule:[database, schema, table, column, algorithm_type,
+    assisted_query_algorithm_type, like_query_algorithm_type, plan_id]', 'prompt:plan_mask_rule:[database,
+    schema, table, column, algorithm_type, plan_id]', 'prompt:plan_readwrite_splitting_rule:[database,
+    write_storage_unit, load_balancer_type, plan_id]', 'prompt:plan_readwrite_splitting_status:[database,
+    storage_unit, plan_id]', 'prompt:plan_shadow_algorithm_cleanup:[database, plan_id]',
+  'prompt:plan_shadow_rule:[database, source_storage_unit, shadow_storage_unit, table,
+    algorithm_type, plan_id]', 'prompt:plan_sharding_default_strategy:[database, algorithm_type,
+    plan_id]', 'prompt:plan_sharding_key_generate_strategy:[database, key_generator_type,
+    plan_id]', 'prompt:plan_sharding_key_generator:[database, key_generator_type,
+    plan_id]', 'prompt:plan_sharding_rule_component_cleanup:[database, plan_id]',
+  'prompt:plan_sharding_table_reference_rule:[database, plan_id]', 'prompt:plan_sharding_table_rule:[database,
+    algorithm_type, plan_id]', 'prompt:recover_workflow:[plan_id]', 'prompt:safe_sql_execution:[database,
+    schema]', 'resource:shardingsphere://databases/{database}/schemas/{schema}/sequences/{sequence}:[database,
+    schema, sequence]', 'resource:shardingsphere://databases/{database}/schemas/{schema}/sequences:[database,
+    schema]', 'resource:shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns/{column}:[database,
+    schema, table, column]', 'resource:shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns:[database,
+    schema, table]', 'resource:shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes/{index}:[database,
+    schema, table, index]', 'resource:shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes:[database,
+    schema, table]', 'resource:shardingsphere://databases/{database}/schemas/{schema}/tables/{table}:[database,
+    schema, table]', 'resource:shardingsphere://databases/{database}/schemas/{schema}/tables:[database,
+    schema]', 'resource:shardingsphere://databases/{database}/schemas/{schema}:[database,
+    schema]', 'resource:shardingsphere://databases/{database}/schemas:[database]',
+  'resource:shardingsphere://databases/{database}/single-table/default-storage-unit:[database]',
+  'resource:shardingsphere://databases/{database}/single-tables/{table}:[database,
+    table]', 'resource:shardingsphere://databases/{database}/single-tables:[database]',
+  'resource:shardingsphere://databases/{database}/storage-units/{storageUnit}/used-by-rules:[database,
+    storageUnit]', 'resource:shardingsphere://databases/{database}/storage-units/{storageUnit}:[database,
+    storageUnit]', 'resource:shardingsphere://databases/{database}/storage-units:[database]',
+  'resource:shardingsphere://databases/{database}:[database]', 'resource:shardingsphere://workflows/{plan_id}:[plan_id]']
+resourceNavigation: [database_gateway_apply_workflow->database_gateway_validate_workflow,
+  database_gateway_plan_broadcast_rule->database_gateway_apply_workflow, 'database_gateway_plan_broadcast_rule->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_default_shadow_algorithm->database_gateway_apply_workflow,
+  'database_gateway_plan_default_shadow_algorithm->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_encrypt_rule->database_gateway_apply_workflow, 'database_gateway_plan_encrypt_rule->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_mask_rule->database_gateway_apply_workflow, 'database_gateway_plan_mask_rule->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_readwrite_splitting_rule->database_gateway_apply_workflow,
+  'database_gateway_plan_readwrite_splitting_rule->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_readwrite_splitting_status->database_gateway_apply_workflow,
+  'database_gateway_plan_readwrite_splitting_status->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_shadow_algorithm_cleanup->database_gateway_apply_workflow,
+  'database_gateway_plan_shadow_algorithm_cleanup->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_shadow_rule->database_gateway_apply_workflow, 'database_gateway_plan_shadow_rule->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_sharding_default_strategy->database_gateway_apply_workflow,
+  'database_gateway_plan_sharding_default_strategy->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_sharding_key_generate_strategy->database_gateway_apply_workflow,
+  'database_gateway_plan_sharding_key_generate_strategy->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_sharding_key_generator->database_gateway_apply_workflow, 'database_gateway_plan_sharding_key_generator->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_sharding_rule_component_cleanup->database_gateway_apply_workflow,
+  'database_gateway_plan_sharding_rule_component_cleanup->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_sharding_table_reference_rule->database_gateway_apply_workflow,
+  'database_gateway_plan_sharding_table_reference_rule->shardingsphere://workflows/{plan_id}',
+  database_gateway_plan_sharding_table_rule->database_gateway_apply_workflow, 'database_gateway_plan_sharding_table_rule->shardingsphere://workflows/{plan_id}',
+  recover_workflow->database_gateway_validate_workflow, 'shardingsphere://capabilities->database_gateway_search_metadata',
+  'shardingsphere://capabilities->shardingsphere://databases', 'shardingsphere://capabilities->shardingsphere://guidance',
+  'shardingsphere://capabilities->shardingsphere://runtime', 'shardingsphere://databases/{database}->shardingsphere://databases/{database}/schemas',
+  'shardingsphere://databases/{database}->shardingsphere://databases/{database}/single-table/default-storage-unit',
+  'shardingsphere://databases/{database}->shardingsphere://databases/{database}/single-tables',
+  'shardingsphere://databases/{database}->shardingsphere://databases/{database}/storage-units',
+  'shardingsphere://databases/{database}/schemas/{schema}->shardingsphere://databases/{database}/schemas/{schema}/sequences',
+  'shardingsphere://databases/{database}/schemas/{schema}->shardingsphere://databases/{database}/schemas/{schema}/tables',
+  'shardingsphere://databases/{database}/schemas/{schema}->shardingsphere://databases/{database}/schemas/{schema}/views',
+  'shardingsphere://databases/{database}/schemas/{schema}/tables/{table}->shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns',
+  'shardingsphere://databases/{database}/schemas/{schema}/tables/{table}->shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes',
+  'shardingsphere://databases/{database}/schemas/{schema}/views/{view}->shardingsphere://databases/{database}/schemas/{schema}/views/{view}/columns',
+  'shardingsphere://databases/{database}/storage-units/{storageUnit}->shardingsphere://databases/{database}/storage-units/{storageUnit}/used-by-rules',
+  'shardingsphere://features/broadcast/databases/{database}/rule-count->shardingsphere://features/broadcast/databases/{database}/rules',
+  'shardingsphere://features/broadcast/databases/{database}/rules->database_gateway_plan_broadcast_rule',
+  'shardingsphere://features/broadcast/databases/{database}/tables/{table}/rule->database_gateway_plan_broadcast_rule',
+  'shardingsphere://features/encrypt/algorithms->database_gateway_plan_encrypt_rule',
+  'shardingsphere://features/encrypt/databases/{database}/rules->database_gateway_plan_encrypt_rule',
+  'shardingsphere://features/encrypt/databases/{database}/tables/{table}/rules->database_gateway_plan_encrypt_rule',
+  'shardingsphere://features/mask/algorithms->database_gateway_plan_mask_rule', 'shardingsphere://features/mask/databases/{database}/rules->database_gateway_plan_mask_rule',
+  'shardingsphere://features/mask/databases/{database}/tables/{table}/rules->database_gateway_plan_mask_rule',
+  'shardingsphere://features/readwrite-splitting/databases/{database}/rules->database_gateway_plan_readwrite_splitting_rule',
+  'shardingsphere://features/readwrite-splitting/databases/{database}/rules/{rule}->database_gateway_plan_readwrite_splitting_rule',
+  'shardingsphere://features/readwrite-splitting/databases/{database}/rules/{rule}/status->database_gateway_plan_readwrite_splitting_status',
+  'shardingsphere://features/readwrite-splitting/databases/{database}/status->database_gateway_plan_readwrite_splitting_status',
+  'shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins->database_gateway_plan_readwrite_splitting_rule',
+  'shardingsphere://features/shadow/algorithm-plugins->database_gateway_plan_default_shadow_algorithm',
+  'shardingsphere://features/shadow/algorithm-plugins->database_gateway_plan_shadow_rule',
+  'shardingsphere://features/shadow/databases/{database}/algorithms->database_gateway_plan_shadow_algorithm_cleanup',
+  'shardingsphere://features/shadow/databases/{database}/default-algorithm->database_gateway_plan_default_shadow_algorithm',
+  'shardingsphere://features/shadow/databases/{database}/rules->database_gateway_plan_shadow_rule',
+  'shardingsphere://features/shadow/databases/{database}/table-rules->database_gateway_plan_shadow_rule',
+  'shardingsphere://features/sharding/algorithm-plugins->database_gateway_plan_sharding_default_strategy',
+  'shardingsphere://features/sharding/algorithm-plugins->database_gateway_plan_sharding_table_rule',
+  'shardingsphere://features/sharding/databases/{database}/default-strategy->database_gateway_plan_sharding_default_strategy',
+  'shardingsphere://features/sharding/databases/{database}/key-generate-strategies->database_gateway_plan_sharding_key_generate_strategy',
+  'shardingsphere://features/sharding/databases/{database}/key-generate-strategies/{strategy}->database_gateway_plan_sharding_key_generate_strategy',
+  'shardingsphere://features/sharding/databases/{database}/key-generators->database_gateway_plan_sharding_key_generator',
+  'shardingsphere://features/sharding/databases/{database}/key-generators/{keyGenerator}->database_gateway_plan_sharding_key_generator',
+  'shardingsphere://features/sharding/databases/{database}/table-reference-rules->database_gateway_plan_sharding_table_reference_rule',
+  'shardingsphere://features/sharding/databases/{database}/table-reference-rules/{rule}->database_gateway_plan_sharding_table_reference_rule',
+  'shardingsphere://features/sharding/databases/{database}/table-rules->database_gateway_plan_sharding_table_rule',
+  'shardingsphere://features/sharding/databases/{database}/tables/{table}/nodes->database_gateway_plan_sharding_table_rule',
+  'shardingsphere://features/sharding/databases/{database}/tables/{table}/table-rule->database_gateway_plan_sharding_table_rule',
+  'shardingsphere://features/sharding/databases/{database}/unused-algorithms->database_gateway_plan_sharding_rule_component_cleanup',
+  'shardingsphere://features/sharding/databases/{database}/unused-auditors->database_gateway_plan_sharding_rule_component_cleanup',
+  'shardingsphere://features/sharding/databases/{database}/unused-key-generators->database_gateway_plan_sharding_rule_component_cleanup',
+  'shardingsphere://features/sharding/key-generate-algorithm-plugins->database_gateway_plan_sharding_key_generate_strategy',
+  'shardingsphere://features/sharding/key-generate-algorithm-plugins->database_gateway_plan_sharding_key_generator']

--- a/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/guidance.yaml
+++ b/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/guidance.yaml
@@ -16,91 +16,13 @@
 #
 
 response_mode: guidance
-guidance_resource: shardingsphere://guidance
-model_first_summary:
+discovery:
   official_discovery_methods: {tools: tools/list, resources: resources/list, resource_templates: resources/templates/list,
     prompts: prompts/list}
   argument_completion_method: completion/complete
   guidance_resource_role: shardingsphere://guidance complements MCP list methods with
     ShardingSphere domain guidance, workflow guidance, and side-effect notes.
-  guidance_resource: shardingsphere://guidance
-  first_call_routes:
-  - {intent: inspect_metadata, first_action: read_resource shardingsphere://databases,
-    next_step: call_tool database_gateway_search_metadata or read returned resource.uri,
-    stop_rule: Stop after the requested detail resource is read.}
-  - {intent: validate_runtime, first_action: read_resource shardingsphere://runtime,
-    next_step: call_tool database_gateway_validate_runtime_database with a configured
-      database, stop_rule: Follow top-level next_actions when validation fails.}
-  - {intent: read_only_sql, first_action: 'read_resource shardingsphere://databases/{database}/capabilities',
-    next_step: call_tool database_gateway_execute_query, stop_rule: Stop after reporting
-      the result rows.}
-  - {intent: explain_query, first_action: 'read_resource shardingsphere://databases/{database}/capabilities',
-    next_step: 'generate database-native EXPLAIN SQL, then call_tool database_gateway_execute_explain_query',
-    stop_rule: Stop after reporting the execution plan rows.}
-  - {intent: rule_workflow, first_action: call_tool matching database_gateway_plan_*
-      workflow tool without plan_id for a new plan, next_step: call_tool database_gateway_apply_workflow
-      execution_mode=preview with the returned plan_id, stop_rule: Use workflow apply
-      and validation for natural-language rule changes before considering raw side-effect
-      SQL.}
-  - {intent: side_effect_sql, first_action: call_tool database_gateway_execute_update
-      execution_mode=preview, next_step: call_tool database_gateway_execute_update
-      execution_mode=execute, stop_rule: Execute only after preview review confirms
-      the intended side effect.}
-  - {intent: complete_uncertain_argument, first_action: call completion/complete for
-      one uncertain argument, next_step: follow completion meta.next_actions when
-      context is missing or no candidates match, stop_rule: Stop after the argument
-      is selected or the nearest resource proves it is unavailable.}
-  - {intent: recover_error, first_action: follow top-level next_actions, next_step: fallback
-      to recovery.next_actions when top-level actions are absent, stop_rule: 'Ask the
-      user only when no deterministic resource, completion, or tool action is available.'}
-  metadata_rule: {first_resource: 'shardingsphere://databases', search_tool: database_gateway_search_metadata,
-    detail_rule: Read the returned resource.uri when the list or search response points
-      to a detail resource.}
-  preflight_rule: {tool: database_gateway_validate_runtime_database, input_rule: Pass
-      only a configured runtime database name., secret_rule: Connection details stay
-      in administrator runtime configuration and are not tool arguments.}
-  sql_tool_selection:
-    read_only: {tool: database_gateway_execute_query, statement_rule: Use for one SELECT
-        statement.}
-    explain: {tool: database_gateway_execute_explain_query, statement_rule: Use for
-        an execution plan of one SELECT statement., candidate_rule: Generate database-native
-        EXPLAIN SQL in explain_sql and never use EXPLAIN ANALYZE.}
-    side_effecting:
-      tool: database_gateway_execute_update
-      first_mode: preview
-      execute_requires: execution_mode=execute
-      rule_change_preference: For natural-language rule changes, use the matching
-        database_gateway_plan_* workflow tool before raw SQL execution; omit plan_id
-        for a new plan.
-  side_effect_rule: Preview side effects first; execute only when the requested side
-    effect is still intended.
-  workflow_rule:
-    selection_rule: For natural-language rule changes, use the matching database_gateway_plan_*
-      workflow tool before raw side-effect SQL; omit plan_id for a new plan and reuse
-      only returned plan_id values.
-    planning_tools: [database_gateway_plan_broadcast_rule, database_gateway_plan_encrypt_rule,
-      database_gateway_plan_mask_rule, database_gateway_plan_readwrite_splitting_rule,
-      database_gateway_plan_readwrite_splitting_status, database_gateway_plan_shadow_rule,
-      database_gateway_plan_default_shadow_algorithm, database_gateway_plan_shadow_algorithm_cleanup,
-      database_gateway_plan_sharding_table_rule, database_gateway_plan_sharding_table_reference_rule,
-      database_gateway_plan_sharding_default_strategy, database_gateway_plan_sharding_key_generator,
-      database_gateway_plan_sharding_key_generate_strategy, database_gateway_plan_sharding_rule_component_cleanup]
-    preview_tool: {tool: database_gateway_apply_workflow, execution_mode: preview}
-    execute_tool: {tool: database_gateway_apply_workflow, execution_mode: review-then-execute,
-      execute_requires: execution_mode=review-then-execute and explicit approved_steps
-        copied from preview_artifacts.approval_step}
-    validate_tool: database_gateway_validate_workflow
-  completion_rule: Use MCP completion for missing database, schema, table, column,
-    index, sequence, or storage unit values before guessing identifiers.
-  recovery_rule: Follow structured recovery.next_actions before inventing a replacement
-    call.
 model_contract:
-  public_surface_source: 'MCP list methods expose the protocol surface: tools/list,
-    resources/list, resources/templates/list, prompts/list.'
-  official_discovery_methods: {tools: tools/list, resources: resources/list, resource_templates: resources/templates/list,
-    prompts: prompts/list}
-  argument_completion_method: completion/complete
-  guidance_resource: shardingsphere://guidance
   metadata_first_resource: shardingsphere://databases
   preflight_rule: Use database_gateway_validate_runtime_database with a configured
     database name before onboarding or troubleshooting runtime connectivity.
@@ -121,33 +43,11 @@ model_contract:
     and arguments.'
   detail_resource_rule: Use resource descriptors, outputSchema, and returned payload
     keys before assuming detail fields.
-  recovery_rule: When a call fails with recovery.next_actions, follow those structured
-    actions before inventing a new call.
-surface_summary:
-  official_discovery_methods: {tools: tools/list, resources: resources/list, resource_templates: resources/templates/list,
-    prompts: prompts/list}
-  argument_completion_method: completion/complete
-  guidance_resource: shardingsphere://guidance
-  metadata_resource: shardingsphere://databases
-  metadata_search_tool: database_gateway_search_metadata
-  preflight_validation_tool: database_gateway_validate_runtime_database
-  read_only_sql_tool: database_gateway_execute_query
-  explain_sql_tool: database_gateway_execute_explain_query
-  side_effect_sql_tool: database_gateway_execute_update
-  workflow_tools: [database_gateway_apply_workflow, database_gateway_validate_workflow]
-  side_effect_rule: Preview first and continue only when the requested side effect
-    is still intended.
-  completion_rule: Use local completion hints on fields, prompts, and resources before
-    guessing identifiers.
-field_naming_contract:
-  official_discovery_methods: [tools/list, resources/list, resources/templates/list,
-    prompts/list]
-  argument_completion_method: completion/complete
-  catalog_fields: [supportedResources, supportedTools, supportedStatementClasses,
-    guidanceResource, resourceTemplates, completionTargets, resourceNavigation, protocolAvailability]
-  payload_fields: ShardingSphere-owned structured payload fields use snake_case.
-  descriptor_fields: Descriptor-derived MCP schema fields keep the protocol or JSON
-    Schema field names required by MCP clients.
+  recovery_rule: When a call fails, follow top-level next_actions before inventing
+    a new call.
+  payload_field_rule: ShardingSphere-owned structured payload fields use snake_case.
+  descriptor_field_rule: Descriptor-derived MCP schema fields keep the protocol or
+    JSON Schema field names required by MCP clients.
 next_action_contract:
 - type: resource_read
   required_fields: [order, type, title, resource_uri]
@@ -164,7 +64,7 @@ next_action_contract:
   description: Use MCP completion for one argument before retrying.
 - type: ask_user
   required_fields: [order, type, title, question]
-  optional_fields: [required_inputs, reason, depends_on]
+  optional_fields: [required_inputs, depends_on]
   description: Ask the user for missing input.
 - type: terminal
   required_fields: [order, type, title]
@@ -175,57 +75,41 @@ common_flows:
   steps: [resources/list, resources/templates/list, 'read_resource shardingsphere://databases',
     call_tool database_gateway_search_metadata, read_resource returned resource.uri]
   stop_condition: Stop when the requested metadata detail resource is read.
-  referenced_tools: [database_gateway_search_metadata]
-  referenced_resources: ['shardingsphere://databases']
 - flow_id: validate_runtime_database
   steps: ['read_resource shardingsphere://databases', call_tool database_gateway_validate_runtime_database]
   stop_condition: Stop after the configured runtime database reports ready or returns
     structured recovery guidance.
-  referenced_tools: [database_gateway_validate_runtime_database]
-  referenced_resources: ['shardingsphere://databases']
 - flow_id: read_only_sql
   steps: ['read_resource shardingsphere://databases/{database}/capabilities', call_tool
       database_gateway_execute_query]
   stop_condition: Use one SELECT statement and stop after the result is reported.
-  referenced_tools: [database_gateway_execute_query]
-  referenced_resources: ['shardingsphere://databases/{database}/capabilities']
 - flow_id: explain_query
   steps: ['read_resource shardingsphere://databases/{database}/capabilities', generate
       database-native EXPLAIN SQL without ANALYZE, call_tool database_gateway_execute_explain_query]
   stop_condition: Use the original SELECT as sql, the generated EXPLAIN as explain_sql,
     and stop after the plan rows are reported.
-  referenced_tools: [database_gateway_execute_explain_query]
-  referenced_resources: ['shardingsphere://databases/{database}/capabilities']
 - flow_id: side_effecting_sql
   steps: [call_tool database_gateway_execute_update execution_mode=preview, call_tool
       database_gateway_execute_update execution_mode=execute]
   stop_condition: Execute only after reviewing the previewed SQL and side-effect scope.
-  referenced_tools: [database_gateway_execute_update]
-  referenced_resources: &id001 []
 - flow_id: complete_uncertain_argument
   steps: [resources/templates/list, call completion/complete for one argument, 'follow
       completion meta.next_actions when diagnostic is missing_context, prefix_filtered_all_candidates,
       or no_candidates']
   stop_condition: Stop when a completion value is selected or the nearest resource
     proves the argument is unavailable.
-  referenced_tools: *id001
-  referenced_resources: *id001
 - flow_id: workflow_plan_apply_validate
   steps: [call_tool descriptor-backed feature planning tool, call_tool database_gateway_apply_workflow
       execution_mode=preview, call_tool database_gateway_apply_workflow execution_mode=review-then-execute
       approved_steps=<preview_artifacts.approval_step>, call_tool database_gateway_validate_workflow]
   stop_condition: Reuse the same current-session plan_id and stop after validation
     succeeds.
-  referenced_tools: [database_gateway_apply_workflow, database_gateway_validate_workflow]
-  referenced_resources: *id001
 - flow_id: recover_from_error
-  steps: [follow recovery.next_actions, prefer official list discovery methods when
+  steps: [follow top-level next_actions, prefer official list discovery methods when
       surface information is needed, 'read_resource shardingsphere://guidance only
       when the server suggests the guidance resource', ask_user only when uncertain]
   stop_condition: Do not invent replacement calls while structured recovery actions
     are present.
-  referenced_tools: *id001
-  referenced_resources: ['shardingsphere://guidance']
 security_hints:
   http_transport: Streamable HTTP is unauthenticated by default; prefer loopback binding
     or put remote exposure behind a trusted gateway.
@@ -236,16 +120,14 @@ security_hints:
   client_safety_policy:
     identity_scope: mcp_session
     transport_scope: HTTP transport can bind trusted session attribution when configured;
-      the MCP runtime does not provide built-in authentication or authorization.
-      STDIO inherits the local process boundary.
-    tool_call_limit: {scope: session, max_calls: 10000, property: shardingsphere.mcp.maxToolCallsPerSession,
-      recovery: Close and recreate the MCP session after the quota is exhausted.}
+      the MCP runtime does not provide built-in authentication or authorization. STDIO
+      inherits the local process boundary.
     runtime_protection:
       tool_call_limit: {scope: session, max_calls: 10000, property: shardingsphere.mcp.maxToolCallsPerSession,
         recovery: Close and recreate the MCP session after the quota is exhausted.}
       completion_rate_limit: {scope: session, window_seconds: 60, max_requests: 600,
-        property: shardingsphere.mcp.maxCompletionRequestsPerMinute, recovery: Retry after
-          the current completion rate-limit window ends.}
+        property: shardingsphere.mcp.maxCompletionRequestsPerMinute, recovery: Retry
+          after the current completion rate-limit window ends.}
       sql_execution_limits:
         max_rows: {default_value: 100, maximum_value: 5000, applied_field: applied_max_rows,
           truncation_field: truncated, recovery: 'For read-only queries, retry with

--- a/test/e2e/mcp/src/test/resources/llm/evaluation/mcp-builder-evaluation.xml
+++ b/test/e2e/mcp/src/test/resources/llm/evaluation/mcp-builder-evaluation.xml
@@ -187,7 +187,7 @@
     <verification>
       <step>Confirm the answer uses completion/complete or resources/read plugin resources before selecting uncertain algorithm names.</step>
       <step>Confirm the answer covers mask, readwrite-splitting, shadow, and sharding plugin completion sources.</step>
-      <step>Confirm the answer keeps completion bounded, secret-safe, and uses recovery next_actions instead of mutation.</step>
+      <step>Confirm the answer keeps completion bounded, secret-safe, and uses top-level next_actions instead of mutation.</step>
     </verification>
   </qa_pair>
   <qa_pair id="q10" category="transport_security" read_only="true">


### PR DESCRIPTION
- remove duplicate runtime, metadata, recovery, workflow, completion and SQL fields
- rely on official MCP discovery and keep ShardingSphere capabilities domain-specific
- align schemas, guidance, tests, E2E baselines and protocol documentation

