### PR TITLE
Improve MCP contract validation and E2E coverage

### DIFF
--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -246,18 +246,30 @@ jobs:
           if-no-files-found: warn
 
   e2e-mcp-llm:
-    name: E2E - MCP LLM - ${{ matrix.test-class }}
+    name: E2E - MCP LLM - ${{ matrix.suite-id }}
     if: github.repository == 'apache/shardingsphere'
     needs: [ e2e-mcp-build-images, e2e-mcp-build-llm-image ]
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
-        test-class:
-          - LLMSmokeE2ETest
-          - LLMUsabilitySuiteE2ETest
-          - MCPBuilderEvaluationE2ETest
+        include:
+          - suite-id: smoke
+            test-class: LLMSmokeE2ETest
+          - suite-id: usability-core
+            test-class: LLMUsabilitySuiteE2ETest
+            test-property: mcp.e2e.llm.usability-suite=core
+          - suite-id: usability-extended
+            test-class: LLMUsabilitySuiteE2ETest
+            test-property: mcp.e2e.llm.usability-suite=extended
+          - suite-id: builder-first
+            test-class: MCPBuilderEvaluationE2ETest
+            test-property: mcp.e2e.llm.builder-case-group=first
+          - suite-id: builder-second
+            test-class: MCPBuilderEvaluationE2ETest
+            test-property: mcp.e2e.llm.builder-case-group=second
     steps:
       - uses: actions/checkout@v6.0.1
       - uses: ./.github/workflows/resources/actions/setup-build-environment
@@ -281,10 +293,17 @@ jobs:
           docker-image-archives: mcp-llm-runtime-image.tar
       - name: Run MCP LLM E2E
         shell: bash
+        env:
+          MCP_LLM_TEST_PROPERTY: ${{ matrix.test-property }}
         run: |
           set -euo pipefail
+          test_property_args=()
+          if [[ -n "${MCP_LLM_TEST_PROPERTY}" ]]; then
+            test_property_args+=("-D${MCP_LLM_TEST_PROPERTY}")
+          fi
           ./mvnw -pl test/e2e/mcp test -DskipITs -Dspotless.skip=true \
             -Dtest='${{ matrix.test-class }}' \
+            "${test_property_args[@]}" \
             -Dgroups=llm-e2e \
             -Dsurefire.failIfNoSpecifiedTests=true \
             -De2e.run.type=DOCKER \
@@ -292,13 +311,13 @@ jobs:
             -Dmcp.llm.ready-timeout-seconds=900 \
             -Dmcp.llm.request-timeout-seconds=300 \
             -Dmcp.llm.artifact-root="${{ github.workspace }}/test/e2e/mcp/target/llm-e2e" \
-            -Dmcp.llm.run-id=gha-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.test-class }} \
+            -Dmcp.llm.run-id=gha-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suite-id }} \
             -B -ntp
       - name: Upload MCP LLM E2E Artifacts
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: e2e-mcp-llm-${{ matrix.test-class }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-mcp-llm-${{ matrix.suite-id }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             test/e2e/mcp/target/llm-e2e
             test/e2e/mcp/target/surefire-reports

--- a/docs/document/content/user-manual/shardingsphere-mcp/configuration.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/configuration.cn.md
@@ -124,7 +124,10 @@ runtimeDatabases:
 
 ## 连接目标选择
 
-`runtimeDatabases` 可以配置任意可连接的 JDBC URL。用户能看到的数据库对象和可执行的治理任务取决于连接目标。
+只有当前发行包同时包含匹配的 ShardingSphere 数据库类型连接器和 JDBC 驱动时，`runtimeDatabases` 才能使用对应的可连接 JDBC URL。
+默认发行包包含 MySQL、PostgreSQL、Oracle、SQL Server 和 openGauss 数据库类型连接器，以及 MySQL、PostgreSQL 和 openGauss JDBC 驱动。
+Oracle、SQL Server 或其他未随包提供 JDBC 驱动的目标，需要把匹配的驱动 jar 放入 `plugins/`；只添加驱动并不能支持一个尚无数据库类型连接器的目标。
+用户能看到的数据库对象和可执行的治理任务取决于连接目标。
 
 ### 连接 ShardingSphere-Proxy 逻辑库
 

--- a/docs/document/content/user-manual/shardingsphere-mcp/configuration.en.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/configuration.en.md
@@ -124,7 +124,10 @@ Notes:
 
 ## Choose a Connection Target
 
-`runtimeDatabases` can use any reachable JDBC URL. The database objects users can see and the governance tasks they can perform depend on the connection target.
+`runtimeDatabases` can use a reachable JDBC URL only when the running distribution contains both the matching ShardingSphere database-type connector and JDBC driver.
+The default distribution includes MySQL, PostgreSQL, Oracle, SQL Server, and openGauss database-type connectors, plus MySQL, PostgreSQL, and openGauss JDBC drivers.
+For Oracle, SQL Server, or another target whose JDBC driver is not packaged, add the matching driver jar under `plugins/`; a driver alone does not add an unsupported database type.
+The database objects users can see and the governance tasks they can perform depend on the connection target.
 
 ### Connecting to a ShardingSphere-Proxy logical database
 

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/performance/MCPPerformanceBudgetSmokeTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/performance/MCPPerformanceBudgetSmokeTest.java
@@ -23,7 +23,9 @@ import org.apache.shardingsphere.mcp.core.completion.handler.WorkflowPlanIdCompl
 import org.apache.shardingsphere.mcp.core.context.MCPFeatureRuntimeRequestContext;
 import org.apache.shardingsphere.mcp.core.context.MCPRuntimeContext;
 import org.apache.shardingsphere.mcp.core.resource.ResourceTestDataFactory;
+import org.apache.shardingsphere.mcp.core.resource.ResourceTestDataFactory.DatabaseMetadataFixture;
 import org.apache.shardingsphere.mcp.core.resource.ResourceTestDataFactory.RequestContextFixture;
+import org.apache.shardingsphere.mcp.core.resource.ResourceTestDataFactory.TableMetadataFixture;
 import org.apache.shardingsphere.mcp.core.resource.handler.capability.ServerCapabilitiesHandler;
 import org.apache.shardingsphere.mcp.core.tool.handler.metadata.SearchMetadataToolHandler;
 import org.apache.shardingsphere.mcp.core.workflow.InMemoryWorkflowSessionStore;
@@ -40,6 +42,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowPlanPayloadBuilder;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -66,7 +69,9 @@ class MCPPerformanceBudgetSmokeTest {
     
     private static final int REQUEST_CONTEXT_ITERATIONS = 200;
     
-    private static final int METADATA_SEARCH_ITERATIONS = 100;
+    private static final int METADATA_SEARCH_ITERATIONS = 20;
+    
+    private static final int METADATA_SEARCH_TABLE_COUNT = 1000;
     
     private static final int WORKFLOW_PLAN_PAYLOAD_ITERATIONS = 1000;
     
@@ -100,19 +105,31 @@ class MCPPerformanceBudgetSmokeTest {
     
     @Test
     void assertMetadataSearchBudget() {
-        MCPRuntimeContext runtimeContext = ResourceTestDataFactory.createRuntimeContext();
-        try (RequestContextFixture requestContextFixture = ResourceTestDataFactory.createRequestContextFixture(runtimeContext, ResourceTestDataFactory.createDatabaseMetadata())) {
+        List<DatabaseMetadataFixture> databaseMetadata = createMetadataSearchScaleFixture();
+        MCPRuntimeContext runtimeContext = ResourceTestDataFactory.createRuntimeContext(databaseMetadata);
+        try (RequestContextFixture requestContextFixture = ResourceTestDataFactory.createRequestContextFixture(runtimeContext, databaseMetadata)) {
             MCPFeatureRuntimeRequestContext requestContext = requestContextFixture.getRequestContext();
             SearchMetadataToolHandler handler = new SearchMetadataToolHandler();
-            Map<String, Object> arguments = Map.of("query", "order", "object_types", List.of("table"));
+            Map<String, Object> arguments = Map.of(
+                    "database", "scale_db", "schema", "public", "query", "target", "object_types", List.of("table"));
             assertDoesNotThrow(() -> handler.handle(requestContext, arguments));
             long elapsedMillis = measureElapsedMillis(() -> {
                 for (int i = 0; i < METADATA_SEARCH_ITERATIONS; i++) {
                     handler.handle(requestContext, arguments).toPayload();
                 }
             });
-            assertWithinBudget("metadata search", elapsedMillis, METADATA_SEARCH_BUDGET_MILLIS);
+            assertWithinBudget(String.format("metadata search across %d tables", METADATA_SEARCH_TABLE_COUNT), elapsedMillis, METADATA_SEARCH_BUDGET_MILLIS);
         }
+    }
+    
+    private List<DatabaseMetadataFixture> createMetadataSearchScaleFixture() {
+        List<TableMetadataFixture> tables = new LinkedList<>();
+        for (int index = 0; index < METADATA_SEARCH_TABLE_COUNT - 1; index++) {
+            tables.add(ResourceTestDataFactory.createTable("metadata_table_" + index, List.of("id"), List.of()));
+        }
+        tables.add(ResourceTestDataFactory.createTable("target_table", List.of("id"), List.of()));
+        return List.of(ResourceTestDataFactory.createDatabase("scale_db", "MySQL", "", List.of(
+                ResourceTestDataFactory.createSchema("public", tables, List.of(), List.of()))));
     }
     
     @Test

--- a/mcp/features/broadcast/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-broadcast.yaml
+++ b/mcp/features/broadcast/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-broadcast.yaml
@@ -371,7 +371,7 @@ tools:
       readOnlyHint: false
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
     runtime:
       workflowRole: plan
     meta:

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowPlanningServiceTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowPlanningServiceTest.java
@@ -66,6 +66,33 @@ class BroadcastWorkflowPlanningServiceTest {
     }
     
     @Test
+    void assertPlanClarifiesMissingDatabase() {
+        BroadcastWorkflowRequest request = createRequest("create", "t_order");
+        request.setDatabase("");
+        WorkflowContextSnapshot actual = createService().plan(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.DATABASE_REQUIRED));
+    }
+    
+    @Test
+    void assertPlanRejectsUnsupportedDatabaseIdentifier() {
+        BroadcastWorkflowRequest request = createRequest("create", "t_order");
+        request.setDatabase("bad`database");
+        WorkflowContextSnapshot actual = createService().plan(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.UNSUPPORTED_IDENTIFIER));
+    }
+    
+    @Test
+    void assertPlanSingleTableInput() {
+        BroadcastWorkflowRequest request = createRequest("create", "");
+        request.setTable("t_order");
+        WorkflowContextSnapshot actual = createService().plan(new TestWorkflowSessionContext(), mockQueryFacade(List.of()), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE BROADCAST TABLE RULE `t_order`"));
+    }
+    
+    @Test
     void assertPlanRejectsTableAndTablesTogether() {
         BroadcastWorkflowRequest request = createRequest("create", "t_order,t_order_item");
         request.setTable("t_customer");
@@ -107,6 +134,29 @@ class BroadcastWorkflowPlanningServiceTest {
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
         assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.DROP_TARGET_RULE_NOT_FOUND));
         assertFalse(actual.getRuleArtifacts().iterator().hasNext());
+    }
+    
+    @Test
+    void assertPlanDropChecksRemainingTablesAfterMismatch() {
+        MCPFeatureQueryFacade queryFacade = mockQueryFacade(List.of(Map.of("broadcast_table", "t_order")));
+        WorkflowContextSnapshot actual = createService().plan(new TestWorkflowSessionContext(), queryFacade, createRequest("drop", "t_order_item,t_order"));
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().size(), is(1));
+    }
+    
+    @Test
+    void assertPlanContinuesPreviousTableList() {
+        TestWorkflowSessionContext sessionContext = new TestWorkflowSessionContext();
+        BroadcastWorkflowRequest previousRequest = createRequest("create", "t_order");
+        WorkflowContextSnapshot previousSnapshot = new WorkflowContextSnapshot();
+        previousSnapshot.setPlanId("plan-1");
+        previousSnapshot.setRequest(previousRequest);
+        sessionContext.save(previousSnapshot);
+        BroadcastWorkflowRequest request = new BroadcastWorkflowRequest();
+        request.setPlanId("plan-1");
+        WorkflowContextSnapshot actual = createService().plan(sessionContext, mockQueryFacade(List.of()), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getRequest().getTable(), is("t_order"));
     }
     
     @Test

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmRecommendationService.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmRecommendationService.java
@@ -140,12 +140,6 @@ public final class EncryptAlgorithmRecommendationService {
                     "Choose an available assisted-query algorithm.", false, Map.of()));
             return "";
         }
-        if (isKnownUnsupported(algorithmType, EncryptFeatureDefinition.ALGORITHM_CAPABILITY_EQUIVALENT_FILTER)) {
-            addSpecifiedCapabilityConflictIssue(issues,
-                    String.format("Assisted-query algorithm `%s` does not support equivalent filtering.", algorithmType),
-                    "Choose an assisted-query algorithm that supports equivalent filtering.");
-            return "";
-        }
         return algorithmType;
     }
     
@@ -229,12 +223,7 @@ public final class EncryptAlgorithmRecommendationService {
     }
     
     private String createEncryptRisk(final Map<String, Boolean> capability) {
-        if (null == capability.get(EncryptFeatureDefinition.ALGORITHM_CAPABILITY_DECRYPT)
-                || null == capability.get(EncryptFeatureDefinition.ALGORITHM_CAPABILITY_EQUIVALENT_FILTER)
-                || null == capability.get(EncryptFeatureDefinition.ALGORITHM_CAPABILITY_LIKE)) {
-            return "Capability is discoverable from plugins but not fully confirmed.";
-        }
-        return "";
+        return capability.containsValue(null) ? "Capability is discoverable from plugins but not fully confirmed." : "";
     }
     
 }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmRecommendationServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmRecommendationServiceTest.java
@@ -72,6 +72,23 @@ class EncryptAlgorithmRecommendationServiceTest {
     }
     
     @Test
