### PR TITLE
Fix MySQL prepared statement parameter signedness in Proxy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,6 +33,7 @@
 1. Proxy: Fix incorrect generated key handling for explicit auto-increment values - [#38810](https://github.com/apache/shardingsphere/pull/38810)
 1. Proxy: Fix microseconds decoded as nanoseconds in MySQL binary TIME value - [#39138](https://github.com/apache/shardingsphere/pull/39138)
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
+1. Proxy: Fix MySQL prepared statement parameter signedness decoding - [#39204](https://github.com/apache/shardingsphere/pull/39204)
 1. JDBC & Proxy: Remove default MySQL prepared statement query properties when creating data sources - [#38593](https://github.com/apache/shardingsphere/pull/38593)
 1. Mode: Fix rule metadata not removed from memory after dropping rules in Etcd cluster mode - [#38561](https://github.com/apache/shardingsphere/pull/38561)
 1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/MySQLComStmtExecutePacket.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/MySQLComStmtExecutePacket.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLBinaryCol
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLNewParametersBoundFlag;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.MySQLCommandPacketType;
-import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.MySQLColumnDefinitionFlag;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.binary.MySQLPreparedStatementParameterType;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.binary.execute.protocol.MySQLBinaryProtocolValue;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.binary.execute.protocol.MySQLBinaryProtocolValueFactory;
@@ -46,6 +45,8 @@ public final class MySQLComStmtExecutePacket extends MySQLCommandPacket {
     private static final int ITERATION_COUNT = 1;
     
     private static final int NULL_BITMAP_OFFSET = 0;
+    
+    private static final int UNSIGNED_FLAG = 0x80;
     
     private final MySQLPacketPayload payload;
     
@@ -94,24 +95,24 @@ public final class MySQLComStmtExecutePacket extends MySQLCommandPacket {
      *
      * @param paramTypes parameter type of values
      * @param longDataIndexes indexes of long data
-     * @param parameterFlags column definition flag of parameters
      * @param parameterColumnTypes column type of parameters from COM_STMT_PREPARE
      * @return parameter values
      * @throws SQLException SQL exception
      */
     public List<Object> readParameters(final List<MySQLPreparedStatementParameterType> paramTypes, final Set<Integer> longDataIndexes,
-                                       final List<Integer> parameterFlags, final List<MySQLBinaryColumnType> parameterColumnTypes) throws SQLException {
+                                       final List<MySQLBinaryColumnType> parameterColumnTypes) throws SQLException {
         List<Object> result = new ArrayList<>(paramTypes.size());
         for (int paramIndex = 0; paramIndex < paramTypes.size(); paramIndex++) {
             if (longDataIndexes.contains(paramIndex)) {
                 result.add(null);
                 continue;
             }
-            MySQLBinaryColumnType parameterType = paramTypes.get(paramIndex).getColumnType();
+            MySQLPreparedStatementParameterType parameter = paramTypes.get(paramIndex);
+            MySQLBinaryColumnType parameterType = parameter.getColumnType();
             MySQLBinaryProtocolValue binaryProtocolValue = MySQLBinaryProtocolValueFactory.getBinaryProtocolValue(parameterType);
             Object value = nullBitmap.isNullParameter(paramIndex)
                     ? null
-                    : readParameterValue(binaryProtocolValue, parameterColumnTypes, paramIndex, parameterType, parameterFlags);
+                    : readParameterValue(binaryProtocolValue, parameterColumnTypes, paramIndex, parameterType, parameter.getUnsignedFlag());
             value = decodeStringParameterValue(parameterColumnTypes, paramIndex, parameterType, value);
             result.add(value);
         }
@@ -119,11 +120,11 @@ public final class MySQLComStmtExecutePacket extends MySQLCommandPacket {
     }
     
     private Object readParameterValue(final MySQLBinaryProtocolValue binaryProtocolValue, final List<MySQLBinaryColumnType> parameterColumnTypes, final int paramIndex,
-                                      final MySQLBinaryColumnType parameterType, final List<Integer> parameterFlags) throws SQLException {
+                                      final MySQLBinaryColumnType parameterType, final int unsignedFlag) throws SQLException {
         if (isStringParameterType(parameterType) && isBinaryColumnType(parameterColumnTypes, paramIndex)) {
             return payload.readStringLenencByBytes();
         }
-        return binaryProtocolValue.read(payload, (parameterFlags.get(paramIndex) & MySQLColumnDefinitionFlag.UNSIGNED.getValue()) == MySQLColumnDefinitionFlag.UNSIGNED.getValue());
+        return binaryProtocolValue.read(payload, (unsignedFlag & UNSIGNED_FLAG) == UNSIGNED_FLAG);
     }
     
     private MySQLBinaryColumnType getParameterColumnType(final List<MySQLBinaryColumnType> parameterColumnTypes, final int paramIndex) {

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/MySQLComStmtExecutePacketTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/MySQLComStmtExecutePacketTest.java
@@ -21,7 +21,6 @@ import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLBinaryColumnType;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLNewParametersBoundFlag;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.binary.MySQLPreparedStatementParameterType;
-import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.MySQLColumnDefinitionFlag;
 import org.apache.shardingsphere.database.protocol.mysql.payload.MySQLPacketPayload;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -74,21 +73,20 @@ class MySQLComStmtExecutePacketTest {
     
     @Test
     void assertReadParametersWithSignedInteger() throws SQLException {
-        byte[] data = {0x01, 0x00, 0x00, 0x00, 0x09, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00};
-        MySQLPacketPayload payload = new MySQLPacketPayload(Unpooled.wrappedBuffer(data), StandardCharsets.UTF_8);
-        MySQLComStmtExecutePacket actual = new MySQLComStmtExecutePacket(payload, 1);
-        List<MySQLPreparedStatementParameterType> parameterTypes = actual.getNewParameterTypes();
-        assertThat(actual.readParameters(parameterTypes, Collections.emptySet(), Collections.singletonList(0), Collections.emptyList()), is(Collections.<Object>singletonList(1)));
-    }
-    
-    @Test
-    void assertReadParametersWithUnsignedInteger() throws SQLException {
         byte[] data = {0x01, 0x00, 0x00, 0x00, 0x09, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, 0x00, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff};
         MySQLPacketPayload payload = new MySQLPacketPayload(Unpooled.wrappedBuffer(data), StandardCharsets.UTF_8);
         MySQLComStmtExecutePacket actual = new MySQLComStmtExecutePacket(payload, 1);
         List<MySQLPreparedStatementParameterType> parameterTypes = actual.getNewParameterTypes();
-        int unsignedFlag = MySQLColumnDefinitionFlag.UNSIGNED.getValue();
-        assertThat(actual.readParameters(parameterTypes, Collections.emptySet(), Collections.singletonList(unsignedFlag), Collections.emptyList()), is(Collections.<Object>singletonList(4294967295L)));
+        assertThat(actual.readParameters(parameterTypes, Collections.emptySet(), Collections.emptyList()), is(Collections.<Object>singletonList(-1)));
+    }
+    
+    @Test
+    void assertReadParametersWithUnsignedInteger() throws SQLException {
+        byte[] data = {0x01, 0x00, 0x00, 0x00, 0x09, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, (byte) 0x80, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff};
+        MySQLPacketPayload payload = new MySQLPacketPayload(Unpooled.wrappedBuffer(data), StandardCharsets.UTF_8);
+        MySQLComStmtExecutePacket actual = new MySQLComStmtExecutePacket(payload, 1);
+        List<MySQLPreparedStatementParameterType> parameterTypes = actual.getNewParameterTypes();
+        assertThat(actual.readParameters(parameterTypes, Collections.emptySet(), Collections.emptyList()), is(Collections.<Object>singletonList(4294967295L)));
     }
     
     @Test
@@ -97,8 +95,7 @@ class MySQLComStmtExecutePacketTest {
         MySQLPacketPayload payload = new MySQLPacketPayload(Unpooled.wrappedBuffer(data), StandardCharsets.UTF_8);
         MySQLComStmtExecutePacket actual = new MySQLComStmtExecutePacket(payload, 1);
         List<MySQLPreparedStatementParameterType> parameterTypes = actual.getNewParameterTypes();
-        List<Integer> parameterFlags = Collections.singletonList(0);
-        assertThat(actual.readParameters(parameterTypes, Collections.emptySet(), parameterFlags, Collections.emptyList()), is(Collections.singletonList(null)));
+        assertThat(actual.readParameters(parameterTypes, Collections.emptySet(), Collections.emptyList()), is(Collections.singletonList(null)));
     }
     
     @Test
@@ -107,7 +104,7 @@ class MySQLComStmtExecutePacketTest {
         MySQLPacketPayload payload = new MySQLPacketPayload(Unpooled.wrappedBuffer(data), StandardCharsets.UTF_8);
         MySQLComStmtExecutePacket actual = new MySQLComStmtExecutePacket(payload, 1);
         List<MySQLPreparedStatementParameterType> parameterTypes = actual.getNewParameterTypes();
-        assertThat(actual.readParameters(parameterTypes, Collections.singleton(0), Collections.emptyList(), Collections.emptyList()), is(Collections.singletonList(null)));
+        assertThat(actual.readParameters(parameterTypes, Collections.singleton(0), Collections.emptyList()), is(Collections.singletonList(null)));
     }
     
     @ParameterizedTest(name = "{0}")
@@ -118,7 +115,7 @@ class MySQLComStmtExecutePacketTest {
         MySQLPacketPayload payload = new MySQLPacketPayload(Unpooled.wrappedBuffer(data), StandardCharsets.UTF_8);
         MySQLComStmtExecutePacket actual = new MySQLComStmtExecutePacket(payload, 1);
         List<MySQLPreparedStatementParameterType> parameterTypes = actual.getNewParameterTypes();
-        Object actualValue = actual.readParameters(parameterTypes, Collections.emptySet(), Collections.singletonList(0), Collections.singletonList(parameterColumnType)).get(0);
+        Object actualValue = actual.readParameters(parameterTypes, Collections.emptySet(), Collections.singletonList(parameterColumnType)).get(0);
         assertTrue(actualValue instanceof byte[]);
         assertArrayEquals(new byte[]{(byte) 0xac, (byte) 0xed, (byte) 0xff}, (byte[]) actualValue);
     }
@@ -148,8 +145,7 @@ class MySQLComStmtExecutePacketTest {
         MySQLPacketPayload payload = new MySQLPacketPayload(Unpooled.wrappedBuffer(data), StandardCharsets.UTF_8);
         MySQLComStmtExecutePacket actual = new MySQLComStmtExecutePacket(payload, 1);
         List<MySQLPreparedStatementParameterType> parameterTypes = actual.getNewParameterTypes();
-        List<Integer> parameterFlags = Collections.singletonList(0);
-        Object actualValue = actual.readParameters(parameterTypes, Collections.emptySet(), parameterFlags, parameterColumnTypes).get(0);
+        Object actualValue = actual.readParameters(parameterTypes, Collections.emptySet(), parameterColumnTypes).get(0);
         assertThat(actualValue instanceof String, is(expectedString));
         if (expectedString) {
             assertThat(actualValue, is("a"));

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/MySQLServerPreparedStatement.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/MySQLServerPreparedStatement.java
@@ -44,8 +44,6 @@ public final class MySQLServerPreparedStatement implements ServerPreparedStateme
     
     private final HintValueContext hintValueContext;
     
-    private final List<Integer> parameterColumnDefinitionFlags;
-    
     private final List<MySQLBinaryColumnType> parameterColumnTypes = new CopyOnWriteArrayList<>();
     
     private final List<MySQLPreparedStatementParameterType> parameterTypes = new CopyOnWriteArrayList<>();

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
@@ -74,8 +74,7 @@ public final class MySQLComStmtExecuteExecutor implements QueryCommandExecutor {
     public Collection<DatabasePacket> execute() throws SQLException {
         MySQLServerPreparedStatement preparedStatement = updateAndGetPreparedStatement();
         List<MySQLPreparedStatementParameterType> parameterTypes = getParameterTypes(preparedStatement);
-        List<Object> params = packet.readParameters(parameterTypes, preparedStatement.getLongData().keySet(),
-                preparedStatement.getParameterColumnDefinitionFlags(), preparedStatement.getParameterColumnTypes());
+        List<Object> params = packet.readParameters(parameterTypes, preparedStatement.getLongData().keySet(), preparedStatement.getParameterColumnTypes());
         preparedStatement.getLongData().forEach(params::set);
         SQLStatementContext sqlStatementContext = preparedStatement.getSqlStatementContext();
         if (sqlStatementContext instanceof ParameterAware) {

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
@@ -61,7 +61,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.sql.SQLException;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * COM_STMT_PREPARE command executor for MySQL.
@@ -87,7 +86,7 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
         SQLStatementContext sqlStatementContext = new SQLBindEngine(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData(),
                 connectionSession.getCurrentDatabaseName(), packet.getHintValueContext()).bind(sqlStatement);
         int statementId = MySQLStatementIdGenerator.getInstance().nextStatementId(connectionSession.getConnectionId());
-        MySQLServerPreparedStatement serverPreparedStatement = new MySQLServerPreparedStatement(packet.getSQL(), sqlStatementContext, packet.getHintValueContext(), new CopyOnWriteArrayList<>());
+        MySQLServerPreparedStatement serverPreparedStatement = new MySQLServerPreparedStatement(packet.getSQL(), sqlStatementContext, packet.getHintValueContext());
         connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(statementId, serverPreparedStatement);
         return createPackets(sqlStatementContext, statementId, serverPreparedStatement);
     }
@@ -132,7 +131,6 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
         MySQLColumnDefinition41Packet defaultColumnPacket = null;
         Collection<ParameterMarkerSegment> parameterMarkerSegments = sqlStatementContext.getSqlStatement().getParameterMarkers();
         Collection<MySQLPacket> result = new ArrayList<>(parameterMarkerSegments.size());
-        Collection<Integer> paramColumnDefinitionFlags = new ArrayList<>(parameterMarkerSegments.size());
         Collection<MySQLBinaryColumnType> parameterColumnTypes = new ArrayList<>(parameterMarkerSegments.size());
         for (int index = 0; index < parameterMarkerSegments.size(); index++) {
             ShardingSphereColumn column = null;
@@ -143,18 +141,15 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
                 int columnDefinitionFlag = calculateColumnDefinitionFlag(column);
                 result.add(createMySQLColumnDefinition41PacketByCache(characterSet, columnPacketCache, column, columnDefinitionFlag));
                 MySQLBinaryColumnType columnType = MySQLBinaryColumnType.valueOfJDBCType(column.getDataType());
-                paramColumnDefinitionFlags.add(columnDefinitionFlag);
                 parameterColumnTypes.add(columnType);
             } else {
                 if (null == defaultColumnPacket) {
                     defaultColumnPacket = createMySQLColumnDefinition41Packet(characterSet, 0, MySQLBinaryColumnType.VAR_STRING);
                 }
                 result.add(defaultColumnPacket);
-                paramColumnDefinitionFlags.add(0);
                 parameterColumnTypes.add(MySQLBinaryColumnType.NULL);
             }
         }
-        serverPreparedStatement.getParameterColumnDefinitionFlags().addAll(paramColumnDefinitionFlags);
         serverPreparedStatement.getParameterColumnTypes().addAll(parameterColumnTypes);
         return result;
     }

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/MySQLCommandPacketFactoryTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/MySQLCommandPacketFactoryTest.java
@@ -48,8 +48,6 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Collections;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -102,7 +100,7 @@ class MySQLCommandPacketFactoryTest {
         when(connectionSession.getServerPreparedStatementRegistry()).thenReturn(serverPreparedStatementRegistry);
         SelectStatement sqlStatement = SelectStatement.builder().databaseType(databaseType).build();
         SQLStatementContext sqlStatementContext = new CommonSQLStatementContext(sqlStatement);
-        serverPreparedStatementRegistry.addPreparedStatement(1, new MySQLServerPreparedStatement("SELECT 1", sqlStatementContext, new HintValueContext(), Collections.emptyList()));
+        serverPreparedStatementRegistry.addPreparedStatement(1, new MySQLServerPreparedStatement("SELECT 1", sqlStatementContext, new HintValueContext()));
         assertThat(MySQLCommandPacketFactory.newInstance(MySQLCommandPacketType.COM_STMT_EXECUTE, payload, connectionSession), isA(MySQLComStmtExecutePacket.class));
     }
     

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/admin/MySQLComResetConnectionExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/admin/MySQLComResetConnectionExecutorTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,7 +54,7 @@ class MySQLComResetConnectionExecutorTest {
         when(connectionSession.getTransactionStatus()).thenReturn(new TransactionStatus());
         when(connectionSession.getServerPreparedStatementRegistry()).thenReturn(new ServerPreparedStatementRegistry());
         int statementId = 1;
-        connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(statementId, new MySQLServerPreparedStatement("", null, new HintValueContext(), Collections.emptyList()));
+        connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(statementId, new MySQLServerPreparedStatement("", null, new HintValueContext()));
         Collection<DatabasePacket> actual = new MySQLComResetConnectionExecutor(connectionSession).execute();
         assertThat(actual.size(), is(1));
         assertThat(actual.iterator().next(), isA(MySQLOKPacket.class));

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/MySQLComStmtSendLongDataExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/MySQLComStmtSendLongDataExecutorTest.java
@@ -44,7 +44,7 @@ class MySQLComStmtSendLongDataExecutorTest {
         when(packet.getData()).thenReturn(data);
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         when(connectionSession.getServerPreparedStatementRegistry()).thenReturn(new ServerPreparedStatementRegistry());
-        MySQLServerPreparedStatement preparedStatement = new MySQLServerPreparedStatement("INSERT INTO t (b) VALUES (?)", mock(), new HintValueContext(), Collections.emptyList());
+        MySQLServerPreparedStatement preparedStatement = new MySQLServerPreparedStatement("INSERT INTO t (b) VALUES (?)", mock(), new HintValueContext());
         connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(1, preparedStatement);
         MySQLComStmtSendLongDataExecutor executor = new MySQLComStmtSendLongDataExecutor(packet, connectionSession);
         Collection<DatabasePacket> actual = executor.execute();

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutorTest.java
@@ -125,15 +125,15 @@ class MySQLComStmtExecuteExecutorTest {
         when(connectionSession.getDatabaseConnectionManager()).thenReturn(databaseConnectionManager);
         SQLStatementContext selectStatementContext = prepareSelectStatementContext();
         when(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(1))
-                .thenReturn(new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE id = ?", selectStatementContext, new HintValueContext(), Collections.emptyList()));
+                .thenReturn(new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE id = ?", selectStatementContext, new HintValueContext()));
         UpdateStatementContext updateStatementContext = mock(UpdateStatementContext.class, RETURNS_DEEP_STUBS);
         when(updateStatementContext.getSqlStatement()).thenReturn(prepareUpdateStatement());
         when(updateStatementContext.getTablesContext().getDatabaseName()).thenReturn(Optional.empty());
         when(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(2))
-                .thenReturn(new MySQLServerPreparedStatement("UPDATE tbl SET col=1 WHERE id = ?", updateStatementContext, new HintValueContext(), Collections.emptyList()));
+                .thenReturn(new MySQLServerPreparedStatement("UPDATE tbl SET col=1 WHERE id = ?", updateStatementContext, new HintValueContext()));
         when(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(3))
                 .thenReturn(
-                        new MySQLServerPreparedStatement("COMMIT", new CommonSQLStatementContext(new CommitStatement(databaseType)), new HintValueContext(), Collections.emptyList()));
+                        new MySQLServerPreparedStatement("COMMIT", new CommonSQLStatementContext(new CommitStatement(databaseType)), new HintValueContext()));
         ConnectionContext connectionContext = mockConnectionContext();
         when(connectionSession.getConnectionContext()).thenReturn(connectionContext);
         when(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData()).thenReturn(new ShardingSphereMetaData(Collections.emptyList(),
@@ -196,7 +196,7 @@ class MySQLComStmtExecuteExecutorTest {
         when(packet.getStatementId()).thenReturn(2);
         when(packet.getNewParametersBoundFlag()).thenReturn(MySQLNewParametersBoundFlag.PARAMETER_TYPE_EXIST);
         when(packet.getNewParameterTypes()).thenReturn(Collections.singletonList(new MySQLPreparedStatementParameterType(MySQLBinaryColumnType.LONG, 0)));
-        when(packet.readParameters(anyList(), any(), anyList(), anyList())).thenReturn(Collections.singletonList(1));
+        when(packet.readParameters(anyList(), any(), anyList())).thenReturn(Collections.singletonList(1));
         MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
         when(proxyBackendHandler.execute()).thenReturn(new UpdateResponseHeader(UpdateStatement.builder().databaseType(databaseType).build()));
         when(ProxyBackendHandlerFactory.newInstance(eq(databaseType), any(QueryContext.class), eq(connectionSession), anyBoolean())).thenReturn(proxyBackendHandler);
@@ -232,13 +232,13 @@ class MySQLComStmtExecuteExecutorTest {
         when(selectStatementContext.getTablesContext().getDatabaseName()).thenReturn(Optional.empty());
         when(selectStatement.getParameterCount()).thenReturn(1);
         when(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(1))
-                .thenReturn(new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE id = ?", selectStatementContext, new HintValueContext(), Collections.singletonList(0)));
+                .thenReturn(new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE id = ?", selectStatementContext, new HintValueContext()));
         when(packet.getNewParameterTypes()).thenReturn(Collections.emptyList());
         when(packet.getNewParametersBoundFlag()).thenReturn(MySQLNewParametersBoundFlag.PARAMETER_TYPE_NOT_EXIST);
         MySQLNullBitmap nullBitmap = mock(MySQLNullBitmap.class);
         when(nullBitmap.isNullParameter(0)).thenReturn(true);
         when(packet.getNullBitmap()).thenReturn(nullBitmap);
-        when(packet.readParameters(anyList(), any(), anyList(), anyList())).thenAnswer(invocation -> Collections.singletonList(null));
+        when(packet.readParameters(anyList(), any(), anyList())).thenAnswer(invocation -> Collections.singletonList(null));
         MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
         when(proxyBackendHandler.execute()).thenReturn(new UpdateResponseHeader(selectStatement));
         AtomicReference<QueryContext> actualQueryContext = new AtomicReference<>();
@@ -251,7 +251,7 @@ class MySQLComStmtExecuteExecutorTest {
         assertFalse(actual.hasNext());
         assertThat(actualQueryContext.get().getParameters(), contains((Object) null));
         ArgumentCaptor<List<MySQLPreparedStatementParameterType>> parameterTypesCaptor = ArgumentCaptor.forClass(List.class);
-        verify(packet).readParameters(parameterTypesCaptor.capture(), any(), anyList(), anyList());
+        verify(packet).readParameters(parameterTypesCaptor.capture(), any(), anyList());
         assertThat(parameterTypesCaptor.getValue().size(), is(1));
         assertThat(parameterTypesCaptor.getValue().get(0).getColumnType(), is(MySQLBinaryColumnType.NULL));
     }
@@ -266,14 +266,14 @@ class MySQLComStmtExecuteExecutorTest {
         when(selectStatementContext.getTablesContext().getDatabaseName()).thenReturn(Optional.empty());
         when(selectStatement.getParameterCount()).thenReturn(2);
         when(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(1))
-                .thenReturn(new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE col1 = ? AND col2 = ?", selectStatementContext, new HintValueContext(), Arrays.asList(0, 1)));
+                .thenReturn(new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE col1 = ? AND col2 = ?", selectStatementContext, new HintValueContext()));
         when(packet.getNewParameterTypes()).thenReturn(Collections.emptyList());
         when(packet.getNewParametersBoundFlag()).thenReturn(MySQLNewParametersBoundFlag.PARAMETER_TYPE_NOT_EXIST);
         MySQLNullBitmap nullBitmap = mock(MySQLNullBitmap.class);
         when(nullBitmap.isNullParameter(0)).thenReturn(true);
         when(nullBitmap.isNullParameter(1)).thenReturn(true);
         when(packet.getNullBitmap()).thenReturn(nullBitmap);
-        when(packet.readParameters(anyList(), any(), anyList(), anyList())).thenReturn(Arrays.asList(null, null));
+        when(packet.readParameters(anyList(), any(), anyList())).thenReturn(Arrays.asList(null, null));
         MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
         when(proxyBackendHandler.execute()).thenReturn(new UpdateResponseHeader(selectStatement));
         AtomicReference<QueryContext> actualQueryContext = new AtomicReference<>();
@@ -286,7 +286,7 @@ class MySQLComStmtExecuteExecutorTest {
         assertFalse(actual.hasNext());
         assertThat(actualQueryContext.get().getParameters(), contains((Object) null, null));
         ArgumentCaptor<List<MySQLPreparedStatementParameterType>> parameterTypesCaptor = ArgumentCaptor.forClass(List.class);
-        verify(packet).readParameters(parameterTypesCaptor.capture(), any(), anyList(), anyList());
+        verify(packet).readParameters(parameterTypesCaptor.capture(), any(), anyList());
         assertThat(parameterTypesCaptor.getValue().size(), is(2));
         assertThat(parameterTypesCaptor.getValue().get(0).getColumnType(), is(MySQLBinaryColumnType.NULL));
         assertThat(parameterTypesCaptor.getValue().get(1).getColumnType(), is(MySQLBinaryColumnType.NULL));
@@ -302,7 +302,7 @@ class MySQLComStmtExecuteExecutorTest {
         when(selectStatementContext.getTablesContext().getDatabaseName()).thenReturn(Optional.empty());
         when(selectStatement.getParameterCount()).thenReturn(2);
         when(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(1))
-                .thenReturn(new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE col1 = ? AND col2 = ?", selectStatementContext, new HintValueContext(), Arrays.asList(0, 1)));
+                .thenReturn(new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE col1 = ? AND col2 = ?", selectStatementContext, new HintValueContext()));
         when(packet.getNewParameterTypes()).thenReturn(Collections.emptyList());
         when(packet.getNewParametersBoundFlag()).thenReturn(MySQLNewParametersBoundFlag.PARAMETER_TYPE_NOT_EXIST);
         MySQLNullBitmap nullBitmap = mock(MySQLNullBitmap.class);
@@ -319,7 +319,7 @@ class MySQLComStmtExecuteExecutorTest {
         when(packet.getNewParametersBoundFlag()).thenReturn(MySQLNewParametersBoundFlag.PARAMETER_TYPE_EXIST);
         List<MySQLPreparedStatementParameterType> expectedTypes = Collections.singletonList(new MySQLPreparedStatementParameterType(MySQLBinaryColumnType.LONG, 0));
         when(packet.getNewParameterTypes()).thenReturn(expectedTypes);
-        when(packet.readParameters(anyList(), any(), anyList(), anyList())).thenReturn(Collections.singletonList(1));
+        when(packet.readParameters(anyList(), any(), anyList())).thenReturn(Collections.singletonList(1));
         MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
         when(proxyBackendHandler.execute()).thenReturn(new UpdateResponseHeader(UpdateStatement.builder().databaseType(databaseType).build()));
         when(ProxyBackendHandlerFactory.newInstance(eq(databaseType), any(QueryContext.class), eq(connectionSession), anyBoolean())).thenReturn(proxyBackendHandler);
@@ -327,7 +327,7 @@ class MySQLComStmtExecuteExecutorTest {
         assertThat(actual.next(), isA(MySQLOKPacket.class));
         assertFalse(actual.hasNext());
         ArgumentCaptor<List<MySQLPreparedStatementParameterType>> parameterTypesCaptor = ArgumentCaptor.forClass(List.class);
-        verify(packet).readParameters(parameterTypesCaptor.capture(), any(), anyList(), anyList());
+        verify(packet).readParameters(parameterTypesCaptor.capture(), any(), anyList());
         assertThat(parameterTypesCaptor.getValue(), is(expectedTypes));
     }
     
@@ -337,10 +337,9 @@ class MySQLComStmtExecuteExecutorTest {
         when(packet.getStatementId()).thenReturn(1);
         when(packet.getNewParametersBoundFlag()).thenReturn(MySQLNewParametersBoundFlag.PARAMETER_TYPE_NOT_EXIST);
         when(packet.getNewParameterTypes()).thenReturn(Collections.emptyList());
-        when(packet.readParameters(anyList(), any(), anyList(), anyList())).thenReturn(Collections.singletonList(1));
+        when(packet.readParameters(anyList(), any(), anyList())).thenReturn(Collections.singletonList(1));
         MySQLPreparedStatementParameterType expectedType = new MySQLPreparedStatementParameterType(MySQLBinaryColumnType.LONG, 0);
-        MySQLServerPreparedStatement preparedStatement = new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE id = ?",
-                prepareSelectStatementContext(), new HintValueContext(), Collections.singletonList(0));
+        MySQLServerPreparedStatement preparedStatement = new MySQLServerPreparedStatement("SELECT * FROM tbl WHERE id = ?", prepareSelectStatementContext(), new HintValueContext());
         preparedStatement.getParameterTypes().add(expectedType);
         when(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(1)).thenReturn(preparedStatement);
         MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
@@ -350,7 +349,7 @@ class MySQLComStmtExecuteExecutorTest {
         assertThat(actual.next(), isA(MySQLOKPacket.class));
         assertFalse(actual.hasNext());
         ArgumentCaptor<List<MySQLPreparedStatementParameterType>> parameterTypesCaptor = ArgumentCaptor.forClass(List.class);
-        verify(packet).readParameters(parameterTypesCaptor.capture(), any(), anyList(), anyList());
+        verify(packet).readParameters(parameterTypesCaptor.capture(), any(), anyList());
         assertThat(parameterTypesCaptor.getValue(), contains(expectedType));
     }
 }

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLPreparedStatementMetadataFactoryTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLPreparedStatementMetadataFactoryTest.java
@@ -115,7 +115,7 @@ class MySQLPreparedStatementMetadataFactoryTest {
         TablesContext tablesContext = mock(TablesContext.class);
         when(tablesContext.getDatabaseNames()).thenReturn(Collections.singleton("foo_db"));
         when(sqlStatementContext.getTablesContext()).thenReturn(tablesContext);
-        return new MySQLServerPreparedStatement("SELECT 1", sqlStatementContext, new HintValueContext(), Collections.emptyList());
+        return new MySQLServerPreparedStatement("SELECT 1", sqlStatementContext, new HintValueContext());
     }
     
     private void mockMetaData() {

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/reset/MySQLComStmtResetExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/reset/MySQLComStmtResetExecutorTest.java
@@ -29,7 +29,6 @@ import org.apache.shardingsphere.proxy.frontend.mysql.command.query.binary.MySQL
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,7 +44,7 @@ class MySQLComStmtResetExecutorTest {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         when(connectionSession.getServerPreparedStatementRegistry()).thenReturn(new ServerPreparedStatementRegistry());
         when(connectionSession.getTransactionStatus()).thenReturn(new TransactionStatus());
-        MySQLServerPreparedStatement preparedStatement = new MySQLServerPreparedStatement("", mock(SQLStatementContext.class), new HintValueContext(), Collections.emptyList());
+        MySQLServerPreparedStatement preparedStatement = new MySQLServerPreparedStatement("", mock(SQLStatementContext.class), new HintValueContext());
         preparedStatement.getLongData().put(0, new byte[0]);
         connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(1, preparedStatement);
         MySQLComStmtResetPacket packet = mock(MySQLComStmtResetPacket.class);


### PR DESCRIPTION
Fixes #39203.

Changes proposed in this pull request:
  - Decode MySQL binary prepared statement numeric parameters using the unsigned flag carried by `COM_STMT_EXECUTE`, instead of the `UNSIGNED` flag of the target column metadata.
  - Prevent a signed `setInt(-1)` parameter from being decoded as `4294967295` before it reaches an `INT UNSIGNED` backend column.
  - Remove `parameterColumnDefinitionFlags` from `MySQLServerPreparedStatement`, because target column flags must not determine client parameter wire decoding.
  - Keep `parameterColumnTypes` for the existing BLOB handling path, so string-family parameters targeting BLOB columns continue to preserve raw bytes.
  - Add signed and unsigned numeric packet coverage using the same `FF FF FF FF` payload:
    - client unsigned flag `0x00` decodes to `-1`;
    - client unsigned flag `0x80` decodes to `4294967295L`.
  - Keep regression coverage for `STRING`, `VAR_STRING`, and `VARCHAR` parameters targeting `TINYBLOB`, `BLOB`, `MEDIUMBLOB`, and `LONGBLOB` columns.

Manual verification:
  - Verified `INT UNSIGNED <- setInt(-1)` through Proxy now forwards `-1` and receives the same `SQLState 22001` out-of-range error as a direct MySQL connection.
  - Verified valid unsigned numeric INSERT and UPDATE scenarios through Proxy.
  - Verified INSERT and UPDATE byte preservation for `TINYBLOB`, `BLOB`, `MEDIUMBLOB`, `LONGBLOB`, `LONG VARBINARY`, `BINARY`, and `VARBINARY`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation. No user documentation change is required for this bug fix.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/).