### PR TITLE
Reuse connection offsets across repeated enumerations

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,7 @@
 1. Sharding: Fix generated actual index names exceeding database identifier length limits while preserving legacy generated index name compatibility - [#38449](https://github.com/apache/shardingsphere/pull/38449)
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
+1. SQL Federation: Reuse connection offsets across repeated enumerations - [#39186](https://github.com/apache/shardingsphere/pull/39186)
 
 ### Enhancements
 

--- a/kernel/sql-federation/executor/src/main/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/implementor/EnumerableScanImplementor.java
+++ b/kernel/sql-federation/executor/src/main/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/implementor/EnumerableScanImplementor.java
@@ -65,8 +65,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -148,25 +150,8 @@ public final class EnumerableScanImplementor implements ScanImplementor {
         };
     }
     
-    private AbstractEnumerable<Object> createJDBCEnumerable(final QueryContext queryContext, final ShardingSphereDatabase database, final ExecutionContext executionContext) {
-        return new AbstractEnumerable<Object>() {
-            
-            @SneakyThrows
-            @Override
-            public Enumerator<Object> enumerator() {
-                computeConnectionOffsets(executionContext);
-                ExecutionGroupContext<JDBCExecutionUnit> executionGroupContext = prepare(database, executionContext);
-                setParameters(executionGroupContext.getInputGroups());
-                ShardingSpherePreconditions.checkState(!ProcessRegistry.getInstance().get(executorContext.getProcessId()).isInterrupted(), SQLExecutionInterruptedException::new);
-                processEngine.executeSQL(executionGroupContext, queryContext);
-                List<QueryResult> queryResults =
-                        executorContext.getJdbcExecutor().execute(executionGroupContext, executorContext.getQueryCallback()).stream().map(QueryResult.class::cast).collect(Collectors.toList());
-                MergeEngine mergeEngine = new MergeEngine(queryContext.getMetaData(), database, queryContext.getMetaData().getProps(), queryContext.getConnectionContext());
-                MergedResult mergedResult = mergeEngine.merge(queryResults, queryContext);
-                Collection<Statement> statements = getStatements(executionGroupContext.getInputGroups());
-                return new JDBCDataRowEnumerator(mergedResult, queryResults.get(0).getMetaData(), statements);
-            }
-        };
+    private AbstractEnumerable<Object> createJDBCEnumerable(final QueryContext scanQueryContext, final ShardingSphereDatabase database, final ExecutionContext executionContext) {
+        return new JDBCEnumerable(scanQueryContext, database, executionContext);
     }
     
     private void computeConnectionOffsets(final ExecutionContext context) {
@@ -176,9 +161,10 @@ public final class EnumerableScanImplementor implements ScanImplementor {
         }
     }
     
-    private ExecutionGroupContext<JDBCExecutionUnit> prepare(final ShardingSphereDatabase database, final ExecutionContext executionContext) throws SQLException {
+    private ExecutionGroupContext<JDBCExecutionUnit> prepare(final ShardingSphereDatabase database, final ExecutionContext executionContext,
+                                                             final Map<String, Integer> connectionOffsets) throws SQLException {
         // TODO pass grantee from proxy and jdbc adapter
-        return executorContext.getPrepareEngine().prepare(database.getName(), executionContext, executorContext.getConnectionOffsets(), executionContext.getExecutionUnits(),
+        return executorContext.getPrepareEngine().prepare(database.getName(), executionContext, connectionOffsets, executionContext.getExecutionUnits(),
                 new ExecutionGroupReportContext(executorContext.getProcessId(), database.getName()));
     }
     
@@ -206,6 +192,42 @@ public final class EnumerableScanImplementor implements ScanImplementor {
     private void setParameters(final PreparedStatement preparedStatement, final List<Object> params) {
         for (int i = 0; i < params.size(); i++) {
             preparedStatement.setObject(i + 1, params.get(i));
+        }
+    }
+    
+    @RequiredArgsConstructor
+    private final class JDBCEnumerable extends AbstractEnumerable<Object> {
+        
+        private final QueryContext scanQueryContext;
+        
+        private final ShardingSphereDatabase database;
+        
+        private final ExecutionContext executionContext;
+        
+        private boolean offsetsComputed;
+        
+        private Map<String, Integer> allocatedConnectionOffsets;
+        
+        @SneakyThrows
+        @Override
+        public Enumerator<Object> enumerator() {
+            synchronized (this) {
+                if (!offsetsComputed) {
+                    computeConnectionOffsets(executionContext);
+                    allocatedConnectionOffsets = new HashMap<>(executorContext.getConnectionOffsets());
+                    offsetsComputed = true;
+                }
+            }
+            ExecutionGroupContext<JDBCExecutionUnit> executionGroupContext = prepare(database, executionContext, allocatedConnectionOffsets);
+            setParameters(executionGroupContext.getInputGroups());
+            ShardingSpherePreconditions.checkState(!ProcessRegistry.getInstance().get(executorContext.getProcessId()).isInterrupted(), SQLExecutionInterruptedException::new);
+            processEngine.executeSQL(executionGroupContext, scanQueryContext);
+            List<QueryResult> queryResults = executorContext.getJdbcExecutor().execute(executionGroupContext, executorContext.getQueryCallback())
+                    .stream().map(QueryResult.class::cast).collect(Collectors.toList());
+            MergeEngine mergeEngine = new MergeEngine(scanQueryContext.getMetaData(), database, scanQueryContext.getMetaData().getProps(), scanQueryContext.getConnectionContext());
+            MergedResult mergedResult = mergeEngine.merge(queryResults, scanQueryContext);
+            Collection<Statement> statements = getStatements(executionGroupContext.getInputGroups());
+            return new JDBCDataRowEnumerator(mergedResult, queryResults.get(0).getMetaData(), statements);
         }
     }
 }

--- a/kernel/sql-federation/executor/src/test/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/implementor/EnumerableScanImplementorTest.java
+++ b/kernel/sql-federation/executor/src/test/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/implementor/EnumerableScanImplementorTest.java
@@ -64,6 +64,7 @@ import org.apache.shardingsphere.sqlfederation.compiler.implementor.ScanImplemen
 import org.apache.shardingsphere.sqlfederation.executor.context.ExecutorContext;
 import org.apache.shardingsphere.sqlfederation.executor.enumerable.enumerator.memory.MemoryTableStatisticsBuilder;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
@@ -76,6 +77,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -91,11 +93,13 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -312,6 +316,89 @@ class EnumerableScanImplementorTest {
                 assertThat(connectionOffsets.get("ds_0"), is(1));
                 verify(preparedStatement).setObject(1, "bar_param");
                 assertFalse(mergeEngineMockedConstruction.constructed().isEmpty());
+            }
+        } finally {
+            ProcessRegistry.getInstance().remove("process_id");
+        }
+    }
+    
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void assertImplementWithJDBCEnumerableRepeatedEnumeratorCalls() throws SQLException {
+        SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
+        when(sqlStatementContext.getSqlStatement().getDatabaseType()).thenReturn(databaseType);
+        QueryContext queryContext = mock(QueryContext.class);
+        when(queryContext.getSqlStatementContext()).thenReturn(sqlStatementContext);
+        when(queryContext.isUseCache()).thenReturn(true);
+        ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class);
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
+        when(database.getName()).thenReturn("foo_db");
+        when(metaData.containsDatabase("foo_db")).thenReturn(true);
+        when(metaData.getDatabase("foo_db")).thenReturn(database);
+        when(metaData.getGlobalRuleMetaData()).thenReturn(mock(RuleMetaData.class));
+        when(queryContext.getMetaData()).thenReturn(metaData);
+        when(queryContext.getParameters()).thenReturn(Collections.singletonList("param_0"));
+        SQLStatement sqlStatement = mock(SQLStatement.class);
+        CompilerContext compilerContext = mock(CompilerContext.class, RETURNS_DEEP_STUBS);
+        when(compilerContext.getSqlParserRule().getSQLParserEngine(databaseType).parse("SELECT ? FROM tbl", true)).thenReturn(sqlStatement);
+        SQLStatementContext boundStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
+        when(boundStatementContext.getTablesContext().getDatabaseNames()).thenReturn(Collections.singletonList("foo_db"));
+        when(boundStatementContext.getSqlStatement()).thenReturn(sqlStatement);
+        
+        ExecutorContext executorContext = mock(ExecutorContext.class);
+        Map<String, Integer> globalConnectionOffsets = new HashMap<>();
+        when(executorContext.getConnectionOffsets()).thenReturn(globalConnectionOffsets);
+        when(executorContext.getCurrentDatabaseName()).thenReturn("foo_db");
+        when(executorContext.getProcessId()).thenReturn("process_id");
+        
+        DriverExecutionPrepareEngine<JDBCExecutionUnit, Connection> prepareEngine = mock(DriverExecutionPrepareEngine.class);
+        when(executorContext.getPrepareEngine()).thenReturn(prepareEngine);
+        JDBCExecutor jdbcExecutor = mock(JDBCExecutor.class);
+        when(executorContext.getJdbcExecutor()).thenReturn(jdbcExecutor);
+        JDBCExecutorCallback<QueryResult> queryCallback = (JDBCExecutorCallback<QueryResult>) mock(JDBCExecutorCallback.class);
+        when(executorContext.getQueryCallback()).thenReturn((JDBCExecutorCallback) queryCallback);
+        
+        ExecutionUnit executionUnit = new ExecutionUnit("ds_0", new SQLUnit("SELECT 1", Collections.emptyList()));
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(executionContext.getExecutionUnits()).thenReturn(Collections.singletonList(executionUnit));
+        
+        JDBCExecutionUnit jdbcExecutionUnit = new JDBCExecutionUnit(executionUnit, ConnectionMode.MEMORY_STRICTLY, mock());
+        ExecutionGroupContext<JDBCExecutionUnit> executionGroupContext = new ExecutionGroupContext<>(
+                Collections.singleton(new ExecutionGroup<>(Collections.singletonList(jdbcExecutionUnit))), new ExecutionGroupReportContext("process_id", "foo_db"));
+        
+        doAnswer(invocation -> executionGroupContext).when(prepareEngine).prepare(anyString(), any(), anyMap(), anyCollection(), any());
+        when(jdbcExecutor.execute(executionGroupContext, queryCallback)).thenReturn(Collections.singletonList(mock(QueryResult.class)));
+        ProcessRegistry.getInstance().add(new Process(new ExecutionGroupContext<>(Collections.emptyList(), new ExecutionGroupReportContext("process_id", "foo_db"))));
+        
+        ScanImplementorContext scanContext = new ScanImplementorContext(mock(DataContext.class), "SELECT ? FROM tbl", new int[]{0});
+        ShardingSphereTable table = mock(ShardingSphereTable.class, RETURNS_DEEP_STUBS);
+        when(table.getAllColumns()).thenReturn(Collections.singleton(new ShardingSphereColumn("id", Types.INTEGER, true, false, false, false, true, false)));
+        
+        try (
+                MockedConstruction<SQLBindEngine> ignoredSQLBindEngine = mockConstruction(SQLBindEngine.class,
+                        (constructed, context) -> when(constructed.bind(sqlStatement)).thenReturn(boundStatementContext));
+                MockedConstruction<KernelProcessor> ignoredKernelProcessor = mockConstruction(KernelProcessor.class,
+                        (constructed, context) -> when(constructed.generateExecutionContext(any(), any(), any())).thenReturn(executionContext));
+                MockedConstruction<MergeEngine> mergeEngineMockedConstruction = mockConstruction(MergeEngine.class,
+                        (constructed, context) -> when(constructed.merge(anyList(), any(QueryContext.class))).thenReturn(mock(MergedResult.class)))) {
+            
+            Enumerable<Object> enumerable = new EnumerableScanImplementor(queryContext, compilerContext, executorContext).implement(table, scanContext);
+            
+            try (Enumerator<Object> ignored1 = enumerable.enumerator()) {
+                assertThat(globalConnectionOffsets.get("ds_0"), is(0));
+            }
+            
+            globalConnectionOffsets.put("ds_0", 5);
+            
+            try (Enumerator<Object> ignored2 = enumerable.enumerator()) {
+                ArgumentCaptor<Map<String, Integer>> captor = ArgumentCaptor.forClass(Map.class);
+                verify(prepareEngine, times(2)).prepare(eq("foo_db"), eq(executionContext), captor.capture(), anyCollection(), any());
+                
+                List<Map<String, Integer>> allSnapshotsPassed = captor.getAllValues();
+                
+                assertThat(allSnapshotsPassed.get(0).get("ds_0"), is(0));
+                assertThat(allSnapshotsPassed.get(1).get("ds_0"), is(0));
+                assertThat(globalConnectionOffsets.get("ds_0"), is(5));
             }
         } finally {
             ProcessRegistry.getInstance().remove("process_id");


### PR DESCRIPTION
Fixes #37438 

Allocate connection offsets only once for a JDBC enumerable and reuse the allocated snapshot across repeated enumerator() invocations. This prevents connection offsets from continuously increasing when the same enumerable is executed multiple times, and adds a regression test covering repeated enumerator() calls.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in the comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally: `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
