### PR TITLE
Fix copy-pasted class Javadoc on EncryptShowCreateViewMergedResult

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dal/show/EncryptShowCreateViewMergedResult.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dal/show/EncryptShowCreateViewMergedResult.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Encrypt show create table merged result.
+ * Encrypt show create view merged result.
  */
 public final class EncryptShowCreateViewMergedResult extends DecoratorMergedResult {
     


### PR DESCRIPTION
No issue: typo fix.

Changes proposed in this pull request:
  - Correct the class-level Javadoc of `EncryptShowCreateViewMergedResult` from "Encrypt show create table merged result." to "Encrypt show create view merged result.", so it describes the class's actual responsibility.
  - The class is a SHOW CREATE VIEW decorator (imports `CreateViewStatement`, holds a `viewName` field, casts the parse result to `CreateViewStatement`); the previous text was copy-pasted from the sibling `EncryptShowCreateTableMergedResult`.
  - Behavior-invariant: Javadoc only, no runtime, signature, or return-value change.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally (`spotless:apply`, `checkstyle:check`, `apache-rat:check`, and `install -pl features/encrypt/core -am` all pass).
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version.