+    void assertRecommendEncryptAlgorithmsWithoutAvailableAlgorithm() {
+        List<WorkflowIssue> issues = new LinkedList<>();
+        List<AlgorithmCandidate> actual = service.recommendEncryptAlgorithms(new EncryptWorkflowRequest(), List.of(), issues);
+        assertTrue(actual.isEmpty());
+        assertTrue(issues.isEmpty());
+    }
+    
+    @Test
+    void assertRecommendEncryptAlgorithmsFallsBackToFirstAvailableAlgorithm() {
+        List<WorkflowIssue> issues = new LinkedList<>();
+        List<AlgorithmCandidate> actual = service.recommendEncryptAlgorithms(
+                new EncryptWorkflowRequest(), List.of(createAlgorithmRow("FPE", null, null, null)), issues);
+        assertThat(actual.getFirst().getAlgorithmType(), is("FPE"));
+        assertTrue(issues.isEmpty());
+    }
+    
+    @Test
     void assertRecommendEncryptAlgorithmsWithMissingAssistedQueryAlgorithm() {
         EncryptWorkflowRequest request = new EncryptWorkflowRequest();
         request.getOptions().setRequiresEqualityFilter(true);
@@ -80,6 +97,44 @@ class EncryptAlgorithmRecommendationServiceTest {
         assertThat(actual.size(), is(1));
         assertThat(actual.getFirst().getAlgorithmType(), is("AES"));
         assertThat(issues.getFirst().getCode(), is(WorkflowIssueCode.ALGORITHM_CAPABILITY_CONFLICT));
+    }
+    
+    @Test
+    void assertRecommendEncryptAlgorithmsWithDefaultAssistedQueryAlgorithm() {
+        EncryptWorkflowRequest request = new EncryptWorkflowRequest();
+        request.getOptions().setRequiresEqualityFilter(true);
+        List<WorkflowIssue> issues = new LinkedList<>();
+        List<AlgorithmCandidate> actual = service.recommendEncryptAlgorithms(request, List.of(
+                createAlgorithmRow("AES", true, true, false), createAlgorithmRow("MD5", false, true, false)), issues);
+        assertThat(actual.size(), is(2));
+        assertThat(actual.get(1).getAlgorithmRole(), is("assisted_query"));
+        assertThat(actual.get(1).getAlgorithmType(), is("MD5"));
+        assertTrue(issues.isEmpty());
+    }
+    
+    @Test
+    void assertRecommendEncryptAlgorithmsWithSpecifiedAssistedQueryAlgorithm() {
+        EncryptWorkflowRequest request = new EncryptWorkflowRequest();
+        request.getOptions().setRequiresEqualityFilter(true);
+        request.getOptions().setAssistedQueryAlgorithmType("CUSTOM_HASH");
+        List<WorkflowIssue> issues = new LinkedList<>();
+        List<AlgorithmCandidate> actual = service.recommendEncryptAlgorithms(request, List.of(
+                createAlgorithmRow("AES", true, true, false), createAlgorithmRow("CUSTOM_HASH", null, true, false)), issues);
+        assertThat(actual.size(), is(2));
+        assertThat(actual.get(1).getAlgorithmType(), is("CUSTOM_HASH"));
+        assertTrue(issues.isEmpty());
+    }
+    
+    @Test
+    void assertRecommendEncryptAlgorithmsRejectsUnavailableSpecifiedAssistedQueryAlgorithm() {
+        EncryptWorkflowRequest request = new EncryptWorkflowRequest();
+        request.getOptions().setRequiresEqualityFilter(true);
+        request.getOptions().setAssistedQueryAlgorithmType("MD5");
+        List<WorkflowIssue> issues = new LinkedList<>();
+        List<AlgorithmCandidate> actual = service.recommendEncryptAlgorithms(request, List.of(createAlgorithmRow("AES", true, true, false)), issues);
+        assertThat(actual.size(), is(1));
+        assertThat(issues.size(), is(1));
+        assertThat(issues.getFirst().getCode(), is(WorkflowIssueCode.ALGORITHM_NOT_FOUND));
     }
     
     @Test
@@ -117,6 +172,42 @@ class EncryptAlgorithmRecommendationServiceTest {
         List<AlgorithmCandidate> actual = service.recommendEncryptAlgorithms(request, List.of(createAlgorithmRow("AES", true, true, false)), issues);
         assertThat(actual.size(), is(1));
         assertThat(issues.getFirst().getCode(), is(WorkflowIssueCode.ALGORITHM_CAPABILITY_CONFLICT));
+    }
+    
+    @Test
+    void assertRecommendEncryptAlgorithmsWithoutLikeCapableAlgorithm() {
+        EncryptWorkflowRequest request = new EncryptWorkflowRequest();
+        request.getOptions().setRequiresLikeQuery(true);
+        List<WorkflowIssue> issues = new LinkedList<>();
+        List<AlgorithmCandidate> actual = service.recommendEncryptAlgorithms(request, List.of(createAlgorithmRow("AES", true, true, false)), issues);
+        assertThat(actual.size(), is(1));
+        assertThat(issues.getFirst().getCode(), is(WorkflowIssueCode.ALGORITHM_CAPABILITY_CONFLICT));
+    }
+    
+    @Test
+    void assertRecommendEncryptAlgorithmsRejectsUnavailableSpecifiedLikeAlgorithm() {
+        EncryptWorkflowRequest request = new EncryptWorkflowRequest();
+        request.getOptions().setRequiresLikeQuery(true);
+        request.getOptions().setLikeQueryAlgorithmType("FPE");
+        List<WorkflowIssue> issues = new LinkedList<>();
+        List<AlgorithmCandidate> actual = service.recommendEncryptAlgorithms(request, List.of(createAlgorithmRow("AES", true, true, false)), issues);
+        assertThat(actual.size(), is(1));
+        assertThat(issues.size(), is(1));
+        assertThat(issues.getFirst().getCode(), is(WorkflowIssueCode.ALGORITHM_NOT_FOUND));
+    }
+    
+    @Test
+    void assertRecommendEncryptAlgorithmsWithSpecifiedUnconfirmedLikeAlgorithm() {
+        EncryptWorkflowRequest request = new EncryptWorkflowRequest();
+        request.getOptions().setRequiresLikeQuery(true);
+        request.getOptions().setLikeQueryAlgorithmType("FPE");
+        List<WorkflowIssue> issues = new LinkedList<>();
+        List<AlgorithmCandidate> actual = service.recommendEncryptAlgorithms(request, List.of(
+                createAlgorithmRow("AES", true, true, false), createAlgorithmRow("FPE", null, null, true)), issues);
+        assertThat(actual.size(), is(2));
+        assertThat(actual.get(1).getAlgorithmType(), is("FPE"));
+        assertThat(actual.get(1).getRecommendationScore(), is(70));
+        assertTrue(issues.isEmpty());
     }
     
     private Map<String, Object> createAlgorithmRow(final String type, final Boolean decrypt, final Boolean equivalentFilter, final Boolean like) {

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationServiceTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationServiceTest.java
@@ -123,12 +123,30 @@ class MaskWorkflowValidationServiceTest {
     }
     
     @Test
+    void assertValidateApplyArtifactsWithAvailableMaskAlgorithm() {
+        WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
+        WorkflowRequest request = new WorkflowRequest();
+        request.setAlgorithmType("MASK_FROM_X_TO_Y");
+        snapshot.setRequest(request);
+        typedSPILoader.when(() -> TypedSPILoader.checkService(MaskAlgorithm.class, "MASK_FROM_X_TO_Y",
+                WorkflowAlgorithmUtils.createProperties(request.getPrimaryAlgorithmProperties()))).thenAnswer(invocation -> null);
+        assertTrue(new MaskWorkflowValidationService().validate(
+                snapshot, List.of(createRuleDistSQLArtifact("CREATE MASK RULE `orders`"))).isEmpty());
+    }
+    
+    @Test
     void assertValidateApplyArtifactsIgnoresDropMaskRule() {
         WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
         WorkflowRequest request = new WorkflowRequest();
         request.setAlgorithmType("MASK_FROM_X_TO_Y");
         snapshot.setRequest(request);
         assertTrue(new MaskWorkflowValidationService().validate(snapshot, List.of(createRuleDistSQLArtifact("DROP MASK RULE `orders`"))).isEmpty());
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsWithoutRequest() {
+        assertTrue(new MaskWorkflowValidationService().validate(
+                new WorkflowContextSnapshot(), List.of(createRuleDistSQLArtifact("CREATE MASK RULE `orders`"))).isEmpty());
     }
     
     @Test
@@ -158,6 +176,19 @@ class MaskWorkflowValidationServiceTest {
     }
     
     @Test
+    void assertValidateDropWorkflowWhenRuleRemains() {
+        WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "drop");
+        workflowSessionContext.save(snapshot);
+        MaskRuleInspectionService ruleInspectionService = mock(MaskRuleInspectionService.class);
+        when(ruleInspectionService.queryMaskRules(any(), any(), any())).thenReturn(List.of(Map.of("column", "phone", "algorithm_type", "MD5")));
+        Map<String, Object> actual = createService(ruleInspectionService)
+                .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+        assertThat(actual.get("status"), is("failed"));
+        assertThat(getValidationSection(actual, "rule").get("details"), is("Mask rule still exists."));
+    }
+    
+    @Test
     void assertValidateWhenAlgorithmMismatch() {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create");
@@ -182,6 +213,64 @@ class MaskWorkflowValidationServiceTest {
                 .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
         assertThat(((Map<?, ?>) ((List<?>) actual.get("mismatches")).getFirst()).get("code"), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @Test
+    void assertValidateRuleWithSecretReference() {
+        WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create");
+        snapshot.getRequest().setAlgorithmType("MASK_FROM_X_TO_Y");
+        snapshot.getRequest().getPrimaryAlgorithmSecretReferences().put("replace-char", SecretReferenceValue.create());
+        workflowSessionContext.save(snapshot);
+        MaskRuleInspectionService ruleInspectionService = mock(MaskRuleInspectionService.class);
+        when(ruleInspectionService.queryMaskRules(any(), any(), any())).thenReturn(List.of(Map.of("column", "phone", "algorithm_type", "MASK_FROM_X_TO_Y")));
+        Map<String, Object> actual = createService(ruleInspectionService)
+                .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+        assertThat(actual.get("status"), is("validated"));
+        assertTrue(String.valueOf(getValidationSection(actual, "rule").get("details")).contains("sensitive properties"));
+    }
+    
+    @Test
+    void assertValidateExpectedState() {
+        WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create");
+        snapshot.setFeatureData(new RuleWorkflowFeatureData(List.of(), List.of(Map.of("column", "phone", "algorithm_type", "MD5"))));
+        workflowSessionContext.save(snapshot);
+        MaskRuleInspectionService ruleInspectionService = mock(MaskRuleInspectionService.class);
+        when(ruleInspectionService.queryMaskRules(any(), any(), any())).thenReturn(List.of(Map.of("column", "phone", "algorithm_type", "MD5")));
+        Map<String, Object> actual = createService(ruleInspectionService)
+                .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+        assertThat(actual.get("status"), is("validated"));
+        assertThat(getValidationSection(actual, "rule").get("details"), is("Mask table rule state matches the planned state."));
+    }
+    
+    @Test
+    void assertValidateExpectedStateDetectsUnexpectedRule() {
+        WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create");
+        snapshot.setFeatureData(new RuleWorkflowFeatureData(List.of(), List.of(Map.of("column", "phone", "algorithm_type", "MD5"))));
+        workflowSessionContext.save(snapshot);
+        MaskRuleInspectionService ruleInspectionService = mock(MaskRuleInspectionService.class);
+        when(ruleInspectionService.queryMaskRules(any(), any(), any())).thenReturn(List.of(
+                Map.of("column", "phone", "algorithm_type", "MD5"), Map.of("column", "email", "algorithm_type", "MD5")));
+        Map<String, Object> actual = createService(ruleInspectionService)
+                .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+        assertThat(actual.get("status"), is("failed"));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("mismatches")).getFirst()).get("actual"), is("column=email"));
+    }
+    
+    @Test
+    void assertValidateExpectedStateDetectsAlgorithmMismatch() {
+        WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create");
+        snapshot.setFeatureData(new RuleWorkflowFeatureData(List.of(), List.of(Map.of("column", "phone", "algorithm_type", "MD5"))));
+        workflowSessionContext.save(snapshot);
+        MaskRuleInspectionService ruleInspectionService = mock(MaskRuleInspectionService.class);
+        when(ruleInspectionService.queryMaskRules(any(), any(), any())).thenReturn(List.of(Map.of("column", "phone", "algorithm_type", "MASK_FROM_X_TO_Y")));
+        Map<String, Object> actual = createService(ruleInspectionService)
+                .validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+        assertThat(actual.get("status"), is("failed"));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("mismatches")).getFirst()).get("expected"), is("algorithm_type=MD5"));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingRuleWorkflowPlanningService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingRuleWorkflowPlanningService.java
@@ -126,7 +126,7 @@ public final class ReadwriteSplittingRuleWorkflowPlanningService {
         }
         addMissingInputs(request, clarifiedIntent, snapshot);
         if (WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(request.getOperationType())) {
-            return !request.getDatabase().isEmpty() && !request.getRuleName().isEmpty();
+            return !request.getRuleName().isEmpty();
         }
         return !request.getRuleName().isEmpty() && !request.getWriteStorageUnit().isEmpty() && !request.getReadStorageUnits().isEmpty()
                 && !request.getTransactionalReadQueryStrategy().isEmpty();

--- a/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
+++ b/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
@@ -545,7 +545,7 @@ tools:
       readOnlyHint: false
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
     runtime:
       workflowRole: plan
     meta:
@@ -663,7 +663,7 @@ tools:
       readOnlyHint: false
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
     runtime:
       workflowRole: plan
     meta:

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowPlanningServicesTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowPlanningServicesTest.java
@@ -27,9 +27,13 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -89,6 +93,17 @@ class ReadwriteSplittingWorkflowPlanningServicesTest {
     }
     
     @Test
