### PR TITLE
Support production data source lookup after sharding routing

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,7 @@
 1. Sharding: Fix generated actual index names exceeding database identifier length limits while preserving legacy generated index name compatibility - [#38449](https://github.com/apache/shardingsphere/pull/38449)
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
+1. Sharding: Support production data source lookup after sharding routing - [#39205](https://github.com/apache/shardingsphere/pull/39205)
 
 ### Enhancements
 

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/rule/ShadowRule.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/rule/ShadowRule.java
@@ -62,11 +62,14 @@ public final class ShadowRule implements DatabaseRule {
     @Getter
     private final RuleAttributes attributes;
     
+    private final Map<String, String> cachedProductionDataSourceNames;
+    
     public ShadowRule(final ShadowRuleConfiguration ruleConfig) {
         configuration = ruleConfig;
         shadowAlgorithms = createShadowAlgorithms(ruleConfig.getShadowAlgorithms());
         defaultShadowAlgorithm = shadowAlgorithms.get(ruleConfig.getDefaultShadowAlgorithmName());
         dataSourceRules = createDataSourceRules(ruleConfig.getDataSources());
+        cachedProductionDataSourceNames = createCachedProductionDataSourceNames(dataSourceRules);
         tableRules = createTableRules(ruleConfig.getTables());
         attributes = new RuleAttributes(new ShadowDataSourceMapperRuleAttribute(dataSourceRules));
     }
@@ -243,11 +246,22 @@ public final class ShadowRule implements DatabaseRule {
     @HighFrequencyInvocation
     public Optional<String> findProductionDataSourceName(final String logicDataSourceName) {
         ShadowDataSourceRule dataSourceRule = dataSourceRules.get(logicDataSourceName);
-        return null == dataSourceRule ? Optional.empty() : Optional.of(dataSourceRule.getProductionDataSource());
+        if (null != dataSourceRule) {
+            return Optional.of(dataSourceRule.getProductionDataSource());
+        }
+        return Optional.ofNullable(cachedProductionDataSourceNames.get(logicDataSourceName));
     }
     
     @Override
     public int getOrder() {
         return ShadowOrder.ORDER;
+    }
+    
+    private Map<String, String> createCachedProductionDataSourceNames(final Map<String, ShadowDataSourceRule> dataSourceRules) {
+        Map<String, String> result = new CaseInsensitiveMap<>();
+        for (ShadowDataSourceRule each : dataSourceRules.values()) {
+            result.put(each.getProductionDataSource(), each.getProductionDataSource());
+        }
+        return result;
     }
 }

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/ShadowSQLRouterTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/ShadowSQLRouterTest.java
@@ -85,6 +85,8 @@ class ShadowSQLRouterTest {
         return Stream.of(
                 Arguments.of("skip route unit when production data source is absent", "foo_ds", null, Collections.emptyMap(), "foo_ds"),
                 Arguments.of("replace route unit with shadow data source", "foo_route_ds", "foo_prod_ds", Collections.singletonMap("foo_prod_ds", "foo_shadow_ds"), "foo_shadow_ds"),
+                Arguments.of("replace route unit with shadow data source after sharding routes to physical", "prod_ds_0", "prod_ds_0", Collections.singletonMap("prod_ds_0", "shadow_ds_0"),
+                        "shadow_ds_0"),
                 Arguments.of("replace route unit with production data source when shadow mapping is absent", "foo_route_ds", "foo_prod_ds", Collections.emptyMap(), "foo_prod_ds"));
     }
 }

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/rule/ShadowRuleTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/rule/ShadowRuleTest.java
@@ -199,4 +199,9 @@ class ShadowRuleTest {
     void assertGetOrder() {
         assertThat(rule.getOrder(), is(ShadowOrder.ORDER));
     }
+    
+    @Test
+    void assertFindProductionDataSourceNameByProductionNameSuccess() {
+        assertThat(rule.findProductionDataSourceName("prod_ds_0"), is(Optional.of("prod_ds_0")));
+    }
 }


### PR DESCRIPTION
Fixes #37081 

Allow findProductionDataSourceName() to resolve production data source names directly after sharding routing. Add unit tests for production data source lookup and shadow routing after sharding.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in the comment I request) added corresponding labels for the pull request.
- [x] I have passed Maven check locally: `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
