### PR TITLE
Align timestamp text output with PostgreSQL

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,7 @@
 1. Sharding: Fix generated actual index names exceeding database identifier length limits while preserving legacy generated index name compatibility - [#38449](https://github.com/apache/shardingsphere/pull/38449)
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
+1. Proxy: Align timestamp text output with PostgreSQL - [#39195](https://github.com/apache/shardingsphere/pull/39195)
 
 ### Enhancements
 

--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.protocol.binary.BinaryCell;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.bind.protocol.PostgreSQLBinaryProtocolValue;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.bind.protocol.PostgreSQLBinaryProtocolValueFactory;
+import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.text.PostgreSQLTextValueFormatterFactory;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.identifier.PostgreSQLIdentifierPacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.identifier.PostgreSQLMessagePacketType;
@@ -80,7 +81,8 @@ public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
             payload.writeInt4(columnData.length);
             payload.writeBytes(columnData);
         } else {
-            byte[] columnData = each.toString().getBytes(payload.getCharset());
+            String formattedValue = PostgreSQLTextValueFormatterFactory.format(each);
+            byte[] columnData = formattedValue.getBytes(payload.getCharset());
             payload.writeInt4(columnData.length);
             payload.writeBytes(columnData);
         }

--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/text/PostgreSQLTextValueFormatter.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/text/PostgreSQLTextValueFormatter.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.text;
+
+/**
+ * Text value formatter for PostgreSQL protocol.
+ */
+public interface PostgreSQLTextValueFormatter {
+    
+    /**
+     * Format the data into PostgreSQL text protocol format.
+     *
+     * @param value data value
+     * @return formatted text
+     */
+    String format(Object value);
+}

--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/text/PostgreSQLTextValueFormatterFactory.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/text/PostgreSQLTextValueFormatterFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.text;
+
+import java.sql.Timestamp;
+
+/**
+ * Text value formatter factory for PostgreSQL.
+ */
+public final class PostgreSQLTextValueFormatterFactory {
+    
+    /**
+     * Format value to text string.
+     *
+     * @param value value to be formatted
+     * @return formatted string
+     */
+    public static String format(final Object value) {
+        if (value instanceof Timestamp) {
+            return new PostgreSQLTimestampTextFormatter().format(value);
+        }
+        
+        return value.toString();
+    }
+}

--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/text/PostgreSQLTimestampTextFormatter.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/text/PostgreSQLTimestampTextFormatter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.text;
+
+import java.sql.Timestamp;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+/**
+ * Timestamp text value formatter for PostgreSQL.
+ */
+public final class PostgreSQLTimestampTextFormatter implements PostgreSQLTextValueFormatter {
+    
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+            .toFormatter();
+    
+    @Override
+    public String format(final Object value) {
+        if (value instanceof Timestamp) {
+            return ((Timestamp) value).toLocalDateTime().format(FORMATTER);
+        }
+        return value.toString();
+    }
+}

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.stream.Stream;
 
@@ -140,6 +141,8 @@ class PostgreSQLDataRowPacketTest {
         return Stream.of(
                 Arguments.of("boolean_true", true, "t".getBytes(StandardCharsets.UTF_8)),
                 Arguments.of("boolean_false", false, "f".getBytes(StandardCharsets.UTF_8)),
-                Arguments.of("string_value", "value", "value".getBytes(StandardCharsets.UTF_8)));
+                Arguments.of("string_value", "value", "value".getBytes(StandardCharsets.UTF_8)),
+                Arguments.of("timestamp_value",
+                        Timestamp.valueOf("1973-06-03 10:30:01.123"), "1973-06-03 10:30:01.123".getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/text/PostgreSQLTimestampTextFormatterTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/text/PostgreSQLTimestampTextFormatterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.text;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class PostgreSQLTimestampTextFormatterTest {
+    
+    private final PostgreSQLTimestampTextFormatter formatter = new PostgreSQLTimestampTextFormatter();
+    
+    @Test
+    void assertFormatWithoutFractionalSeconds() {
+        Timestamp timestamp = Timestamp.valueOf("1973-06-03 10:30:01.0");
+        assertThat(formatter.format(timestamp), is("1973-06-03 10:30:01"));
+    }
+    
+    @Test
+    void assertFormatWithFractionalSeconds() {
+        Timestamp timestamp = Timestamp.valueOf("1973-06-03 10:30:01.123");
+        assertThat(formatter.format(timestamp), is("1973-06-03 10:30:01.123"));
+    }
+    
+    @Test
+    void assertFormatWithTrailingZerosInFraction() {
+        Timestamp timestamp = Timestamp.valueOf("1973-06-03 10:30:01.500");
+        assertThat(formatter.format(timestamp), is("1973-06-03 10:30:01.5"));
+    }
+    
+    @Test
+    void assertFormatWithMicrosecondPrecision() {
+        Timestamp timestamp = Timestamp.valueOf("1973-06-03 10:30:01.123456");
+        assertThat(formatter.format(timestamp), is("1973-06-03 10:30:01.123456"));
+    }
+    
+    @Test
+    void assertFormatWithLeadingZerosInFraction() {
+        Timestamp timestamp = Timestamp.valueOf("1973-06-03 10:30:01.000001");
+        assertThat(formatter.format(timestamp), is("1973-06-03 10:30:01.000001"));
+    }
+    
+    @Test
+    void assertFormatWithNanosecondsTruncatedToMicroseconds() {
+        Timestamp timestamp = Timestamp.valueOf("1973-06-03 10:30:01.123456789");
+        assertThat(formatter.format(timestamp), is("1973-06-03 10:30:01.123456"));
+    }
+    
+    @Test
+    void assertFormatWithNonTimestampValue() {
+        String nonTimestamp = "test_string";
+        assertThat(formatter.format(nonTimestamp), is("test_string"));
+    }
+}

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/select_timestamp_without_fractional_seconds.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/select_timestamp_without_fractional_seconds.xml
@@ -1,0 +1,6 @@
+<dataset>
+    <metadata>
+        <column name="c8" type="timestamp" />
+    </metadata>
+    <row values="1973-06-03 10:30:01" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/select_timestamp_without_fractional_seconds.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/select_timestamp_without_fractional_seconds.xml
@@ -1,3 +1,20 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <dataset>
     <metadata>
         <column name="c8" type="timestamp" />

--- a/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select.xml
@@ -187,4 +187,12 @@
     <test-case sql="SELECT user_name, telephone FROM t_user" db-types="Hive" scenario-types="mask">
         <assertion expected-data-source-name="expected_dataset" />
     </test-case>
+
+    <test-case sql="SELECT CAST('1973-06-03 10:30:01' AS TIMESTAMP) AS c8">
+        <assertion expected-data-file="select_timestamp_without_fractional_seconds.xml" />
+    </test-case>
+
+    <test-case sql="SELECT CAST('1973-06-03 10:30:01.123' AS TIMESTAMP) AS c8">
+        <assertion expected-data-file="select_timestamp_with_fractional_seconds.xml" />
+    </test-case>
 </e2e-test-cases>

--- a/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select.xml
@@ -189,10 +189,10 @@
     </test-case>
 
     <test-case sql="SELECT CAST('1973-06-03 10:30:01' AS TIMESTAMP) AS c8" db-types="PostgreSQL,openGauss">
-        <assertion expected-data-file="dataset/select_timestamp_without_fractional_seconds.xml" />
+        <assertion expected-data-file="select_timestamp_without_fractional_seconds.xml" />
     </test-case>
 
     <test-case sql="SELECT CAST('1973-06-03 10:30:01.123' AS TIMESTAMP) AS c8" db-types="PostgreSQL,openGauss">
-        <assertion expected-data-file="dataset/select_timestamp_with_fractional_seconds.xml" />
+        <assertion expected-data-file="select_timestamp_with_fractional_seconds.xml" />
     </test-case>
 </e2e-test-cases>

--- a/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select.xml
@@ -188,11 +188,11 @@
         <assertion expected-data-source-name="expected_dataset" />
     </test-case>
 
-    <test-case sql="SELECT CAST('1973-06-03 10:30:01' AS TIMESTAMP) AS c8">
-        <assertion expected-data-file="select_timestamp_without_fractional_seconds.xml" />
+    <test-case sql="SELECT CAST('1973-06-03 10:30:01' AS TIMESTAMP) AS c8" db-types="PostgreSQL,openGauss">
+        <assertion expected-data-file="dataset/select_timestamp_without_fractional_seconds.xml" />
     </test-case>
 
-    <test-case sql="SELECT CAST('1973-06-03 10:30:01.123' AS TIMESTAMP) AS c8">
-        <assertion expected-data-file="select_timestamp_with_fractional_seconds.xml" />
+    <test-case sql="SELECT CAST('1973-06-03 10:30:01.123' AS TIMESTAMP) AS c8" db-types="PostgreSQL,openGauss">
+        <assertion expected-data-file="dataset/select_timestamp_with_fractional_seconds.xml" />
     </test-case>
 </e2e-test-cases>


### PR DESCRIPTION
Fixes #37437 

Introduce PostgreSQL-specific text formatting for TIMESTAMP values instead of relying on java.sql.Timestamp#toString(), ensuring timestamps without fractional seconds are returned without a trailing ".0" to match native PostgreSQL behavior. Add unit tests for timestamp formatting and packet serialization, along with protocol integration tests covering timestamp values with and without fractional seconds.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in the comment I request) added corresponding labels for the pull request.
- [x] I have passed Maven check locally: `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