+    void assertPlanCreateRuleRejectsUnavailableLoadBalancer() {
+        ReadwriteSplittingRuleWorkflowRequest request = createRuleRequest("create");
+        request.setLoadBalancerType("UNAVAILABLE");
+        MCPFeatureQueryFacade queryFacade = mockRuleQueryFacade(List.of());
+        when(queryFacade.queryWithAnyDatabase("SHOW LOAD BALANCE ALGORITHM PLUGINS")).thenReturn(List.of(Map.of("type", "RANDOM")));
+        WorkflowContextSnapshot actual = createRuleService().plan(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.ALGORITHM_NOT_FOUND));
+    }
+    
+    @Test
     void assertPlanAlterRule() {
         WorkflowContextSnapshot actual =
                 createRuleService().plan(new TestWorkflowSessionContext(), mockRuleQueryFacade(List.of(Map.of("name", "readwrite_ds"))), createRuleRequest("alter"));
@@ -108,12 +123,29 @@ class ReadwriteSplittingWorkflowPlanningServicesTest {
     }
     
     @Test
-    void assertPlanClarifiesMissingStorageUnits() {
+    void assertPlanDropClarifiesMissingRule() {
+        ReadwriteSplittingRuleWorkflowRequest request = new ReadwriteSplittingRuleWorkflowRequest();
+        request.setDatabase("logic_db");
+        request.setOperationType("drop");
+        WorkflowContextSnapshot actual = createRuleService().plan(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getDetails().get("missing_inputs"), is(List.of("rule")));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("missingRuleInputs")
+    void assertPlanClarifiesMissingRuleInputs(final String name, final String ruleName, final String writeStorageUnit,
+                                              final List<String> readStorageUnits, final String strategy, final List<String> expectedMissingInputs) {
         ReadwriteSplittingRuleWorkflowRequest request = createRuleRequest("create");
-        request.setWriteStorageUnit("");
+        request.setRuleName(ruleName);
+        request.setWriteStorageUnit(writeStorageUnit);
+        request.getReadStorageUnits().clear();
+        request.setReadStorageUnits(readStorageUnits);
+        request.setTransactionalReadQueryStrategy(strategy);
         WorkflowContextSnapshot actual = createRuleService().plan(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
         assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_INPUT_REQUIRED));
+        assertThat(actual.getIssues().getFirst().getDetails().get("missing_inputs"), is(expectedMissingInputs));
     }
     
     @Test
@@ -136,9 +168,30 @@ class ReadwriteSplittingWorkflowPlanningServicesTest {
     }
     
     @Test
-    void assertPlanFailsForUnsupportedIdentifier() {
+    void assertPlanAlterFailsWhenRuleDoesNotExist() {
+        WorkflowContextSnapshot actual = createRuleService().plan(new TestWorkflowSessionContext(), mockRuleQueryFacade(List.of()), createRuleRequest("alter"));
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @Test
+    void assertPlanClarifiesMissingDatabase() {
         ReadwriteSplittingRuleWorkflowRequest request = createRuleRequest("create");
-        request.setRuleName("bad`rule");
+        request.setDatabase("");
+        WorkflowContextSnapshot actual = createRuleService().plan(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.DATABASE_REQUIRED));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unsupportedIdentifiers")
+    void assertPlanFailsForUnsupportedIdentifier(final String name, final String database, final String ruleName,
+                                                 final String writeStorageUnit, final List<String> readStorageUnits) {
+        ReadwriteSplittingRuleWorkflowRequest request = createRuleRequest("create");
+        request.setDatabase(database);
+        request.setRuleName(ruleName);
+        request.setWriteStorageUnit(writeStorageUnit);
+        request.setReadStorageUnits(readStorageUnits);
         WorkflowContextSnapshot actual = createRuleService().plan(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
         assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.UNSUPPORTED_IDENTIFIER));
@@ -196,6 +249,22 @@ class ReadwriteSplittingWorkflowPlanningServicesTest {
     
     private ReadwriteSplittingRuleWorkflowPlanningService createRuleService() {
         return new ReadwriteSplittingRuleWorkflowPlanningService();
+    }
+    
+    private static Stream<Arguments> missingRuleInputs() {
+        return Stream.of(
+                Arguments.of("missing rule", "", "write_ds", List.of("read_ds_0"), "DYNAMIC", List.of("rule")),
+                Arguments.of("missing write storage unit", "readwrite_ds", "", List.of("read_ds_0"), "DYNAMIC", List.of("write_storage_unit")),
+                Arguments.of("missing read storage units", "readwrite_ds", "write_ds", List.of(), "DYNAMIC", List.of("read_storage_units")),
+                Arguments.of("missing strategy", "readwrite_ds", "write_ds", List.of("read_ds_0"), "", List.of("transactional_read_query_strategy")));
+    }
+    
+    private static Stream<Arguments> unsupportedIdentifiers() {
+        return Stream.of(
+                Arguments.of("database", "bad`database", "readwrite_ds", "write_ds", List.of("read_ds_0")),
+                Arguments.of("rule", "logic_db", "bad`rule", "write_ds", List.of("read_ds_0")),
+                Arguments.of("write storage unit", "logic_db", "readwrite_ds", "bad`write", List.of("read_ds_0")),
+                Arguments.of("read storage unit", "logic_db", "readwrite_ds", "write_ds", List.of("bad`read")));
     }
     
     private ReadwriteSplittingStatusWorkflowPlanningService createStatusService() {

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningService.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningService.java
@@ -137,9 +137,6 @@ public final class ShadowWorkflowPlanningService {
         if (!ensureDefaultAlgorithmType(mergedRequest, result)) {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
         }
-        if (!isReadyForAlgorithmArtifactPlanning(mergedRequest, result)) {
-            return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_CLARIFYING, WorkflowLifecycle.STATUS_CLARIFYING);
-        }
         boolean exists = !inspectionService.queryDefaultAlgorithm(queryFacade, mergedRequest.getDatabase()).isEmpty();
         if (!planningSupport.ensureLifecycleState("Default shadow algorithm", result.getClarifiedIntent(), exists, result)) {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
@@ -288,7 +285,7 @@ public final class ShadowWorkflowPlanningService {
     }
     
     private void addMissingInput(final Collection<String> missingInputs, final String value, final String fieldName) {
-        if (null == value || value.trim().isEmpty()) {
+        if (value.trim().isEmpty()) {
             missingInputs.add(fieldName);
         }
     }

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowValidationService.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowValidationService.java
@@ -145,11 +145,12 @@ public final class ShadowWorkflowValidationService implements MCPWorkflowRuntime
         ShadowRuleWorkflowRequest request = (ShadowRuleWorkflowRequest) snapshot.getRequest();
         List<Map<String, Object>> rules = inspectionService.queryRules(queryFacade, request.getDatabase());
         boolean ruleExists = containsRule(rules, queryFacade, request.getDatabase(), request.getRuleName());
-        if (WorkflowLifecycleUtils.isDropWorkflow(snapshot) && ruleExists || !WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !ruleExists) {
+        boolean dropWorkflow = WorkflowLifecycleUtils.isDropWorkflow(snapshot);
+        if (dropWorkflow == ruleExists) {
             addMismatch(validationReport, "shadow_rule", request.getRuleName(), "Shadow rule state does not match the planned DistSQL artifact.");
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, rules, "Shadow rule state does not match the planned DistSQL artifact.");
         }
-        if (!WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !validateRuleShape(rules, queryFacade, request, validationReport)) {
+        if (!dropWorkflow && !validateRuleShape(rules, queryFacade, request, validationReport)) {
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, rules, "Shadow rule shape differs from the planned DistSQL artifact.");
         }
         return new ValidationSection(WorkflowLifecycle.STATUS_PASSED, rules, "Shadow rule state matches the planned DistSQL artifact.");
@@ -160,11 +161,12 @@ public final class ShadowWorkflowValidationService implements MCPWorkflowRuntime
         ShadowDefaultAlgorithmWorkflowRequest request = (ShadowDefaultAlgorithmWorkflowRequest) snapshot.getRequest();
         List<Map<String, Object>> defaultAlgorithm = inspectionService.queryDefaultAlgorithm(queryFacade, request.getDatabase());
         boolean exists = !defaultAlgorithm.isEmpty();
-        if (WorkflowLifecycleUtils.isDropWorkflow(snapshot) && exists || !WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !exists) {
+        boolean dropWorkflow = WorkflowLifecycleUtils.isDropWorkflow(snapshot);
+        if (dropWorkflow == exists) {
             addMismatch(validationReport, "default_shadow_algorithm", request.getAlgorithmType(), "Default shadow algorithm state does not match the planned DistSQL artifact.");
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, defaultAlgorithm, "Default shadow algorithm state does not match the planned DistSQL artifact.");
         }
-        if (!WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !matchesDefaultAlgorithm(defaultAlgorithm, request)) {
+        if (!dropWorkflow && !matchesDefaultAlgorithm(defaultAlgorithm, request)) {
             addMismatch(validationReport, "default_shadow_algorithm", request.getAlgorithmType(), "Default shadow algorithm type or properties differ from the planned artifact.");
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, defaultAlgorithm, "Default shadow algorithm configuration differs from the planned artifact.");
         }

--- a/mcp/features/shadow/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-shadow.yaml
+++ b/mcp/features/shadow/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-shadow.yaml
@@ -449,23 +449,30 @@ tools:
           properties:
             rule:
               type: string
+              description: "Shadow rule name extracted from the user request."
             source_storage_unit:
               type: string
+              description: "Source storage unit extracted from the user request."
             shadow_storage_unit:
               type: string
+              description: "Shadow storage unit extracted from the user request."
             table:
               type: string
+              description: "Logical table extracted from the user request."
             algorithm_type:
               type: string
+              description: "Shadow algorithm type extracted from the user request."
           required: []
           additionalProperties: false
         delivery_mode:
           type: string
+          description: "Preferred delivery mode for the generated workflow plan."
           enum:
             - all-at-once
             - step-by-step
         execution_mode:
           type: string
+          description: "Preferred apply mode recorded in the workflow plan."
           enum:
             - review-then-execute
             - manual-only
@@ -619,7 +626,7 @@ tools:
       title: Plan Shadow Rule
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
       readOnlyHint: false
     runtime:
       workflowRole: plan
@@ -650,8 +657,10 @@ tools:
           description: "Existing workflow plan identifier used only to continue the same shadow.default workflow kind. Omit when starting a new plan; never use placeholder values such as `plan_id`."
         database:
           type: string
+          description: "ShardingSphere logical database that owns the default shadow algorithm."
         operation_type:
           type: string
+          description: "Default shadow algorithm lifecycle operation."
           enum:
             - create
             - alter
@@ -663,26 +672,32 @@ tools:
           description: "Default shadow algorithm type. ShardingSphere requires SQL_HINT."
         algorithm_properties:
           type: object
+          description: "Default shadow algorithm properties."
           additionalProperties:
             type: string
         natural_language_intent:
           type: string
+          description: "User request in natural language."
         structured_intent_evidence:
           type: object
+          description: "Default shadow algorithm intent extracted from the user request."
           properties:
             algorithm_type:
               type: string
+              description: "Default shadow algorithm type extracted from the user request."
               enum:
                 - SQL_HINT
           required: []
           additionalProperties: false
         delivery_mode:
           type: string
+          description: "Preferred delivery mode for the generated workflow plan."
           enum:
             - all-at-once
             - step-by-step
         execution_mode:
           type: string
+          description: "Preferred apply mode recorded in the workflow plan."
           enum:
             - review-then-execute
             - manual-only
@@ -715,7 +730,7 @@ tools:
       title: Plan Default Shadow Algorithm
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
       readOnlyHint: false
     runtime:
       workflowRole: plan
@@ -745,24 +760,31 @@ tools:
           description: "Existing workflow plan identifier used only to continue the same shadow.cleanup workflow kind. Omit when starting a new plan; never use placeholder values such as `plan_id`."
         database:
           type: string
+          description: "ShardingSphere logical database that owns the shadow algorithm."
         algorithm_name:
           type: string
+          description: "Unused shadow algorithm to remove."
         natural_language_intent:
           type: string
+          description: "User request in natural language."
         structured_intent_evidence:
           type: object
+          description: "Shadow algorithm cleanup intent extracted from the user request."
           properties:
             algorithm_name:
               type: string
+              description: "Shadow algorithm name extracted from the user request."
           required: []
           additionalProperties: false
         delivery_mode:
           type: string
+          description: "Preferred delivery mode for the generated workflow plan."
           enum:
             - all-at-once
             - step-by-step
         execution_mode:
           type: string
+          description: "Preferred apply mode recorded in the workflow plan."
           enum:
             - review-then-execute
             - manual-only
@@ -795,7 +817,7 @@ tools:
       title: Plan Shadow Algorithm Cleanup
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
       readOnlyHint: false
     runtime:
       workflowRole: plan

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningServiceTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningServiceTest.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.mcp.feature.shadow.tool.model.ShadowDefaultAlgo
 import org.apache.shardingsphere.mcp.feature.shadow.tool.model.ShadowRuleWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
 import org.junit.jupiter.api.AfterEach;
@@ -83,6 +84,88 @@ class ShadowWorkflowPlanningServiceTest {
     }
     
     @Test
+    void assertPlanRuleWithoutDatabase() {
+        ShadowRuleWorkflowRequest request = createRuleRequest();
+        request.setDatabase("");
+        WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService().planRule(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.DATABASE_REQUIRED));
+    }
+    
+    @Test
+    void assertPlanRuleWithUnsupportedIdentifier() {
+        ShadowRuleWorkflowRequest request = createRuleRequest();
+        request.setTableName("bad`table");
+        WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService().planRule(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.UNSUPPORTED_IDENTIFIER));
+    }
+    
+    @Test
+    void assertPlanRuleWithUnsupportedDatabaseIdentifier() {
+        ShadowRuleWorkflowRequest request = createRuleRequest();
+        request.setDatabase("bad`database");
+        WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService().planRule(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.UNSUPPORTED_IDENTIFIER));
+    }
+    
+    @Test
+    void assertPlanRuleWithoutRuleName() {
+        ShadowRuleWorkflowRequest request = createRuleRequest();
+        request.setRuleName("");
+        WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService().planRule(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getDetails().get("missing_inputs"), is(List.of("rule")));
+    }
+    
+    @Test
+    void assertPlanRuleWhenCreateTargetExists() {
+        ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
+        ShadowInspectionService inspectionService = getInspectionService();
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "shadow_rule", "shadow_rule")).thenReturn(true);
+        when(inspectionService.queryRules(queryFacade, "logic_db")).thenReturn(List.of(Map.of("rule_name", "shadow_rule")));
+        WorkflowContextSnapshot actual = service.planRule(new TestWorkflowSessionContext(), queryFacade, createRuleRequest());
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @Test
+    void assertPlanRuleDrop() {
+        ShadowRuleWorkflowRequest request = new ShadowRuleWorkflowRequest();
+        request.setDatabase("logic_db");
+        request.setRuleName("shadow_rule");
+        request.setOperationType("drop");
+        ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
+        ShadowInspectionService inspectionService = getInspectionService();
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "shadow_rule", "shadow_rule")).thenReturn(true);
+        when(inspectionService.queryRules(queryFacade, "logic_db")).thenReturn(List.of(Map.of("rule_name", "shadow_rule")));
+        WorkflowContextSnapshot actual = service.planRule(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP SHADOW RULE `shadow_rule`"));
+    }
+    
+    @Test
+    void assertPlanRuleAlter() {
+        ShadowRuleWorkflowRequest request = createRuleRequest();
+        request.setOperationType("alter");
+        ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
+        ShadowInspectionService inspectionService = getInspectionService();
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "shadow_rule", "shadow_rule")).thenReturn(true);
+        when(inspectionService.queryRules(queryFacade, "logic_db")).thenReturn(List.of(Map.of("rule_name", "shadow_rule")));
+        WorkflowContextSnapshot actual = service.planRule(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("ALTER SHADOW RULE `shadow_rule`"));
+    }
+    
+    @Test
     void assertPlanRuleWithDefaultSqlHintRecommendation() {
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         ShadowRuleWorkflowRequest request = createRuleRequest();
@@ -109,6 +192,68 @@ class ShadowWorkflowPlanningServiceTest {
         when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of(Map.of("shadow_algorithm_name", "default_shadow_algorithm")));
         WorkflowContextSnapshot actual = service.planDefaultAlgorithm(new TestWorkflowSessionContext(), queryFacade, request);
         assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP DEFAULT SHADOW ALGORITHM"));
+    }
+    
+    @Test
+    void assertPlanDefaultAlgorithmCreate() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        ShadowDefaultAlgorithmWorkflowRequest request = createDefaultAlgorithmRequest();
+        ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
+        ShadowInspectionService inspectionService = getInspectionService();
+        when(inspectionService.queryAlgorithmPlugins(queryFacade)).thenReturn(List.of(Map.of("type", "SQL_HINT")));
+        when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of());
+        WorkflowContextSnapshot actual = service.planDefaultAlgorithm(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("CREATE DEFAULT SHADOW ALGORITHM"));
+    }
+    
+    @Test
+    void assertPlanDefaultAlgorithmWithoutDatabase() {
+        ShadowDefaultAlgorithmWorkflowRequest request = createDefaultAlgorithmRequest();
+        request.setDatabase("");
+        WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService().planDefaultAlgorithm(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.DATABASE_REQUIRED));
+    }
+    
+    @Test
+    void assertPlanDefaultAlgorithmWithoutAlgorithmType() {
+        ShadowDefaultAlgorithmWorkflowRequest request = createDefaultAlgorithmRequest();
+        request.setAlgorithmType("");
+        WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService().planDefaultAlgorithm(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        WorkflowIssue actualIssue = actual.getIssues().stream()
+                .filter(each -> WorkflowIssueCode.RULE_INPUT_REQUIRED.equals(each.getCode())).findFirst().orElseThrow();
+        assertThat(actualIssue.getDetails().get("missing_inputs"), is(List.of("algorithm_type")));
+    }
+    
+    @Test
+    void assertPlanDefaultAlgorithmWhenCreateTargetExists() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        ShadowDefaultAlgorithmWorkflowRequest request = createDefaultAlgorithmRequest();
+        ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
+        ShadowInspectionService inspectionService = getInspectionService();
+        when(inspectionService.queryAlgorithmPlugins(queryFacade)).thenReturn(List.of(Map.of("type", "SQL_HINT")));
+        when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of(Map.of("shadow_algorithm_name", "default_shadow_algorithm")));
+        WorkflowContextSnapshot actual = service.planDefaultAlgorithm(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @Test
+    void assertPlanDefaultAlgorithmAlter() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        ShadowDefaultAlgorithmWorkflowRequest request = createDefaultAlgorithmRequest();
+        request.setOperationType("alter");
+        ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
+        ShadowInspectionService inspectionService = getInspectionService();
+        when(inspectionService.queryAlgorithmPlugins(queryFacade)).thenReturn(List.of(Map.of("type", "SQL_HINT")));
+        when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of(Map.of("shadow_algorithm_name", "default_shadow_algorithm")));
+        WorkflowContextSnapshot actual = service.planDefaultAlgorithm(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("ALTER DEFAULT SHADOW ALGORITHM"));
     }
     
     @Test
