### PR TITLE
Match broadcast table names case-insensitively in DistSQL executors

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 1. Metadata: Fix MySQL metadata loading fallback when JDBC catalog is null for named tables - [#38855](https://github.com/apache/shardingsphere/pull/38855)
 1. Metadata: Fix Oracle metadata version comparison skipping identity and collation columns on 18c and later - [#39104](https://github.com/apache/shardingsphere/pull/39104)
 1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)
+1. DistSQL: Use case-insensitive table name matching in broadcast create and drop executors - [#39200](https://github.com/apache/shardingsphere/pull/39200)
 1. JDBC: Fix stale generated values leaking into prepared statement executeBatch calls without pending batches - [#38160](https://github.com/apache/shardingsphere/pull/38160)
 1. JDBC: Fix MySQL-compatible typed string conversion for `ResultSet#getObject(index, Class<T>)` - [#38444](https://github.com/apache/shardingsphere/pull/38444)
 1. Proxy: Resolve MySQL prepared statement parameter columns for where clause - [#38382](https://github.com/apache/shardingsphere/pull/38382)

--- a/features/broadcast/distsql/handler/src/main/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleExecutor.java
+++ b/features/broadcast/distsql/handler/src/main/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.broadcast.distsql.handler.update;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Setter;
 import org.apache.shardingsphere.broadcast.config.BroadcastRuleConfiguration;
 import org.apache.shardingsphere.broadcast.distsql.statement.CreateBroadcastTableRuleStatement;
@@ -54,7 +55,7 @@ public final class CreateBroadcastTableRuleExecutor implements DatabaseRuleCreat
     }
     
     private Collection<String> getDuplicatedRuleNames(final CreateBroadcastTableRuleStatement sqlStatement) {
-        Collection<String> result = new HashSet<>(null == rule ? Collections.emptySet() : rule.getTables());
+        Collection<String> result = new CaseInsensitiveSet<>(null == rule ? Collections.emptySet() : rule.getTables());
         result.retainAll(sqlStatement.getTables());
         return result;
     }

--- a/features/broadcast/distsql/handler/src/main/java/org/apache/shardingsphere/broadcast/distsql/handler/update/DropBroadcastTableRuleExecutor.java
+++ b/features/broadcast/distsql/handler/src/main/java/org/apache/shardingsphere/broadcast/distsql/handler/update/DropBroadcastTableRuleExecutor.java
@@ -59,7 +59,7 @@ public final class DropBroadcastTableRuleExecutor implements DatabaseRuleDropExe
     
     @Override
     public boolean hasAnyOneToBeDropped(final DropBroadcastTableRuleStatement sqlStatement) {
-        return !Collections.disjoint(rule.getConfiguration().getTables(), sqlStatement.getTables());
+        return !Collections.disjoint(new CaseInsensitiveSet<>(rule.getConfiguration().getTables()), sqlStatement.getTables());
     }
     
     @Override

--- a/features/broadcast/distsql/handler/src/main/java/org/apache/shardingsphere/broadcast/distsql/handler/update/DropBroadcastTableRuleExecutor.java
+++ b/features/broadcast/distsql/handler/src/main/java/org/apache/shardingsphere/broadcast/distsql/handler/update/DropBroadcastTableRuleExecutor.java
@@ -29,7 +29,6 @@ import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.MissingReq
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.stream.Collectors;
 
@@ -59,7 +58,8 @@ public final class DropBroadcastTableRuleExecutor implements DatabaseRuleDropExe
     
     @Override
     public boolean hasAnyOneToBeDropped(final DropBroadcastTableRuleStatement sqlStatement) {
-        return !Collections.disjoint(new CaseInsensitiveSet<>(rule.getConfiguration().getTables()), sqlStatement.getTables());
+        Collection<String> currentTableNames = new CaseInsensitiveSet<>(rule.getConfiguration().getTables());
+        return sqlStatement.getTables().stream().anyMatch(currentTableNames::contains);
     }
     
     @Override

--- a/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleExecutorTest.java
+++ b/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleExecutorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.broadcast.distsql.handler.update;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import org.apache.shardingsphere.broadcast.config.BroadcastRuleConfiguration;
 import org.apache.shardingsphere.broadcast.distsql.statement.CreateBroadcastTableRuleStatement;
 import org.apache.shardingsphere.broadcast.rule.BroadcastRule;
@@ -59,6 +60,15 @@ class CreateBroadcastTableRuleExecutorTest {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         BroadcastRule rule = mock(BroadcastRule.class);
         when(rule.getTables()).thenReturn(Collections.singleton("foo_tbl"));
+        assertThrows(DuplicateRuleException.class, () -> new DistSQLUpdateExecuteEngine(sqlStatement, "foo_db", mockContextManager(database, rule), null).executeUpdate());
+    }
+    
+    @Test
+    void assertExecuteUpdateWithCaseInsensitiveDuplicateBroadcastTables() {
+        CreateBroadcastTableRuleStatement sqlStatement = new CreateBroadcastTableRuleStatement(false, Collections.singleton("FOO_TBL"));
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        BroadcastRule rule = mock(BroadcastRule.class);
+        when(rule.getTables()).thenReturn(new CaseInsensitiveSet<>(Collections.singleton("foo_tbl")));
         assertThrows(DuplicateRuleException.class, () -> new DistSQLUpdateExecuteEngine(sqlStatement, "foo_db", mockContextManager(database, rule), null).executeUpdate());
     }
     

--- a/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/DropBroadcastTableRuleExecutorTest.java
+++ b/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/DropBroadcastTableRuleExecutorTest.java
@@ -64,6 +64,19 @@ class DropBroadcastTableRuleExecutorTest {
         verify(metaDataManagerPersistService).removeRuleConfiguration(eq(database), any(RuleConfiguration.class), eq("broadcast"));
     }
     
+    @Test
+    void assertExecuteUpdateWithCaseInsensitiveTableName() throws SQLException {
+        DropBroadcastTableRuleStatement sqlStatement = new DropBroadcastTableRuleStatement(false, Collections.singleton("FOO_TBL"));
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getName()).thenReturn("foo_db");
+        BroadcastRule rule = mock(BroadcastRule.class, RETURNS_DEEP_STUBS);
+        when(rule.getConfiguration().getTables()).thenReturn(Collections.singleton("foo_tbl"));
+        ContextManager contextManager = mockContextManager(database, rule);
+        new DistSQLUpdateExecuteEngine(sqlStatement, "foo_db", contextManager, null).executeUpdate();
+        MetaDataManagerPersistService metaDataManagerPersistService = contextManager.getPersistServiceFacade().getModeFacade().getMetaDataManagerService();
+        verify(metaDataManagerPersistService).removeRuleConfiguration(eq(database), any(RuleConfiguration.class), eq("broadcast"));
+    }
+    
     private ContextManager mockContextManager(final ShardingSphereDatabase database, final BroadcastRule rule) {
         ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");


### PR DESCRIPTION

Fixes #39199.

Changes proposed in this pull request:
  - Broadcast table names are case-insensitive (core `BroadcastRule.tables` is a `CaseInsensitiveSet`), but two DistSQL executors compared them case-sensitively.
  - `CreateBroadcastTableRuleExecutor.getDuplicatedRuleNames()`: copy current tables into a `CaseInsensitiveSet` instead of `HashSet`, so `CREATE BROADCAST TABLE RULE T_ORDER` over an existing `t_order` now raises `DuplicateRuleException` instead of storing both.
  - `DropBroadcastTableRuleExecutor.hasAnyOneToBeDropped()`: wrap current tables in `CaseInsensitiveSet` before `Collections.disjoint`, so `DROP BROADCAST TABLE RULE T_ORDER` removes `t_order` instead of being a silent no-op.
  - Both align with the executors' own existing `CaseInsensitiveSet` usage (`checkBroadcastTableExist`, alter builder) and the sibling `DropMaskRuleExecutor.hasAnyOneToBeDropped()`; completes the drop-path fix started in #30180.
  - Added case-insensitive unit tests to both executor test classes.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)


