### PR TITLE
Refactor MCP constructors with Lombok

### DIFF
--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/capability/tool/MCPToolAnnotations.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/capability/tool/MCPToolAnnotations.java
@@ -17,12 +17,16 @@
 
 package org.apache.shardingsphere.mcp.api.capability.tool;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
  * SDK-independent MCP tool annotations.
  */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public final class MCPToolAnnotations {
     
@@ -36,12 +40,4 @@ public final class MCPToolAnnotations {
     
     private final boolean openWorldHint;
     
-    @Builder
-    private MCPToolAnnotations(final String title, final boolean readOnlyHint, final boolean destructiveHint, final boolean idempotentHint, final boolean openWorldHint) {
-        this.title = title;
-        this.readOnlyHint = readOnlyHint;
-        this.destructiveHint = destructiveHint;
-        this.idempotentHint = idempotentHint;
-        this.openWorldHint = openWorldHint;
-    }
 }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionRateLimiter.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionRateLimiter.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.core.completion;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.exception.MCPUnavailableException;
 import org.apache.shardingsphere.mcp.support.security.MCPRuntimeProtectionPolicy;
 
@@ -29,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Per-session fixed-window rate limiter for MCP completion requests.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 final class MCPCompletionRateLimiter {
     
     private static final Duration WINDOW_DURATION = Duration.ofMinutes(1L);
@@ -41,11 +44,6 @@ final class MCPCompletionRateLimiter {
     
     MCPCompletionRateLimiter() {
         this(MCPRuntimeProtectionPolicy.getMaxCompletionRequestsPerMinute(), Clock.systemUTC());
-    }
-    
-    MCPCompletionRateLimiter(final int maxRequestsPerWindow, final Clock clock) {
-        this.maxRequestsPerWindow = maxRequestsPerWindow;
-        this.clock = clock;
     }
     
     void acquire(final String sessionId) {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/InMemoryWorkflowSessionStore.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/InMemoryWorkflowSessionStore.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.core.workflow;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPWorkflowStateException;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -59,13 +61,10 @@ public final class InMemoryWorkflowSessionStore {
         sessionSnapshots.remove(sessionId);
     }
     
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     private final class SessionContext implements WorkflowSessionContext {
         
         private final String sessionId;
-        
-        private SessionContext(final String sessionId) {
-            this.sessionId = sessionId;
-        }
         
         @Override
         public WorkflowContextSnapshot getOrCreate(final String planId) {

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.core.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.api.MCPRequestContext;
 import org.apache.shardingsphere.mcp.api.exception.MCPUnsupportedException;
@@ -360,6 +362,7 @@ class CoreResourceHandlerSurfaceTest {
         return Collections.singletonList(metadata);
     }
     
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class HandlerCase {
         
         private final String description;
@@ -375,17 +378,6 @@ class CoreResourceHandlerSurfaceTest {
         private final String expectedDatabase;
         
         private final List<String> expectedObjectNames;
-        
-        private HandlerCase(final String description, final MCPResourceHandler<?> handler, final String expectedUriTemplate, final String resourceUri,
-                            final HandlerResultType expectedType, final String expectedDatabase, final List<String> expectedObjectNames) {
-            this.description = description;
-            this.handler = handler;
-            this.expectedUriTemplate = expectedUriTemplate;
-            this.resourceUri = resourceUri;
-            this.expectedType = expectedType;
-            this.expectedDatabase = expectedDatabase;
-            this.expectedObjectNames = expectedObjectNames;
-        }
         
         private MCPResourceHandler<?> getHandler() {
             return handler;

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowLifecycleSpec.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowLifecycleSpec.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.workflow.model.RuleArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -27,6 +28,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 @Getter(AccessLevel.PACKAGE)
 final class ShardingWorkflowLifecycleSpec {
     
@@ -43,19 +45,5 @@ final class ShardingWorkflowLifecycleSpec {
     private final BiFunction<ShardingWorkflowRequest, WorkflowContextSnapshot, Boolean> algorithmPlanSupplier;
     
     private final Function<ShardingWorkflowRequest, RuleArtifact> artifactSupplier;
-    
-    ShardingWorkflowLifecycleSpec(final WorkflowKind workflowKind, final String defaultOperationType, final String summary,
-                                  final Function<ShardingWorkflowRequest, Boolean> existsSupplier,
-                                  final BiFunction<ShardingWorkflowRequest, WorkflowContextSnapshot, Boolean> requiredInputSupplier,
-                                  final BiFunction<ShardingWorkflowRequest, WorkflowContextSnapshot, Boolean> algorithmPlanSupplier,
-                                  final Function<ShardingWorkflowRequest, RuleArtifact> artifactSupplier) {
-        this.workflowKind = workflowKind;
-        this.defaultOperationType = defaultOperationType;
-        this.summary = summary;
-        this.existsSupplier = existsSupplier;
-        this.requiredInputSupplier = requiredInputSupplier;
-        this.algorithmPlanSupplier = algorithmPlanSupplier;
-        this.artifactSupplier = artifactSupplier;
-    }
     
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseCapabilityProviderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseCapabilityProviderTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.database.capability;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.support.database.metadata.TransactionCapability;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
@@ -202,6 +204,7 @@ class MCPDatabaseCapabilityProviderTest {
                 Arguments.of("firebird", "Firebird", true, true, true, SchemaExecutionSemantics.BEST_EFFORT, false));
     }
     
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class CapabilityFixture {
         
         private final boolean transactionSupported;
@@ -212,12 +215,5 @@ class MCPDatabaseCapabilityProviderTest {
         
         private final DialectSchemaSemantics schemaSemantics;
         
-        private CapabilityFixture(final boolean transactionSupported, final boolean savepointSupported, final boolean sequenceSupported,
-                                  final DialectSchemaSemantics schemaSemantics) {
-            this.transactionSupported = transactionSupported;
-            this.savepointSupported = savepointSupported;
-            this.sequenceSupported = sequenceSupported;
-            this.schemaSemantics = schemaSemantics;
-        }
     }
 }


### PR DESCRIPTION
Replace redundant MCP constructors with RequiredArgsConstructor while preserving their access levels and builder behavior.
