### PR TITLE
Fix Javadoc of DropBroadcastTableRuleStatement to match class name

### DIFF
--- a/features/broadcast/distsql/statement/src/main/java/org/apache/shardingsphere/broadcast/distsql/statement/DropBroadcastTableRuleStatement.java
+++ b/features/broadcast/distsql/statement/src/main/java/org/apache/shardingsphere/broadcast/distsql/statement/DropBroadcastTableRuleStatement.java
@@ -23,7 +23,7 @@ import org.apache.shardingsphere.distsql.statement.type.rdl.rule.database.type.D
 import java.util.Collection;
 
 /**
- * Drop broadcast table rules statement.
+ * Drop broadcast table rule statement.
  */
 @Getter
 public final class DropBroadcastTableRuleStatement extends DropRuleStatement {


### PR DESCRIPTION
No issue: typo fix.

Changes proposed in this pull request:
  - Correct the Javadoc summary of `DropBroadcastTableRuleStatement` from "Drop broadcast table rules statement." to "Drop broadcast table rule statement.", so it matches the class name (singular `Rule`).
  - Aligns with the only other `Drop*TableRuleStatement`, `DropShardingTableRuleStatement`, whose Javadoc already reads "Drop sharding table rule statement.", and with the sibling `CreateBroadcastTableRuleStatement` ("Create broadcast table rule statement.").
  - Javadoc-only change; public class, constructor and field are unchanged.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed the required maven checks locally: `./mvnw spotless:check checkstyle:check apache-rat:check -Pcheck -T1C -pl features/broadcast/distsql/statement` (BUILD SUCCESS). This is a Javadoc-only comment change with no compilation impact.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version.