@@ -147,10 +292,67 @@ class ShadowWorkflowPlanningServiceTest {
         when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "unused_algorithm", "unused_algorithm")).thenReturn(true);
         ShadowAlgorithmCleanupWorkflowRequest request = createCleanupRequest();
         when(inspectionService.queryAlgorithms(queryFacade, "logic_db")).thenReturn(List.of(Map.of("shadow_algorithm_name", "unused_algorithm")));
-        when(inspectionService.queryTableRules(queryFacade, "logic_db")).thenReturn(List.of(Map.of("shadow_algorithm_name", "unused_algorithm")));
+        when(inspectionService.queryTableRules(queryFacade, "logic_db")).thenReturn(List.of(Map.of("shadow_algorithm_name", "other_algorithm, , unused_algorithm")));
         when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of());
         WorkflowContextSnapshot actual = service.planAlgorithmCleanup(new TestWorkflowSessionContext(), queryFacade, request);
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+    }
+    
+    @Test
+    void assertPlanAlgorithmCleanupWithoutName() {
+        ShadowAlgorithmCleanupWorkflowRequest request = createCleanupRequest();
+        request.setAlgorithmName("");
+        WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService().planAlgorithmCleanup(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getDetails().get("missing_inputs"), is(List.of("algorithm_name")));
+    }
+    
+    @Test
+    void assertPlanAlgorithmCleanupWithoutDatabase() {
+        ShadowAlgorithmCleanupWorkflowRequest request = createCleanupRequest();
+        request.setDatabase("");
+        WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService().planAlgorithmCleanup(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.DATABASE_REQUIRED));
+    }
+    
+    @Test
+    void assertPlanAlgorithmCleanupRejectsUnsupportedName() {
+        ShadowAlgorithmCleanupWorkflowRequest request = createCleanupRequest();
+        request.setAlgorithmName("unused_algorithm\ndrop");
+        WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService().planAlgorithmCleanup(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.UNSUPPORTED_IDENTIFIER));
+    }
+    
+    @Test
+    void assertPlanAlgorithmCleanupWhenNotConfigured() {
+        ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
+        ShadowInspectionService inspectionService = getInspectionService();
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(inspectionService.queryAlgorithms(queryFacade, "logic_db")).thenReturn(List.of());
+        when(inspectionService.queryTableRules(queryFacade, "logic_db")).thenReturn(List.of());
+        when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of());
+        WorkflowContextSnapshot actual = service.planAlgorithmCleanup(new TestWorkflowSessionContext(), queryFacade, createCleanupRequest());
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @Test
+    void assertPlanAlgorithmCleanupWhenDefaultReferenced() {
+        ShadowWorkflowPlanningService service = new ShadowWorkflowPlanningService();
+        ShadowInspectionService inspectionService = getInspectionService();
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "unused_algorithm", "unused_algorithm")).thenReturn(true);
+        when(inspectionService.queryAlgorithms(queryFacade, "logic_db")).thenReturn(List.of(Map.of("shadow_algorithm_name", "unused_algorithm")));
+        when(inspectionService.queryTableRules(queryFacade, "logic_db")).thenReturn(List.of());
+        when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of(Map.of("shadow_algorithm_name", "unused_algorithm")));
+        WorkflowContextSnapshot actual = service.planAlgorithmCleanup(new TestWorkflowSessionContext(), queryFacade, createCleanupRequest());
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
     }
     
     private ShadowInspectionService getInspectionService() {
@@ -173,6 +375,13 @@ class ShadowWorkflowPlanningServiceTest {
         ShadowAlgorithmCleanupWorkflowRequest result = new ShadowAlgorithmCleanupWorkflowRequest();
         result.setDatabase("logic_db");
         result.setAlgorithmName("unused_algorithm");
+        return result;
+    }
+    
+    private ShadowDefaultAlgorithmWorkflowRequest createDefaultAlgorithmRequest() {
+        ShadowDefaultAlgorithmWorkflowRequest result = new ShadowDefaultAlgorithmWorkflowRequest();
+        result.setDatabase("logic_db");
+        result.setAlgorithmType("SQL_HINT");
         return result;
     }
 }

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowValidationServiceTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowValidationServiceTest.java
@@ -53,6 +53,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.withSettings;
 import static org.mockito.Mockito.when;
 
@@ -105,6 +106,44 @@ class ShadowWorkflowValidationServiceTest {
         assertThat(actualMismatch.get("actual"), is("2"));
     }
     
+    @Test
+    void assertValidateRuleWhenMissing() {
+        ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
+        MCPFeatureQueryFacade queryFacade = createRuleQueryFacade();
+        when(inspectionService.queryRules(queryFacade, "logic_db")).thenReturn(List.of());
+        Map<String, Object> actual = createService(inspectionService)
+                .validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade,
+                        mock(MCPFeatureExecutionFacade.class), "session-1", createRuleSnapshot());
+        assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(((Map<?, ?>) ((List<?>) actual.get("mismatches")).getFirst()).get("layer"), is("shadow_rule"));
+    }
+    
+    @Test
+    void assertValidateRuleDrop() {
+        ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
+        MCPFeatureQueryFacade queryFacade = createRuleQueryFacade();
+        when(inspectionService.queryRules(queryFacade, "logic_db")).thenReturn(List.of());
+        WorkflowContextSnapshot snapshot = createRuleSnapshot();
+        snapshot.getClarifiedIntent().setOperationType(WorkflowLifecycle.OPERATION_DROP);
+        Map<String, Object> actual = createService(inspectionService)
+                .validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade,
+                        mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+        assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_VALIDATED));
+    }
+    
+    @Test
+    void assertValidateRuleDropWhenRuleRemains() {
+        ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
+        MCPFeatureQueryFacade queryFacade = createRuleQueryFacade();
+        when(inspectionService.queryRules(queryFacade, "logic_db")).thenReturn(List.of(createRuleRow(Map.of())));
+        WorkflowContextSnapshot snapshot = createRuleSnapshot();
+        snapshot.getClarifiedIntent().setOperationType(WorkflowLifecycle.OPERATION_DROP);
+        Map<String, Object> actual = createService(inspectionService)
+                .validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade,
+                        mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+        assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_FAILED));
+    }
+    
     @ParameterizedTest(name = "{0}")
     @MethodSource("mismatchedRuleShapes")
     void assertValidateRuleReportsMismatchedShape(final String name, final String fieldName, final String actualValue, final String expectedLayer) {
@@ -135,6 +174,33 @@ class ShadowWorkflowValidationServiceTest {
     }
     
     @Test
+    void assertValidateDefaultAlgorithmRejectsDifferentType() {
+        ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
+        request.setDatabase("logic_db");
+        request.setAlgorithmType("SQL_HINT");
+        ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of(Map.of("type", "VALUE_MATCH")));
+        Map<String, Object> actual = createService(inspectionService).validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade,
+                mock(MCPFeatureExecutionFacade.class), "session-1", createSnapshot(request, "create"));
+        assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_FAILED));
+    }
+    
+    @Test
+    void assertValidateDefaultAlgorithmRejectsDuplicateRows() {
+        ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
+        request.setDatabase("logic_db");
+        request.setAlgorithmType("SQL_HINT");
+        ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        Map<String, Object> row = Map.of("type", "SQL_HINT", "props", Map.of());
+        when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of(row, row));
+        Map<String, Object> actual = createService(inspectionService).validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade,
+                mock(MCPFeatureExecutionFacade.class), "session-1", createSnapshot(request, "create"));
+        assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_FAILED));
+    }
+    
+    @Test
     void assertValidateDefaultAlgorithm() {
         ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
         request.setDatabase("logic_db");
@@ -149,6 +215,30 @@ class ShadowWorkflowValidationServiceTest {
     }
     
     @Test
+    void assertValidateDefaultAlgorithmDrop() {
+        ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
+        request.setDatabase("logic_db");
+        ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of());
+        Map<String, Object> actual = createService(inspectionService).validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade,
+                mock(MCPFeatureExecutionFacade.class), "session-1", createSnapshot(request, WorkflowLifecycle.OPERATION_DROP));
+        assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_VALIDATED));
+    }
+    
+    @Test
+    void assertValidateDefaultAlgorithmDropWhenAlgorithmRemains() {
+        ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
+        request.setDatabase("logic_db");
+        ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of(Map.of("type", "SQL_HINT")));
+        Map<String, Object> actual = createService(inspectionService).validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade,
+                mock(MCPFeatureExecutionFacade.class), "session-1", createSnapshot(request, WorkflowLifecycle.OPERATION_DROP));
+        assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_FAILED));
+    }
+    
+    @Test
     void assertValidateCleanupFailure() {
         ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
@@ -157,6 +247,17 @@ class ShadowWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(inspectionService)
                 .validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade, mock(MCPFeatureExecutionFacade.class), "session-1", createCleanupSnapshot());
         assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_FAILED));
+    }
+    
+    @Test
+    void assertValidateCleanup() {
+        ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(inspectionService.queryAlgorithms(queryFacade, "logic_db")).thenReturn(List.of());
+        Map<String, Object> actual = createService(inspectionService)
+                .validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade,
+                        mock(MCPFeatureExecutionFacade.class), "session-1", createCleanupSnapshot());
+        assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_VALIDATED));
     }
     
     @Test
