### PR TITLE
Correct Javadoc casing on EncryptAlgorithm toConfiguration

### DIFF
--- a/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/spi/EncryptAlgorithm.java
+++ b/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/spi/EncryptAlgorithm.java
@@ -52,7 +52,7 @@ public interface EncryptAlgorithm extends ShardingSphereAlgorithm {
     EncryptAlgorithmMetaData getMetaData();
     
     /**
-     * convert to encryptor configuration.
+     * Convert to encryptor configuration.
      *
      * @return converted configuration
      */


### PR DESCRIPTION
No issue: typo fix.

Changes proposed in this pull request:
  - Capitalize the first word of the `toConfiguration()` Javadoc summary in `EncryptAlgorithm` from `convert` to `Convert`.
  - Aligns the summary sentence with its sibling methods (`encrypt`, `decrypt`, `getMetaData`) in the same SPI, which all start with a capitalized verb.
  - Documentation-only change; the SPI signature, behavior, and contract are unchanged.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw spotless:apply -Pcheck -T1C -pl features/encrypt/api` and `./mvnw checkstyle:check -Pcheck -T1C -pl features/encrypt/api`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version.