@@ -187,6 +288,52 @@ class ShadowWorkflowValidationServiceTest {
             assertThat(actual.getFirst().get("message"), is("Generated shadow DistSQL references algorithm `SQL_HINT`, "
                     + "but it cannot be loaded or initialized by ShadowAlgorithm SPI."));
         }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsAcceptsAvailableDefaultAlgorithm() {
+        ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
+        request.setAlgorithmType("SQL_HINT");
+        WorkflowContextSnapshot snapshot = createSnapshot(request, "create");
+        try (MockedStatic<TypedSPILoader> ignored = mockStatic(TypedSPILoader.class)) {
+            assertThat(new ShadowWorkflowValidationService().validate(snapshot,
+                    List.of(createRuleDistSQLArtifact("CREATE DEFAULT SHADOW ALGORITHM TYPE(NAME='sql_hint')"))).size(), is(0));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsWithoutRuleAlgorithm() {
+        WorkflowContextSnapshot snapshot = createRuleSnapshot();
+        ((ShadowRuleWorkflowRequest) snapshot.getRequest()).setAlgorithmType("");
+        assertThat(new ShadowWorkflowValidationService().validate(
+                snapshot, List.of(createRuleDistSQLArtifact("ALTER SHADOW RULE `shadow_rule`(...)"))).size(), is(0));
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsWithoutDefaultAlgorithm() {
+        ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
+        WorkflowContextSnapshot snapshot = createSnapshot(request, "create");
+        assertThat(new ShadowWorkflowValidationService().validate(
+                snapshot, List.of(createRuleDistSQLArtifact("ALTER DEFAULT SHADOW ALGORITHM TYPE(NAME='sql_hint')"))).size(), is(0));
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsIgnoresCleanupArtifact() {
+        assertThat(new ShadowWorkflowValidationService().validate(
+                createCleanupSnapshot(), List.of(createRuleDistSQLArtifact("DROP SHADOW ALGORITHM `unused_algorithm`"))).size(), is(0));
+    }
+    
+    @Test
+    void assertSynchronize() {
+        ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
+        MCPFeatureQueryFacade queryFacade = createRuleQueryFacade();
+        when(inspectionService.queryRules(queryFacade, "logic_db")).thenReturn(List.of(createRuleRow(
+                Map.of("operation", "INSERT", "column", "shadow", "value", "true"))));
+        MCPMetadataQueryFacade metadataQueryFacade = mock(MCPMetadataQueryFacade.class);
+        MCPFeatureExecutionFacade executionFacade = mock(MCPFeatureExecutionFacade.class);
+        createService(inspectionService).synchronize(createRuleSnapshot(), metadataQueryFacade, queryFacade, executionFacade, "session-1");
+        verifyNoInteractions(metadataQueryFacade);
+        verifyNoInteractions(executionFacade);
     }
     
     private ShadowWorkflowValidationService createService(final ShadowInspectionService inspectionService) {

--- a/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
+++ b/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
@@ -897,7 +897,7 @@ tools:
       title: Plan Sharding Table Rule
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
       readOnlyHint: false
     runtime: &planningRuntime
       workflowRole: plan
@@ -939,7 +939,7 @@ tools:
       title: Plan Sharding Table Reference Rule
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
       readOnlyHint: false
     runtime: *planningRuntime
     meta:
@@ -980,7 +980,7 @@ tools:
       title: Plan Sharding Default Strategy
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
       readOnlyHint: false
     runtime: *planningRuntime
     meta:
@@ -1019,7 +1019,7 @@ tools:
       title: Plan Sharding Key Generator
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
       readOnlyHint: false
     runtime: *planningRuntime
     meta:
@@ -1062,7 +1062,7 @@ tools:
       title: Plan Sharding Key Generate Strategy
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
       readOnlyHint: false
     runtime: *planningRuntime
     meta:
@@ -1101,7 +1101,7 @@ tools:
       title: Plan Sharding Rule Component Cleanup
       destructiveHint: false
       idempotentHint: false
-      openWorldHint: false
+      openWorldHint: true
       readOnlyHint: false
     runtime: *planningRuntime
     meta:

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.TestWorkflowSessionContext;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
@@ -33,13 +34,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,6 +75,14 @@ class ShardingWorkflowPlanningServiceTest {
     }
     
     @Test
+    void assertPlanTableRule() {
+        WorkflowContextSnapshot actual = planningService.planTableRule(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of()), createTableRuleRequest());
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_0.t_order'))"));
+    }
+    
+    @Test
     void assertPlanTableReferenceRuleClarifiesMissingInputs() {
         ShardingWorkflowRequest request = createDatabaseRequest();
         WorkflowContextSnapshot actual = planningService.planTableReferenceRule(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
@@ -93,12 +102,91 @@ class ShardingWorkflowPlanningServiceTest {
     }
     
     @Test
+    void assertPlanTableReferenceRule() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setRuleName("order_reference");
+        request.getReferenceTables().addAll(List.of("t_order", "t_order_item"));
+        WorkflowContextSnapshot actual = planningService.planTableReferenceRule(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of()), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE REFERENCE RULE `order_reference`(`t_order`, `t_order_item`)"));
+    }
+    
+    @Test
+    void assertPlanTableReferenceRuleRejectsExistingRule() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setRuleName("order_reference");
+        request.getReferenceTables().addAll(List.of("t_order", "t_order_item"));
+        WorkflowContextSnapshot actual = planningService.planTableReferenceRule(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of(Map.of("name", "order_reference"))), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @Test
     void assertPlanDefaultStrategyClarifiesMissingInputs() {
         ShardingWorkflowRequest request = createDatabaseRequest();
         WorkflowContextSnapshot actual = planningService.planDefaultStrategy(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
         assertThat(actual.getWorkflowKind().getValue(), is("sharding.default.strategy"));
         assertThat(actual.getClarifiedIntent().getClarificationMessages(), is(List.of("Please provide DATABASE or TABLE default strategy type.")));
         assertThat(WorkflowPlanPayloadBuilder.build(actual).get("missing_required_inputs"), is(List.of("default_strategy_type")));
+    }
+    
+    @Test
+    void assertPlanDefaultStrategy() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setDefaultStrategyType("DATABASE");
+        request.setStrategyType("none");
+        WorkflowContextSnapshot actual = planningService.planDefaultStrategy(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of()), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE DEFAULT SHARDING DATABASE STRATEGY (TYPE='none')"));
+    }
+    
+    @Test
+    void assertPlanDefaultStrategyRejectsExistingStrategy() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setDefaultStrategyType("DATABASE");
+        request.setStrategyType("none");
+        MCPFeatureQueryFacade queryFacade = createQueryFacade(List.of(Map.of("name", "DATABASE", "type", "NONE")));
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "DATABASE", "DATABASE")).thenReturn(true);
+        WorkflowContextSnapshot actual = planningService.planDefaultStrategy(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @Test
+    void assertPlanDefaultStrategyIgnoresIncompleteState() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setDefaultStrategyType("DATABASE");
+        request.setStrategyType("none");
+        MCPFeatureQueryFacade queryFacade = createQueryFacade(List.of(Map.of("name", "DATABASE", "type", "")));
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "DATABASE", "DATABASE")).thenReturn(true);
+        WorkflowContextSnapshot actual = planningService.planDefaultStrategy(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+    }
+    
+    @Test
+    void assertPlanDefaultStrategyIgnoresDifferentStrategy() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setDefaultStrategyType("DATABASE");
+        request.setStrategyType("none");
+        WorkflowContextSnapshot actual = planningService.planDefaultStrategy(new TestWorkflowSessionContext(),
+                createQueryFacade(List.of(Map.of("name", "TABLE", "type", "NONE"))), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+    }
+    
+    @Test
+    void assertPlanDefaultStrategyClarifiesMissingAlgorithmProperties() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setDefaultStrategyType("DATABASE");
+        request.setStrategyType("standard");
+        request.setColumn("order_id");
+        request.setAlgorithmType("INLINE");
+        WorkflowContextSnapshot actual = planningService.planDefaultStrategy(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of()), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.REQUIRED_PROPERTY_MISSING));
     }
     
     @Test
@@ -111,6 +199,28 @@ class ShardingWorkflowPlanningServiceTest {
     }
     
     @Test
+    void assertPlanKeyGenerator() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setKeyGeneratorName("snowflake_generator");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        WorkflowContextSnapshot actual = planningService.planKeyGenerator(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of()), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING KEY GENERATOR `snowflake_generator`(TYPE(NAME='snowflake'))"));
+    }
+    
+    @Test
+    void assertPlanKeyGeneratorRejectsExistingGenerator() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setKeyGeneratorName("snowflake_generator");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        WorkflowContextSnapshot actual = planningService.planKeyGenerator(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of(Map.of("name", "snowflake_generator"))), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @Test
     void assertPlanKeyGenerateStrategyClarifiesMissingInputs() {
         ShardingWorkflowRequest request = createDatabaseRequest();
         WorkflowContextSnapshot actual = planningService.planKeyGenerateStrategy(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
@@ -119,16 +229,37 @@ class ShardingWorkflowPlanningServiceTest {
         assertThat(WorkflowPlanPayloadBuilder.build(actual).get("missing_required_inputs"), is(List.of("key_generate_strategy")));
     }
     
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("getTableRuleConflictCases")
-    void assertPlanTableRuleRejectsConflictingInputs(final String name, final Consumer<ShardingWorkflowRequest> requestCustomizer,
-                                                     final List<String> expectedConflictingInputs) {
+    @Test
+    void assertPlanTableRuleRejectsDataNodeAndStorageUnitInputs() {
         ShardingWorkflowRequest request = createTableRuleRequest();
-        requestCustomizer.accept(request);
-        WorkflowContextSnapshot actual = planningService.planTableRule(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
-        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
-        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_INPUT_CONFLICT));
-        assertThat(actual.getIssues().getFirst().getDetails().get("conflicting_inputs"), is(expectedConflictingInputs));
+        request.setStorageUnits("ds_0");
+        assertTableRuleInputConflict(request, List.of("data_nodes", "storage_units"));
+    }
+    
+    @Test
+    void assertPlanTableRuleRejectsComplexStrategyColumn() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setStrategyType("complex");
+        request.setColumn("order_id");
+        request.setShardingColumns("order_id,user_id");
+        request.setAlgorithmType("COMPLEX_INLINE");
+        assertTableRuleInputConflict(request, List.of("strategy_type", "column"));
+    }
+    
+    @Test
+    void assertPlanTableRuleRejectsAlgorithmWithNoneStrategy() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setAlgorithmType("INLINE");
+        assertTableRuleInputConflict(request, List.of("strategy_type", "algorithm_type"));
+    }
+    
+    @Test
+    void assertPlanTableRuleRejectsNamedAndInlineKeyGenerator() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setKeyGenerateColumn("order_id");
+        request.setKeyGeneratorName("snowflake_generator");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        assertTableRuleInputConflict(request, List.of("key_generator", "key_generator_type"));
     }
     
     @Test
@@ -199,6 +330,32 @@ class ShardingWorkflowPlanningServiceTest {
     }
     
     @Test
+    void assertPlanTableRuleWithInlineKeyGenerator() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setStrategyType("standard");
+        request.setColumn("order_id");
+        request.setAlgorithmType("INLINE");
+        request.putAlgorithmProperties(Map.of("algorithm-expression", "t_order_${order_id % 2}"));
+        request.setKeyGenerateColumn("order_id");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        WorkflowContextSnapshot actual = planningService.planTableRule(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of()), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getAlgorithmCandidates().size(), is(2));
+    }
+    
+    @Test
+    void assertPlanTableRuleWithNamedKeyGenerator() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setKeyGenerateColumn("order_id");
+        request.setKeyGeneratorName("snowflake_generator");
+        WorkflowContextSnapshot actual = planningService.planTableRule(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of()), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getAlgorithmCandidates().size(), is(0));
+    }
+    
+    @Test
     void assertPlanSequenceKeyGenerateStrategy() {
         ShardingWorkflowRequest request = createDatabaseRequest();
         request.setKeyGenerateStrategyName("order_sequence_strategy");
@@ -207,6 +364,44 @@ class ShardingWorkflowPlanningServiceTest {
         WorkflowContextSnapshot actual = planningService.planKeyGenerateStrategy(new TestWorkflowSessionContext(), createQueryFacade(List.of()), request);
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
         assertThat(actual.getWorkflowKind(), is(ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND));
+    }
+    
+    @Test
+    void assertPlanInlineKeyGenerateStrategy() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setKeyGenerateStrategyName("order_id_strategy");
+        request.setTable("t_order");
+        request.setColumn("order_id");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.query(anyString(), eq("SHOW KEY GENERATE ALGORITHM PLUGINS"))).thenReturn(List.of(Map.of("type", "SNOWFLAKE")));
+        WorkflowContextSnapshot actual = planningService.planKeyGenerateStrategy(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getAlgorithmCandidates().getFirst().getAlgorithmType(), is("SNOWFLAKE"));
+    }
+    
+    @Test
+    void assertPlanKeyGenerateStrategyRejectsExistingStrategy() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setKeyGenerateStrategyName("order_id_strategy");
+        request.setTable("t_order");
+        request.setColumn("order_id");
+        request.setKeyGeneratorName("snowflake_generator");
+        WorkflowContextSnapshot actual = planningService.planKeyGenerateStrategy(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of(Map.of("name", "order_id_strategy"))), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @Test
+    void assertPlanKeyGenerateStrategyDrop() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setOperationType("drop");
+        request.setKeyGenerateStrategyName("order_id_strategy");
+        WorkflowContextSnapshot actual = planningService.planKeyGenerateStrategy(
+                new TestWorkflowSessionContext(), createQueryFacade(List.of(Map.of("name", "order_id_strategy"))), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP SHARDING KEY GENERATE STRATEGY `order_id_strategy`"));
     }
     
     @Test
@@ -227,6 +422,14 @@ class ShardingWorkflowPlanningServiceTest {
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
         assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_INPUT_REQUIRED));
         assertThat(WorkflowPlanPayloadBuilder.build(actual).get("missing_required_inputs"), is(List.of("component_type")));
+    }
+    
+    @Test
+    void assertPlanComponentCleanupClarifiesMissingDatabase() {
+        WorkflowContextSnapshot actual = planningService.planComponentCleanup(
+                new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), new ShardingWorkflowRequest());
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_CLARIFYING));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.DATABASE_REQUIRED));
     }
     
     @Test
@@ -275,6 +478,35 @@ class ShardingWorkflowPlanningServiceTest {
         assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
     }
     
+    @Test
+    void assertPlanComponentCleanupRejectsUsedComponent() {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setComponentType("algorithm");
+        request.setComponentName("inline_algorithm");
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.query(anyString(), anyString())).thenAnswer(invocation -> ((String) invocation.getArgument(1)).startsWith("SHOW UNUSED")
+                ? List.of(Map.of("name", "inline_algorithm"))
+                : List.of(Map.of("type", "table", "name", "t_order")));
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "inline_algorithm", "inline_algorithm")).thenReturn(true);
+        WorkflowContextSnapshot actual = planningService.planComponentCleanup(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("componentCleanupCases")
+    void assertPlanComponentCleanup(final String name, final String componentType, final String componentName, final String expectedSQL) {
+        ShardingWorkflowRequest request = createDatabaseRequest();
+        request.setComponentType(componentType);
+        request.setComponentName(componentName);
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.query(anyString(), anyString())).thenAnswer(invocation -> ((String) invocation.getArgument(1)).startsWith("SHOW UNUSED") ? List.of(Map.of("name", componentName)) : List.of());
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, componentName, componentName)).thenReturn(true);
+        WorkflowContextSnapshot actual = planningService.planComponentCleanup(new TestWorkflowSessionContext(), queryFacade, request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is(expectedSQL));
+    }
+    
     private ShardingWorkflowRequest createDatabaseRequest() {
         ShardingWorkflowRequest result = new ShardingWorkflowRequest();
         result.setDatabase("logic_db");
@@ -295,23 +527,18 @@ class ShardingWorkflowPlanningServiceTest {
         return result;
     }
     
-    private static Stream<Arguments> getTableRuleConflictCases() {
+    private void assertTableRuleInputConflict(final ShardingWorkflowRequest request, final List<String> expectedConflictingInputs) {
+        WorkflowContextSnapshot actual = planningService.planTableRule(new TestWorkflowSessionContext(), mock(MCPFeatureQueryFacade.class), request);
+        assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_FAILED));
+        assertThat(actual.getIssues().getFirst().getCode(), is(WorkflowIssueCode.RULE_INPUT_CONFLICT));
+        assertThat(actual.getIssues().getFirst().getDetails().get("conflicting_inputs"), is(expectedConflictingInputs));
+    }
+    
+    private static Stream<Arguments> componentCleanupCases() {
         return Stream.of(
-                Arguments.of("data nodes and storage units", (Consumer<ShardingWorkflowRequest>) request -> request.setStorageUnits("ds_0"),
-                        List.of("data_nodes", "storage_units")),
-                Arguments.of("complex strategy with column", (Consumer<ShardingWorkflowRequest>) request -> {
-                    request.setStrategyType("complex");
-                    request.setColumn("order_id");
-                    request.setShardingColumns("order_id,user_id");
-                    request.setAlgorithmType("COMPLEX_INLINE");
-                }, List.of("strategy_type", "column")),
-                Arguments.of("none strategy with algorithm", (Consumer<ShardingWorkflowRequest>) request -> request.setAlgorithmType("INLINE"),
-                        List.of("strategy_type", "algorithm_type")),
-                Arguments.of("named and inline key generator", (Consumer<ShardingWorkflowRequest>) request -> {
-                    request.setKeyGenerateColumn("order_id");
-                    request.setKeyGeneratorName("snowflake_generator");
-                    request.setKeyGeneratorType("SNOWFLAKE");
-                }, List.of("key_generator", "key_generator_type")));
+                Arguments.of("algorithm", "algorithm", "inline_algorithm", "DROP SHARDING ALGORITHM `inline_algorithm`"),
+                Arguments.of("key generator", "key-generator", "snowflake_generator", "DROP SHARDING KEY GENERATOR `snowflake_generator`"),
+                Arguments.of("auditor", "auditor", "dml_auditor", "DROP SHARDING AUDITOR `dml_auditor`"));
     }
     
     private void assertRuleDistSQLOnlyPayloadDoesNotExpose(final WorkflowContextSnapshot snapshot, final String term) {

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationServiceTest.java
@@ -37,12 +37,17 @@ import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowAlgorithmU
 import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
 import org.apache.shardingsphere.sharding.spi.ShardingAuditAlgorithm;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.AdditionalAnswers;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -164,6 +169,108 @@ class ShardingWorkflowValidationServiceTest {
     }
     
     @Test
+    void assertValidateApplyArtifactsRejectsUnavailableDefaultStrategyAlgorithm() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
+                ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND, request);
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(ShardingAlgorithm.class, "INLINE",
+                    WorkflowAlgorithmUtils.createProperties(request.getPrimaryAlgorithmProperties()))).thenThrow(new IllegalArgumentException("unavailable"));
+            List<Map<String, Object>> actual = new ShardingWorkflowValidationService().validate(
+                    snapshot, List.of(createRuleDistSQLArtifact("CREATE DEFAULT SHARDING TABLE STRATEGY(TYPE='standard')")));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("code"), is(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsRejectsUnavailableInlineKeyGenerator() {
+        ShardingWorkflowRequest request = new ShardingWorkflowRequest();
+        request.setKeyGeneratorType("SNOWFLAKE");
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
+                ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND, request);
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(KeyGenerateAlgorithm.class, "SNOWFLAKE",
+                    WorkflowAlgorithmUtils.createProperties(request.getKeyGeneratorProperties()))).thenThrow(new IllegalArgumentException("unavailable"));
+            List<Map<String, Object>> actual = new ShardingWorkflowValidationService().validate(
+                    snapshot, List.of(createRuleDistSQLArtifact("CREATE SHARDING KEY GENERATE STRATEGY `order_id_strategy`(...)")));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("code"), is(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsWithoutShardingRequest() {
+        assertThat(new ShardingWorkflowValidationService().validate(
+                new WorkflowContextSnapshot(), List.of(createRuleDistSQLArtifact("CREATE SHARDING TABLE RULE `t_order`(...)"))).size(), is(0));
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsIgnoresDropArtifact() {
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "drop",
+                ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, createTableRuleRequest());
+        assertThat(new ShardingWorkflowValidationService().validate(
+                snapshot, List.of(createRuleDistSQLArtifact("DROP SHARDING TABLE RULE `t_order`"))).size(), is(0));
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsAcceptsAvailableAlgorithms() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setStorageUnits("ds_0");
+        request.setKeyGenerateColumn("order_id");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        request.getAuditorNames().add("DML_SHARDING_CONDITIONS");
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
+                ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, request);
+        try (MockedStatic<TypedSPILoader> ignored = mockStatic(TypedSPILoader.class)) {
+            assertThat(new ShardingWorkflowValidationService().validate(
+                    snapshot, List.of(createRuleDistSQLArtifact("CREATE SHARDING TABLE RULE `t_order`(...)"))).size(), is(0));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsAcceptsNamedKeyGenerator() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setKeyGenerateColumn("order_id");
+        request.setKeyGeneratorName("snowflake_generator");
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
+                ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, request);
+        try (MockedStatic<TypedSPILoader> ignored = mockStatic(TypedSPILoader.class)) {
+            assertThat(new ShardingWorkflowValidationService().validate(
+                    snapshot, List.of(createRuleDistSQLArtifact("CREATE SHARDING TABLE RULE `t_order`(...)"))).size(), is(0));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsAcceptsTableReferenceRule() {
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
+                ShardingFeatureDefinition.TABLE_REFERENCE_WORKFLOW_KIND, createReferenceRuleRequest());
+        assertThat(new ShardingWorkflowValidationService().validate(snapshot,
+                List.of(createRuleDistSQLArtifact("CREATE SHARDING TABLE REFERENCE RULE `ref_rule`(...)"))).size(), is(0));
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsIgnoresEmptyAlgorithmTypes() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setStrategyType("");
+        request.setAlgorithmType("");
+        request.setKeyGenerateColumn("order_id");
+        request.getAuditorNames().add("");
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
+                ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, request);
+        assertThat(new ShardingWorkflowValidationService().validate(
+                snapshot, List.of(createRuleDistSQLArtifact("CREATE SHARDING TABLE RULE `t_order`(...)"))).size(), is(0));
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsIgnoresEmptyKeyGeneratorType() {
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
+                ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND, new ShardingWorkflowRequest());
+        assertThat(new ShardingWorkflowValidationService().validate(
+                snapshot, List.of(createRuleDistSQLArtifact("CREATE SHARDING KEY GENERATOR `generator`(TYPE(NAME=''))"))).size(), is(0));
+    }
+    
+    @Test
     void assertValidateTableRuleMismatch() {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
@@ -227,6 +334,230 @@ class ShardingWorkflowValidationServiceTest {
     }
     
     @Test
+    void assertValidateTableRuleWithInlineKeyGeneratorAndAuditor() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setKeyGenerateColumn("order_id");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        request.putKeyGeneratorProperties(Map.of("worker-id", "1"));
+        request.getAuditorNames().add("DML_SHARDING_CONDITIONS");
+        request.setAllowHintDisable("true");
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
+                ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, request);
+        WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
+        workflowSessionContext.save(snapshot);
+        Map<String, Object> row = new LinkedHashMap<>(createTableRuleRowWithKeyGenerator());
+        row.put("key_generator_type", "SNOWFLAKE");
+        row.put("key_generator_props", Map.of("worker-id", "1"));
+        row.put("auditor_types", "DML_SHARDING_CONDITIONS");
+        row.put("allow_hint_disable", "true");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(row));
+        Map<String, Object> actual = createService(inspectionService).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class),
+                createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+        assertThat(actual.get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateTableRuleDrop() {
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of());
+        assertThat(validateState("drop", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                createTableRuleRequest(), inspectionService, createQueryFacade()).get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateTableRuleDropWhenRuleRemains() {
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(createTableRuleRow(
+                "ds_0.t_order_0,ds_1.t_order_1", Map.of("algorithm-expression", "t_order_${order_id % 2}"), "")));
+        assertThat(validateState("drop", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                createTableRuleRequest(), inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateAutomaticTableRule() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDataNodes("");
+        request.setStorageUnits("ds_0,ds_1");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(Map.of(
+                "table", "t_order", "actual_data_sources", "ds_0,ds_1", "table_strategy_type", "STANDARD",
+                "table_sharding_column", "order_id", "table_sharding_algorithm_type", "INLINE",
+                "table_sharding_algorithm_props", Map.of("algorithm-expression", "t_order_${order_id % 2}"), "key_generate_column", "")));
+        MCPFeatureQueryFacade queryFacade = createQueryFacade();
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "ds_0", "ds_0")).thenReturn(true);
+        when(queryFacade.isSameIdentifier("logic_db", IdentifierScope.TABLE, "ds_1", "ds_1")).thenReturn(true);
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, queryFacade).get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateTableRuleWithoutStrategy() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setStrategyType("none");
+        request.setAlgorithmType("");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(Map.of(
+                "table", "t_order", "actual_data_nodes", "ds_0.t_order_0,ds_1.t_order_1", "key_generate_column", "")));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentStrategy() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(Map.of(
+                "table", "t_order", "actual_data_nodes", "ds_0.t_order_0,ds_1.t_order_1", "table_strategy_type", "HINT",
+                "table_sharding_algorithm_type", "INLINE", "table_sharding_algorithm_props", request.getPrimaryAlgorithmProperties(), "key_generate_column", "")));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentName() {
+        Map<String, Object> row = new LinkedHashMap<>(createTableRuleRow(
+                "ds_0.t_order_0,ds_1.t_order_1", Map.of("algorithm-expression", "t_order_${order_id % 2}"), ""));
+        row.put("table", "t_other");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(row));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                createTableRuleRequest(), inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentAlgorithmType() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        Map<String, Object> row = new LinkedHashMap<>(createTableRuleRow(
+                "ds_0.t_order_0,ds_1.t_order_1", request.getPrimaryAlgorithmProperties(), ""));
+        row.put("table_sharding_algorithm_type", "MOD");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(row));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentAlgorithmProperties() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(createTableRuleRow(
+                "ds_0.t_order_0,ds_1.t_order_1", Map.of("algorithm-expression", "t_order_${user_id % 2}"), "")));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateHintTableRule() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setStrategyType("hint");
+        request.setAlgorithmType("HINT_INLINE");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(Map.of(
+                "table", "t_order", "actual_data_nodes", "ds_0.t_order_0,ds_1.t_order_1", "table_strategy_type", "HINT",
+                "table_sharding_algorithm_type", "HINT_INLINE", "table_sharding_algorithm_props", request.getPrimaryAlgorithmProperties(), "key_generate_column", "")));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentKeyGenerateColumn() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setKeyGenerateColumn("order_id");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(createTableRuleRow(
+                "ds_0.t_order_0,ds_1.t_order_1", request.getPrimaryAlgorithmProperties(), "other_id")));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentInlineKeyGenerator() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setKeyGenerateColumn("order_id");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        request.putKeyGeneratorProperties(Map.of("worker-id", "1"));
+        Map<String, Object> row = new LinkedHashMap<>(createTableRuleRowWithKeyGenerator());
+        row.put("key_generator_type", "SNOWFLAKE");
+        row.put("key_generator_props", Map.of("worker-id", "2"));
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(row));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentInlineKeyGeneratorType() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setKeyGenerateColumn("order_id");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        Map<String, Object> row = new LinkedHashMap<>(createTableRuleRowWithKeyGenerator());
+        row.put("key_generator_type", "UUID");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(row));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableRuleWithDefaultAuditorOption() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.getAuditorNames().add("DML_SHARDING_CONDITIONS");
+        Map<String, Object> row = new LinkedHashMap<>(createTableRuleRow(
+                "ds_0.t_order_0,ds_1.t_order_1", request.getPrimaryAlgorithmProperties(), ""));
+        row.put("auditor_types", "DML_SHARDING_CONDITIONS, , ");
+        row.put("allow_hint_disable", "false");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(row));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentAuditors() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.getAuditorNames().addAll(List.of("DML_SHARDING_CONDITIONS", "DML_SHARDING_CONDITIONS_2"));
+        Map<String, Object> row = new LinkedHashMap<>(createTableRuleRow(
+                "ds_0.t_order_0,ds_1.t_order_1", request.getPrimaryAlgorithmProperties(), ""));
+        row.put("auditor_types", "DML_SHARDING_CONDITIONS");
+        row.put("allow_hint_disable", "false");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(row));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentAllowHintDisable() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.getAuditorNames().add("DML_SHARDING_CONDITIONS");
+        request.setAllowHintDisable("true");
+        Map<String, Object> row = new LinkedHashMap<>(createTableRuleRow(
+                "ds_0.t_order_0,ds_1.t_order_1", request.getPrimaryAlgorithmProperties(), ""));
+        row.put("auditor_types", "DML_SHARDING_CONDITIONS");
+        row.put("allow_hint_disable", "false");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(row));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableRuleRejectsDifferentAuditorName() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.getAuditorNames().add("DML_SHARDING_CONDITIONS");
+        Map<String, Object> row = new LinkedHashMap<>(createTableRuleRow(
+                "ds_0.t_order_0,ds_1.t_order_1", request.getPrimaryAlgorithmProperties(), ""));
+        row.put("auditor_types", "OTHER_AUDITOR");
+        row.put("allow_hint_disable", "false");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableRule(any(), any(), any())).thenReturn(List.of(row));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
     void assertValidateDefaultStrategyDrop() {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         ShardingWorkflowRequest request = createTableRuleRequest();
@@ -242,16 +573,42 @@ class ShardingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertValidateCleanupHappyPath() {
+    void assertValidateDefaultStrategyDropWhenStrategyRemains() {
+        WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDefaultStrategyType("DATABASE");
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "drop",
+                ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND, request);
+        workflowSessionContext.save(snapshot);
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryDefaultStrategy(any(), any())).thenReturn(List.of(Map.of("name", "DATABASE", "type", "STANDARD")));
+        Map<String, Object> actual = createService(inspectionService).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class),
+                createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+        assertThat(actual.get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateCleanupWhenComponentRemains() {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "drop",
                 ShardingFeatureDefinition.COMPONENT_CLEANUP_WORKFLOW_KIND, createCleanupRequest());
         workflowSessionContext.save(snapshot);
         ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
-        when(inspectionService.queryAlgorithms(any(), any())).thenReturn(List.of());
+        when(inspectionService.queryAlgorithms(any(), any())).thenReturn(List.of(Map.of("name", "unused_algorithm")));
         Map<String, Object> actual = createService(inspectionService).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class),
                 createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
-        assertThat(actual.get("status"), is("validated"));
+        assertThat(actual.get("status"), is("failed"));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("cleanupComponentCases")
+    void assertValidateCleanupComponentTypes(final String name, final String componentType, final String componentName) {
+        ShardingWorkflowRequest request = createCleanupRequest();
+        request.setComponentType(componentType);
+        request.setComponentName(componentName);
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        assertThat(validateState("drop", ShardingFeatureDefinition.COMPONENT_CLEANUP_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("validated"));
     }
     
     @Test
@@ -281,6 +638,24 @@ class ShardingWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(inspectionService).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class),
                 createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableReferenceRuleRejectsDifferentName() {
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableReferenceRule(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "other_ref", "sharding_table_reference", "t_order,t_order_item")));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_REFERENCE_WORKFLOW_KIND,
+                createReferenceRuleRequest(), inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateTableReferenceRuleRejectsMissingTable() {
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryTableReferenceRule(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "ref_rule", "sharding_table_reference", "t_order")));
+        assertThat(validateState("create", ShardingFeatureDefinition.TABLE_REFERENCE_WORKFLOW_KIND,
+                createReferenceRuleRequest(), inspectionService, createQueryFacade()).get("status"), is("failed"));
     }
     
     @Test
@@ -315,6 +690,99 @@ class ShardingWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(inspectionService).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class),
                 createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateDefaultStrategyRejectsDuplicateRows() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDefaultStrategyType("DATABASE");
+        Map<String, Object> row = Map.of(
+                "name", "DATABASE", "type", "STANDARD", "sharding_column", "order_id", "sharding_algorithm_type", "INLINE",
+                "sharding_algorithm_props", request.getPrimaryAlgorithmProperties());
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryDefaultStrategy(any(), any())).thenReturn(List.of(row, row));
+        assertThat(validateState("create", ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateDefaultStrategyRejectsIncompleteState() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDefaultStrategyType("DATABASE");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryDefaultStrategy(any(), any())).thenReturn(List.of(Map.of("name", "DATABASE", "type", "")));
+        assertThat(validateState("create", ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateDefaultStrategyRejectsDifferentName() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDefaultStrategyType("DATABASE");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryDefaultStrategy(any(), any())).thenReturn(List.of(Map.of("name", "TABLE", "type", "STANDARD")));
+        assertThat(validateState("create", ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateDefaultStrategyRejectsDifferentType() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDefaultStrategyType("DATABASE");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryDefaultStrategy(any(), any())).thenReturn(List.of(Map.of("name", "DATABASE", "type", "HINT")));
+        assertThat(validateState("create", ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateHintDefaultStrategy() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDefaultStrategyType("DATABASE");
+        request.setStrategyType("hint");
+        request.setAlgorithmType("HINT_INLINE");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryDefaultStrategy(any(), any())).thenReturn(List.of(Map.of(
+                "name", "DATABASE", "type", "HINT", "sharding_algorithm_type", "HINT_INLINE",
+                "sharding_algorithm_props", request.getPrimaryAlgorithmProperties())));
+        assertThat(validateState("create", ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateDefaultStrategyRejectsDifferentAlgorithmType() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDefaultStrategyType("DATABASE");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryDefaultStrategy(any(), any())).thenReturn(List.of(Map.of(
+                "name", "DATABASE", "type", "STANDARD", "sharding_column", "order_id", "sharding_algorithm_type", "MOD",
+                "sharding_algorithm_props", request.getPrimaryAlgorithmProperties())));
+        assertThat(validateState("create", ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateDefaultStrategyWithoutSharding() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDefaultStrategyType("DATABASE");
+        request.setStrategyType("none");
+        request.setAlgorithmType("");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryDefaultStrategy(any(), any())).thenReturn(List.of(Map.of("name", "DATABASE", "type", "NONE")));
+        assertThat(validateState("create", ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateDefaultStrategyRejectsDifferentColumn() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setDefaultStrategyType("DATABASE");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryDefaultStrategy(any(), any())).thenReturn(List.of(Map.of(
+                "name", "DATABASE", "type", "STANDARD", "sharding_column", "user_id", "sharding_algorithm_type", "INLINE",
+                "sharding_algorithm_props", request.getPrimaryAlgorithmProperties())));
+        assertThat(validateState("create", ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
     }
     
     @Test
@@ -358,6 +826,34 @@ class ShardingWorkflowValidationServiceTest {
     }
     
     @Test
+    void assertValidateKeyGeneratorRejectsDifferentName() {
+        ShardingWorkflowRequest request = createKeyGeneratorRequest();
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerator(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "other_generator", "type", "SNOWFLAKE", "props", Map.of("worker-id", "1"))));
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateKeyGeneratorRejectsMissingState() {
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerator(any(), any(), any())).thenReturn(List.of());
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND,
+                createKeyGeneratorRequest(), inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateKeyGeneratorRejectsDifferentType() {
+        ShardingWorkflowRequest request = createKeyGeneratorRequest();
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerator(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "snowflake_generator", "type", "UUID", "props", Map.of("worker-id", "1"))));
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
     void assertValidateKeyGenerator() {
         ShardingWorkflowRequest request = new ShardingWorkflowRequest();
         request.setDatabase("logic_db");
@@ -394,6 +890,86 @@ class ShardingWorkflowValidationServiceTest {
         Map<String, Object> actual = createService(inspectionService).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class),
                 createQueryFacade(), mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
         assertThat(actual.get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateKeyGenerateStrategyRejectsMissingState() {
+        ShardingWorkflowRequest request = createColumnKeyGenerateStrategyRequest();
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerateStrategy(any(), any(), any())).thenReturn(List.of());
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateKeyGenerateStrategyRejectsDifferentName() {
+        ShardingWorkflowRequest request = createColumnKeyGenerateStrategyRequest();
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerateStrategy(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "other_strategy", "type", "COLUMN", "table", "t_order", "column", "order_id", "generator_name", "snowflake_generator")));
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateKeyGenerateStrategyRejectsDifferentType() {
+        ShardingWorkflowRequest request = createColumnKeyGenerateStrategyRequest();
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerateStrategy(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "order_id_strategy", "type", "SEQUENCE", "sequence", "order_seq", "generator_name", "snowflake_generator")));
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateKeyGenerateStrategyRejectsDifferentTable() {
+        ShardingWorkflowRequest request = createColumnKeyGenerateStrategyRequest();
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerateStrategy(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "order_id_strategy", "type", "COLUMN", "table", "t_other", "column", "order_id", "generator_name", "snowflake_generator")));
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateInlineKeyGenerateStrategy() {
+        ShardingWorkflowRequest request = createColumnKeyGenerateStrategyRequest();
+        request.setKeyGeneratorName("");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        request.putKeyGeneratorProperties(Map.of("worker-id", "1"));
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerateStrategy(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "order_id_strategy", "type", "COLUMN", "table", "t_order", "column", "order_id",
+                "generator_type", "SNOWFLAKE", "generator_props", Map.of("worker-id", "1"))));
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("validated"));
+    }
+    
+    @Test
+    void assertValidateInlineKeyGenerateStrategyRejectsDifferentProperties() {
+        ShardingWorkflowRequest request = createColumnKeyGenerateStrategyRequest();
+        request.setKeyGeneratorName("");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        request.putKeyGeneratorProperties(Map.of("worker-id", "1"));
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerateStrategy(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "order_id_strategy", "type", "COLUMN", "table", "t_order", "column", "order_id",
+                "generator_type", "SNOWFLAKE", "generator_props", Map.of("worker-id", "2"))));
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
+    }
+    
+    @Test
+    void assertValidateInlineKeyGenerateStrategyRejectsDifferentType() {
+        ShardingWorkflowRequest request = createColumnKeyGenerateStrategyRequest();
+        request.setKeyGeneratorName("");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
+        when(inspectionService.queryKeyGenerateStrategy(any(), any(), any())).thenReturn(List.of(Map.of(
+                "name", "order_id_strategy", "type", "COLUMN", "table", "t_order", "column", "order_id",
+                "generator_type", "UUID", "generator_props", Map.of())));
+        assertThat(validateState("create", ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
+                request, inspectionService, createQueryFacade()).get("status"), is("failed"));
     }
     
     @Test
@@ -465,6 +1041,15 @@ class ShardingWorkflowValidationServiceTest {
         }
     }
     
+    private Map<String, Object> validateState(final String operationType, final WorkflowKind workflowKind, final ShardingWorkflowRequest request,
+                                              final ShardingInspectionService inspectionService, final MCPFeatureQueryFacade queryFacade) {
+        WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", operationType, workflowKind, request);
+        workflowSessionContext.save(snapshot);
+        return createService(inspectionService).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class), queryFacade,
+                mock(MCPFeatureExecutionFacade.class), "session-1", snapshot);
+    }
+    
     private MCPFeatureQueryFacade createQueryFacade() {
         MCPFeatureQueryFacade result = mock(MCPFeatureQueryFacade.class);
         when(result.isSameIdentifier("logic_db", IdentifierScope.TABLE, "t_order", "t_order")).thenReturn(true);
@@ -526,6 +1111,25 @@ class ShardingWorkflowValidationServiceTest {
         return result;
     }
     
+    private ShardingWorkflowRequest createKeyGeneratorRequest() {
+        ShardingWorkflowRequest result = new ShardingWorkflowRequest();
+        result.setDatabase("logic_db");
+        result.setKeyGeneratorName("snowflake_generator");
+        result.setKeyGeneratorType("SNOWFLAKE");
+        result.putKeyGeneratorProperties(Map.of("worker-id", "1"));
+        return result;
+    }
+    
+    private ShardingWorkflowRequest createColumnKeyGenerateStrategyRequest() {
+        ShardingWorkflowRequest result = new ShardingWorkflowRequest();
+        result.setDatabase("logic_db");
+        result.setKeyGenerateStrategyName("order_id_strategy");
+        result.setTable("t_order");
+        result.setColumn("order_id");
+        result.setKeyGeneratorName("snowflake_generator");
+        return result;
+    }
+    
     private Map<String, Object> createTableRuleRow(final String dataNodes, final Map<String, String> algorithmProperties, final String keyGenerateColumn) {
         return Map.of(
                 "table", "t_order",
@@ -547,6 +1151,13 @@ class ShardingWorkflowValidationServiceTest {
         result.setComponentType("algorithm");
         result.setComponentName("unused_algorithm");
         return result;
+    }
+    
+    private static Stream<Arguments> cleanupComponentCases() {
+        return Stream.of(
+                Arguments.of("algorithm", "algorithm", "unused_algorithm"),
+                Arguments.of("key generator", "key-generator", "unused_generator"),
+                Arguments.of("auditor", "auditor", "unused_auditor"));
     }
     
     private ExecutableWorkflowArtifact createRuleDistSQLArtifact(final String sql) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
@@ -112,6 +112,11 @@ public final class MCPToolDescriptorCatalogValidator {
         }
         for (Entry<?, ?> entry : ((Map<?, ?>) properties).entrySet()) {
             validateInputSchemaMapField(descriptor, entry.getValue(), path + "." + entry.getKey());
+            if (entry.getValue() instanceof Map) {
+                Object description = ((Map<?, ?>) entry.getValue()).get("description");
+                MCPToolDescriptorValidationUtils.checkDescription(null == description ? "" : description.toString(),
+                        String.format("Tool `%s` inputSchema property `%s.%s` description", descriptor.getName(), path, entry.getKey()));
+            }
         }
     }
     

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
@@ -102,6 +102,16 @@ class MCPDescriptorCatalogValidatorTest {
     }
     
     @Test
+    void assertValidateRejectsMissingNestedInputDescription() {
+        assertValidationError(createCatalog(List.of(), List.of(new MCPToolDescriptor(
+                "database_gateway_test_tool", "Test Tool", "Run a test tool.",
+                createInputSchema(Map.of("intent", Map.of("type", "object", "description", "Structured intent.", "properties",
+                        Map.of("query", Map.of("type", "string"))))),
+                createOutputSchema(), createReadOnlyToolAnnotations(), Map.of()))),
+                "Tool `database_gateway_test_tool` inputSchema property `inputSchema.properties.intent.properties.query` description is required.");
+    }
+    
+    @Test
     void assertValidateRejectsUnknownRelatedResourceUri() {
         assertValidationError(createCatalog(List.of(), List.of(new MCPToolDescriptor(
                 "database_gateway_test_tool", "Test Tool", "Run a test tool.", createInputSchema(),

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationPayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationPayloadBuilderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.descriptor;
+
+import org.apache.shardingsphere.mcp.api.capability.resource.MCPResourceDescriptor;
+import org.apache.shardingsphere.mcp.api.capability.resource.MCPUriVariables;
+import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MCPResourceNavigationPayloadBuilderTest {
+    
+    @Test
+    void assertCreate() {
+        MCPResourceDescriptor descriptor = createDescriptor("shardingsphere://databases/{database}");
+        Map<String, Object> actual = MCPResourceNavigationPayloadBuilder.create(descriptor, new MCPUriVariables(Map.of("database", "foo_db")));
+        assertThat(((Map<?, ?>) actual.get(MCPPayloadFieldNames.SELF_RESOURCE)).get("uri"), is("shardingsphere://databases/foo_db"));
+        assertThat(actual.size(), is(1));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("resourceKinds")
+    void assertCreateWithParent(final String name, final String parentUriTemplate, final String expectedResourceKind) {
+        MCPResourceDescriptor descriptor = createDescriptor("shardingsphere://databases/{database}");
+        Map<String, Object> actual = MCPResourceNavigationPayloadBuilder.create(
+                descriptor, new MCPUriVariables(Map.of("database", "foo_db")), parentUriTemplate);
+        Map<?, ?> actualParent = (Map<?, ?>) actual.get(MCPPayloadFieldNames.PARENT_RESOURCE);
+        assertThat(actualParent.get("resource_kind"), is(expectedResourceKind));
+        assertThat(actualParent.get("source_field"), is(MCPPayloadFieldNames.PARENT_RESOURCE));
+    }
+    
+    @Test
+    void assertCreateWithIncompleteUriVariables() {
+        MCPResourceDescriptor descriptor = createDescriptor("shardingsphere://databases/{database}");
+        Map<String, Object> actual = MCPResourceNavigationPayloadBuilder.create(
+                descriptor, new MCPUriVariables(Map.of()), "shardingsphere://databases/{database}/rules");
+        assertThat(actual, is(Map.of()));
+    }
+    
+    private static Stream<Arguments> resourceKinds() {
+        return Stream.of(
+                Arguments.of("rule", "shardingsphere://databases/{database}/rules", "rule"),
+                Arguments.of("algorithm", "shardingsphere://databases/{database}/algorithms", "algorithm"),
+                Arguments.of("column", "shardingsphere://databases/{database}/columns", "column"),
+                Arguments.of("index", "shardingsphere://databases/{database}/indexes", "index"),
+                Arguments.of("resource", "shardingsphere://databases/{database}", "resource"));
+    }
+    
+    private MCPResourceDescriptor createDescriptor(final String uriTemplate) {
+        MCPResourceDescriptor result = mock(MCPResourceDescriptor.class);
+        when(result.getUriTemplate()).thenReturn(uriTemplate);
+        return result;
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/AutonomousMCPBuilderEvaluationRunner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/AutonomousMCPBuilderEvaluationRunner.java
@@ -43,18 +43,11 @@ public final class AutonomousMCPBuilderEvaluationRunner {
     
     private static final String SYSTEM_PROMPT = """
             You are evaluating a live ShardingSphere MCP server in a read-only task. Use the available MCP functions to inspect current state.
-            Use database_gateway_execute_query for row values, aggregates, filters, joins, and view results. Use database_gateway_search_metadata
-            only for metadata names: query is a name fragment, blank query lists the narrowed scope, schema is a namespace rather than a table name,
-            and unknown schemas should be omitted. The database argument only selects a configured logical runtime connection; never qualify SQL objects
-            with that value. A same-valued metadata namespace is not an SQL catalog or schema. Pass resource URIs only to mcp_read_resource, never as SQL.
+            Choose tools from their advertised names, descriptions, and input schemas. Pass resource URIs only to mcp_read_resource, never as SQL.
             Never guess, request a write, or stop before retrieving the requested value. Use function calls for every tool invocation rather than
             printing a tool-call object as the answer. When you have enough evidence, follow the user's exact answer format and return only the answer
             with no explanation or Markdown.
             """;
-    
-    private static final List<String> READ_ONLY_TOOL_NAMES = List.of(
-            "database_gateway_search_metadata",
-            "database_gateway_execute_query");
     
     private static final List<String> BRIDGE_TOOL_NAMES = List.of(MCPInteractionActionNames.READ_RESOURCE);
     
@@ -95,7 +88,7 @@ public final class AutonomousMCPBuilderEvaluationRunner {
         try {
             mcpInteractionClient.open();
             List<Map<String, Object>> advertisedTools = mcpInteractionClient.listTools();
-            List<Map<String, Object>> toolDefinitions = toolDefinitionFactory.createFromRemote(advertisedTools, READ_ONLY_TOOL_NAMES, BRIDGE_TOOL_NAMES);
+            List<Map<String, Object>> toolDefinitions = toolDefinitionFactory.createReadOnlyFromRemote(advertisedTools, BRIDGE_TOOL_NAMES);
             artifacts.setToolDefinitions(toolDefinitions);
             artifacts.addTrace(traceRecordFactory.createTraceRecord(artifacts.nextSequence(), MCPInteractionActionNames.LIST_TOOLS,
                     MCPInteractionTraceRecord.PROTOCOL_BRIDGE_ORIGIN, Map.of(), Map.of("tools", advertisedTools), 0L));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/AutonomousMCPBuilderEvaluationRunnerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/AutonomousMCPBuilderEvaluationRunnerTest.java
@@ -66,7 +66,8 @@ class AutonomousMCPBuilderEvaluationRunnerTest {
         assertThat(actual.evidence().interactionTrace().size(), is(2));
         assertThat(actual.evidence().interactionTrace().get(1).getActionOrigin(), is(MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN));
         assertThat(actual.evidence().toolDefinitions().stream().map(each -> LLMMCPJsonValues.castToMap(each.get("function")).get("name")).toList(),
-                is(List.of("mcp_read_resource", "database_gateway_search_metadata", "database_gateway_execute_query")));
+                is(List.of("mcp_read_resource", "database_gateway_search_metadata", "database_gateway_validate_runtime_database",
+                        "database_gateway_execute_query", "database_gateway_execute_explain_query")));
         verify(interactionClient).open();
         verify(interactionClient).close();
     }
@@ -115,6 +116,7 @@ class AutonomousMCPBuilderEvaluationRunnerTest {
         return ADVERTISED_TOOL_NAMES.stream().map(each -> Map.of(
                 "name", each,
                 "description", "Remote tool definition.",
-                "inputSchema", Map.of("type", "object", "description", "remote-marker", "properties", Map.of()))).toList();
+                "inputSchema", Map.of("type", "object", "description", "remote-marker", "properties", Map.of()),
+                "annotations", Map.of("readOnlyHint", !"database_gateway_execute_update".equals(each)))).toList();
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPToolDefinitionFactory.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPToolDefinitionFactory.java
@@ -59,6 +59,20 @@ final class LLMMCPToolDefinitionFactory {
         return result;
     }
     
+    List<Map<String, Object>> createReadOnlyFromRemote(final List<Map<String, Object>> advertisedTools, final Collection<String> bridgeToolNames) {
+        List<String> readOnlyToolNames = new LinkedList<>();
+        for (Map<String, Object> each : advertisedTools) {
+            Object annotations = each.get("annotations");
+            if (annotations instanceof Map && Boolean.TRUE.equals(((Map<?, ?>) annotations).get("readOnlyHint"))) {
+                readOnlyToolNames.add(Objects.toString(each.get("name"), "").trim());
+            }
+        }
+        if (readOnlyToolNames.isEmpty()) {
+            throw new IllegalStateException("MCP runtime did not advertise any read-only tools.");
+        }
+        return createFromRemote(advertisedTools, readOnlyToolNames, bridgeToolNames);
+    }
+    
     private Map<String, Object> createRemoteToolDefinition(final Map<String, Object> advertisedTool, final String toolName) {
         Object inputSchema = advertisedTool.get("inputSchema");
         if (!(inputSchema instanceof Map)) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPToolDefinitionFactoryTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPToolDefinitionFactoryTest.java
@@ -78,6 +78,23 @@ class LLMMCPToolDefinitionFactoryTest {
     }
     
     @Test
+    void assertReadOnlyRemoteToolDefinitionsUseAdvertisedAnnotations() {
+        List<Map<String, Object>> advertisedTools = List.of(
+                createAdvertisedTool("read_only_tool", true),
+                createAdvertisedTool("write_tool", false));
+        List<Map<String, Object>> actual = new LLMMCPToolDefinitionFactory().createReadOnlyFromRemote(
+                advertisedTools, List.of(MCPInteractionActionNames.READ_RESOURCE));
+        assertThat(getToolNames(actual), is(List.of(MCPInteractionActionNames.READ_RESOURCE, "read_only_tool")));
+    }
+    
+    @Test
+    void assertCreateReadOnlyFromRemoteWithoutReadOnlyTool() {
+        IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> new LLMMCPToolDefinitionFactory().createReadOnlyFromRemote(List.of(createAdvertisedTool("write_tool", false)), List.of()));
+        assertThat(actual.getMessage(), is("MCP runtime did not advertise any read-only tools."));
+    }
+    
+    @Test
     void assertCreateFromRemoteWithMissingRequiredTool() {
         IllegalStateException actual = assertThrows(IllegalStateException.class,
                 () -> new LLMMCPToolDefinitionFactory().createFromRemote(List.of(), List.of("read_only_tool"), List.of()));
@@ -95,6 +112,14 @@ class LLMMCPToolDefinitionFactoryTest {
     void assertCreateWithUnsupportedToolDescriptor() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> new LLMMCPToolDefinitionFactory().create(List.of("unsupported_tool")));
         assertThat(actual.getMessage(), is("Unsupported tool descriptor: unsupported_tool"));
+    }
+    
+    private Map<String, Object> createAdvertisedTool(final String toolName, final boolean readOnly) {
+        return Map.of(
+                "name", toolName,
+                "description", "Remote tool definition.",
+                "inputSchema", Map.of("type", "object", "properties", Map.of()),
+                "annotations", Map.of("readOnlyHint", readOnly));
     }
     
     private void assertOfficialToolDefinition(final Map<?, ?> toolDefinition, final MCPToolDescriptor toolDescriptor) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/evaluation/MCPBuilderEvaluationE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/evaluation/MCPBuilderEvaluationE2ETest.java
@@ -24,6 +24,8 @@ import org.apache.shardingsphere.test.e2e.mcp.llm.fixture.LLMRuntimeFixtureFacto
 import org.apache.shardingsphere.test.e2e.mcp.llm.fixture.LLMRuntimeFixtureFactory.Fixture;
 import org.apache.shardingsphere.test.e2e.mcp.llm.fixture.LLMRuntimeSupport;
 import org.apache.shardingsphere.test.e2e.mcp.llm.suite.MCPBuilderEvaluationCatalog;
+import org.apache.shardingsphere.test.e2e.mcp.llm.suite.MCPBuilderEvaluationCatalog.EvaluationCase;
+import org.apache.shardingsphere.test.e2e.mcp.llm.suite.MCPBuilderEvaluationCatalog.EvaluationSuite;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.AbstractConfigBackedRuntimeE2ETest;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.RuntimeTransport;
 import org.junit.jupiter.api.AfterAll;
@@ -34,6 +36,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.condition.EnabledIf;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 @Tag("llm-e2e")
@@ -42,6 +45,8 @@ import java.util.Map;
 class MCPBuilderEvaluationE2ETest extends AbstractConfigBackedRuntimeE2ETest {
     
     private static final String DATABASE_NAME = "logic_db";
+    
+    private static final String CASE_GROUP_PROPERTY = "mcp.e2e.llm.builder-case-group";
     
     private static LLMRuntimeSupport.ModelRuntime llmRuntime;
     
@@ -79,7 +84,25 @@ class MCPBuilderEvaluationE2ETest extends AbstractConfigBackedRuntimeE2ETest {
         prepareRuntimeFixture();
         LLMRuntimeSupport.ModelRuntime modelRuntime = getRequiredLLMRuntime();
         new MCPBuilderEvaluationSuiteRunner(modelRuntime.getConfiguration(), modelRuntime.getEvidence())
-                .assertFullScore(new MCPBuilderEvaluationCatalog().load(), this::createInteractionClient);
+                .assertFullScore(selectEvaluationCases(new MCPBuilderEvaluationCatalog().load()), this::createInteractionClient);
+    }
+    
+    private EvaluationSuite selectEvaluationCases(final EvaluationSuite evaluationSuite) {
+        String caseGroup = System.getProperty(CASE_GROUP_PROPERTY, "all");
+        if ("all".equals(caseGroup)) {
+            return evaluationSuite;
+        }
+        List<EvaluationCase> cases = evaluationSuite.cases();
+        int midpoint = cases.size() / 2;
+        List<EvaluationCase> selectedCases;
+        if ("first".equals(caseGroup)) {
+            selectedCases = cases.subList(0, midpoint);
+        } else if ("second".equals(caseGroup)) {
+            selectedCases = cases.subList(midpoint, cases.size());
+        } else {
+            throw new IllegalArgumentException("Unsupported MCP Builder evaluation case group: " + caseGroup);
+        }
+        return new EvaluationSuite(evaluationSuite.standardReference(), evaluationSuite.operationMode(), evaluationSuite.requiresExternalModel(), selectedCases);
     }
     
     @Override

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/evaluation/MCPBuilderEvaluationSuiteRunner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/evaluation/MCPBuilderEvaluationSuiteRunner.java
@@ -83,7 +83,7 @@ final class MCPBuilderEvaluationSuiteRunner {
         Path scorecardFile = configuration.createArtifactDirectory("mcp-builder-evaluation").resolve("scorecard.json");
         artifactWriter.writeScorecard(scorecardFile, results);
         assertArtifactsSecure(artifactDirectories, scorecardFile);
-        assertAllPassed(results);
+        assertAllPassed(results, evaluationSuite.cases().size());
     }
     
     private void assertArtifactsSecure(final List<Path> artifactDirectories, final Path scorecardFile) throws IOException {
@@ -106,9 +106,11 @@ final class MCPBuilderEvaluationSuiteRunner {
         }
     }
     
-    private void assertAllPassed(final List<EvaluationResult> results) {
+    private void assertAllPassed(final List<EvaluationResult> results, final int expectedCaseCount) {
         String failureSummary = createFailureSummary(results);
-        assertTrue(results.size() == 10, () -> "MCP Builder evaluation must execute exactly 10 cases, but executed " + results.size());
+        assertFalse(results.isEmpty(), "MCP Builder evaluation must execute at least one case.");
+        assertTrue(results.size() == expectedCaseCount,
+                () -> String.format("MCP Builder evaluation expected %d cases, but executed %d.", expectedCaseCount, results.size()));
         assertTrue(results.stream().allMatch(each -> each.assertionReport().isSuccess()), failureSummary);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteE2ETest.java
@@ -58,6 +58,8 @@ class LLMUsabilitySuiteE2ETest extends AbstractConfigBackedRuntimeE2ETest {
     
     private static final String FULL_TRANSPORT_MATRIX_PROPERTY = "mcp.e2e.llm.full-transport-matrix";
     
+    private static final String SUITE_PART_PROPERTY = "mcp.e2e.llm.usability-suite";
+    
     private static LLMRuntimeSupport.ModelRuntime llmRuntime;
     
     private final LLMRuntimeFixtureFactory runtimeFixtureFactory = new LLMRuntimeFixtureFactory();
@@ -119,14 +121,22 @@ class LLMUsabilitySuiteE2ETest extends AbstractConfigBackedRuntimeE2ETest {
         LLMConversationExecutor conversationExecutor = new LLMConversationExecutor(getRequiredLLMConfiguration(), getRequiredLLMRuntimeEvidence());
         conversationExecutor.assertModelReady();
         prepareRuntimeFixture();
-        suiteRunner.assertSuite(suiteId + "/core",
-                this::createCoreScenarios,
-                each -> conversationExecutor.runConversation(suiteId + "/core/" + each.getScenarioId(), each, createInteractionClient()),
-                conversationExecutor.getConfiguration());
-        suiteRunner.assertSuite(suiteId + "/extended",
-                this::createExtendedScenarios,
-                each -> conversationExecutor.runConversation(suiteId + "/extended/" + each.getScenarioId(), each, createInteractionClient()),
-                conversationExecutor.getConfiguration());
+        String suitePart = System.getProperty(SUITE_PART_PROPERTY, "all");
+        if ("all".equals(suitePart) || "core".equals(suitePart)) {
+            suiteRunner.assertSuite(suiteId + "/core",
+                    this::createCoreScenarios,
+                    each -> conversationExecutor.runConversation(suiteId + "/core/" + each.getScenarioId(), each, createInteractionClient()),
+                    conversationExecutor.getConfiguration());
+        }
+        if ("all".equals(suitePart) || "extended".equals(suitePart)) {
+            suiteRunner.assertSuite(suiteId + "/extended",
+                    this::createExtendedScenarios,
+                    each -> conversationExecutor.runConversation(suiteId + "/extended/" + each.getScenarioId(), each, createInteractionClient()),
+                    conversationExecutor.getConfiguration());
+        }
+        if (!List.of("all", "core", "extended").contains(suitePart)) {
+            throw new IllegalArgumentException("Unsupported LLM usability suite part: " + suitePart);
+        }
     }
     
     private List<LLMUsabilityScenario> createCoreScenarios() {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLRuntimeE2ETest.java
@@ -210,6 +210,22 @@ class ProductionMySQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2ETes
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("semanticPrimaryTransport")
+    void assertValidateRuntimeDatabaseWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call(
+                    "database_gateway_validate_runtime_database", Map.of("database", LOGICAL_DATABASE_NAME));
+            assertThat(actual.get("response_mode"), is("validation"));
+            assertThat(actual.get("status"), is("ready"));
+            assertThat(actual.get("database"), is(LOGICAL_DATABASE_NAME));
+            assertFalse(((List<?>) actual.get("checks")).isEmpty());
+            assertTrue(((List<?>) actual.get("checks")).stream().map(each -> (Map<?, ?>) each)
+                    .allMatch(each -> "passed".equals(each.get("status"))));
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
     void assertSearchMetadataPaginationWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
         useTransport(transport);
         try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/FeatureWorkflowContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/FeatureWorkflowContractE2ETest.java
@@ -134,6 +134,7 @@ class FeatureWorkflowContractE2ETest extends AbstractSharedHttpProgrammaticRunti
         Map<String, Object> payload = MCPInteractionPayloads.getRequiredJsonRpcResult(parseJsonBody(actual.body()));
         assertModelFacingPayloadContract(payload);
         Map<String, Object> actualTool = findByKey(MCPInteractionPayloads.getRequiredObjectList(payload, "tools"), "name", scenario.toolName());
+        assertTrue((Boolean) MCPInteractionPayloads.getRequiredObject(actualTool, "annotations").get("openWorldHint"));
         Map<String, Object> actualInputSchema = MCPInteractionPayloads.getRequiredObject(actualTool, "inputSchema");
         assertFalse((Boolean) actualInputSchema.get("additionalProperties"));
         Map<String, Object> actualProperties = MCPInteractionPayloads.getRequiredObject(actualInputSchema, "properties");


### PR DESCRIPTION
- validate nested tool schema descriptions and planner annotations
- broaden workflow, runtime, and performance regression coverage
- discover read-only MCP tools dynamically
- split LLM E2E suites and clarify runtime connector requirements

