### PR TITLE
Fix stale encryptors leaking when altering an encrypt rule

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,6 +51,7 @@
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
 1. SQL Federation: Fix SQL Federation pagination binding for long LIMIT parameters - [#39237](https://github.com/apache/shardingsphere/pull/39237)
+1. Encrypt: Fix stale encryptors leaking when altering an encrypt rule - [#39209](https://github.com/apache/shardingsphere/pull/39209)
 
 ### Enhancements
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -82,6 +82,7 @@
 1. Readwrite-splitting: Evaluate inline expressions in data source names of rule configuration checker - [#39374](https://github.com/apache/shardingsphere/pull/39374)
 1. SQL Federation: Fix SQL Federation pagination binding for long LIMIT parameters - [#39237](https://github.com/apache/shardingsphere/pull/39237)
 1. Broadcast: Fix case-sensitive table name lookup in broadcast data node rule attribute - [#39153](https://github.com/apache/shardingsphere/pull/39153)
+1. Encrypt: Fix stale encryptors leaking when altering an encrypt rule - [#39209](https://github.com/apache/shardingsphere/pull/39209)
 
 ### Enhancements
 

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutor.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutor.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.data
 import org.apache.shardingsphere.distsql.handler.required.DistSQLExecutorCurrentRuleRequired;
 import org.apache.shardingsphere.distsql.segment.AlgorithmSegment;
 import org.apache.shardingsphere.encrypt.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.config.rule.EncryptTableRuleConfiguration;
 import org.apache.shardingsphere.encrypt.distsql.handler.converter.EncryptRuleStatementConverter;
 import org.apache.shardingsphere.encrypt.distsql.segment.EncryptRuleSegment;
 import org.apache.shardingsphere.encrypt.distsql.statement.AlterEncryptRuleStatement;
@@ -102,7 +103,11 @@ public final class AlterEncryptRuleExecutor implements DatabaseRuleAlterExecutor
     
     @Override
     public EncryptRuleConfiguration buildToBeDroppedRuleConfiguration(final EncryptRuleConfiguration toBeAlteredRuleConfig) {
-        Collection<String> unusedEncryptor = UnusedAlgorithmFinder.findUnusedEncryptor(rule.getConfiguration());
+        Collection<String> toBeAlteredTableNames = toBeAlteredRuleConfig.getTables().stream().map(EncryptTableRuleConfiguration::getName).collect(Collectors.toList());
+        Collection<EncryptTableRuleConfiguration> tables = rule.getConfiguration().getTables().stream().filter(each -> !toBeAlteredTableNames.contains(each.getName())).collect(Collectors.toList());
+        tables.addAll(toBeAlteredRuleConfig.getTables());
+        EncryptRuleConfiguration toBeCheckedRuleConfig = new EncryptRuleConfiguration(tables, rule.getConfiguration().getEncryptors());
+        Collection<String> unusedEncryptor = UnusedAlgorithmFinder.findUnusedEncryptor(toBeCheckedRuleConfig);
         Map<String, AlgorithmConfiguration> toBeDroppedEncryptors = new HashMap<>(unusedEncryptor.size(), 1F);
         unusedEncryptor.forEach(each -> toBeDroppedEncryptors.put(each, rule.getConfiguration().getEncryptors().get(each)));
         return new EncryptRuleConfiguration(Collections.emptyList(), toBeDroppedEncryptors);

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutor.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.encrypt.distsql.handler.update;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Setter;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.type.DatabaseRuleAlterExecutor;
 import org.apache.shardingsphere.distsql.handler.required.DistSQLExecutorCurrentRuleRequired;
@@ -103,7 +104,7 @@ public final class AlterEncryptRuleExecutor implements DatabaseRuleAlterExecutor
     
     @Override
     public EncryptRuleConfiguration buildToBeDroppedRuleConfiguration(final EncryptRuleConfiguration toBeAlteredRuleConfig) {
-        Collection<String> toBeAlteredTableNames = toBeAlteredRuleConfig.getTables().stream().map(EncryptTableRuleConfiguration::getName).collect(Collectors.toList());
+        Collection<String> toBeAlteredTableNames = new CaseInsensitiveSet<>(toBeAlteredRuleConfig.getTables().stream().map(EncryptTableRuleConfiguration::getName).collect(Collectors.toList()));
         Collection<EncryptTableRuleConfiguration> tables = rule.getConfiguration().getTables().stream().filter(each -> !toBeAlteredTableNames.contains(each.getName())).collect(Collectors.toList());
         tables.addAll(toBeAlteredRuleConfig.getTables());
         EncryptRuleConfiguration toBeCheckedRuleConfig = new EncryptRuleConfiguration(tables, rule.getConfiguration().getEncryptors());

--- a/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutorTest.java
+++ b/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutorTest.java
@@ -22,12 +22,15 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine;
 import org.apache.shardingsphere.distsql.segment.AlgorithmSegment;
 import org.apache.shardingsphere.encrypt.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.config.rule.EncryptColumnItemRuleConfiguration;
+import org.apache.shardingsphere.encrypt.config.rule.EncryptColumnRuleConfiguration;
 import org.apache.shardingsphere.encrypt.config.rule.EncryptTableRuleConfiguration;
 import org.apache.shardingsphere.encrypt.distsql.segment.EncryptColumnItemSegment;
 import org.apache.shardingsphere.encrypt.distsql.segment.EncryptColumnSegment;
 import org.apache.shardingsphere.encrypt.distsql.segment.EncryptRuleSegment;
 import org.apache.shardingsphere.encrypt.distsql.statement.AlterEncryptRuleStatement;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
+import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.InvalidRuleConfigurationException;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.MissingRequiredRuleException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -40,7 +43,9 @@ import org.mockito.ArgumentMatchers;
 
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
@@ -111,6 +116,38 @@ class AlterEncryptRuleExecutorTest {
         assertDoesNotThrow(() -> metaDataManagerPersistService.alterRuleConfiguration(any(), ArgumentMatchers.argThat(this::assertToBeAlteredRuleConfiguration)));
     }
     
+    @Test
+    void assertBuildToBeDroppedRuleConfigurationWhenAssistedAndLikeQueriesRemoved() {
+        EncryptRule rule = mock(EncryptRule.class);
+        when(rule.getConfiguration()).thenReturn(createCurrentRuleConfigurationWithGeneratedEncryptors());
+        AlterEncryptRuleExecutor executor = new AlterEncryptRuleExecutor();
+        executor.setRule(rule);
+        EncryptColumnRuleConfiguration alteredColumn = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "foo_cipher"));
+        EncryptRuleConfiguration toBeAlteredRuleConfig = new EncryptRuleConfiguration(
+                Collections.singleton(new EncryptTableRuleConfiguration("t_encrypt", Collections.singleton(alteredColumn))), Collections.emptyMap());
+        EncryptRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(toBeAlteredRuleConfig);
+        assertTrue(actual.getTables().isEmpty());
+        assertThat(actual.getEncryptors().size(), is(2));
+        assertTrue(actual.getEncryptors().containsKey("foo_assisted"));
+        assertTrue(actual.getEncryptors().containsKey("foo_like"));
+    }
+    
+    @Test
+    void assertBuildToBeDroppedRuleConfigurationWhenColumnDefinitionUnchanged() {
+        EncryptRule rule = mock(EncryptRule.class);
+        when(rule.getConfiguration()).thenReturn(createCurrentRuleConfigurationWithGeneratedEncryptors());
+        AlterEncryptRuleExecutor executor = new AlterEncryptRuleExecutor();
+        executor.setRule(rule);
+        EncryptColumnRuleConfiguration alteredColumn = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "foo_cipher"));
+        alteredColumn.setAssistedQuery(new EncryptColumnItemRuleConfiguration("user_assisted", "foo_assisted"));
+        alteredColumn.setLikeQuery(new EncryptColumnItemRuleConfiguration("user_like", "foo_like"));
+        EncryptRuleConfiguration toBeAlteredRuleConfig = new EncryptRuleConfiguration(
+                Collections.singleton(new EncryptTableRuleConfiguration("t_encrypt", Collections.singleton(alteredColumn))), Collections.emptyMap());
+        EncryptRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(toBeAlteredRuleConfig);
+        assertTrue(actual.getTables().isEmpty());
+        assertTrue(actual.getEncryptors().isEmpty());
+    }
+    
     private ContextManager mockContextManager(final EncryptRule rule) {
         DatabaseType databaseType = mock(DatabaseType.class);
         ResourceMetaData resourceMetaData = mock(ResourceMetaData.class);
@@ -140,6 +177,18 @@ class AlterEncryptRuleExecutorTest {
     private EncryptRuleConfiguration createCurrentRuleConfiguration() {
         EncryptTableRuleConfiguration tableRuleConfig = new EncryptTableRuleConfiguration("t_encrypt", Collections.emptyList());
         return new EncryptRuleConfiguration(new LinkedList<>(Collections.singleton(tableRuleConfig)), Collections.emptyMap());
+    }
+    
+    private EncryptRuleConfiguration createCurrentRuleConfigurationWithGeneratedEncryptors() {
+        EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "foo_cipher"));
+        columnRuleConfig.setAssistedQuery(new EncryptColumnItemRuleConfiguration("user_assisted", "foo_assisted"));
+        columnRuleConfig.setLikeQuery(new EncryptColumnItemRuleConfiguration("user_like", "foo_like"));
+        Map<String, AlgorithmConfiguration> encryptors = new HashMap<>(3, 1F);
+        encryptors.put("foo_cipher", new AlgorithmConfiguration("MD5", new Properties()));
+        encryptors.put("foo_assisted", new AlgorithmConfiguration("MD5", new Properties()));
+        encryptors.put("foo_like", new AlgorithmConfiguration("MD5", new Properties()));
+        EncryptTableRuleConfiguration tableRuleConfig = new EncryptTableRuleConfiguration("t_encrypt", Collections.singleton(columnRuleConfig));
+        return new EncryptRuleConfiguration(new LinkedList<>(Collections.singleton(tableRuleConfig)), encryptors);
     }
     
     private boolean assertToBeDroppedRuleConfiguration(final EncryptRuleConfiguration actual) {

--- a/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutorTest.java
+++ b/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutorTest.java
@@ -21,12 +21,15 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine;
 import org.apache.shardingsphere.distsql.segment.AlgorithmSegment;
 import org.apache.shardingsphere.encrypt.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.config.rule.EncryptColumnItemRuleConfiguration;
+import org.apache.shardingsphere.encrypt.config.rule.EncryptColumnRuleConfiguration;
 import org.apache.shardingsphere.encrypt.config.rule.EncryptTableRuleConfiguration;
 import org.apache.shardingsphere.encrypt.distsql.segment.EncryptColumnItemSegment;
 import org.apache.shardingsphere.encrypt.distsql.segment.EncryptColumnSegment;
 import org.apache.shardingsphere.encrypt.distsql.segment.EncryptRuleSegment;
 import org.apache.shardingsphere.encrypt.distsql.statement.AlterEncryptRuleStatement;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
+import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.InvalidRuleConfigurationException;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.MissingRequiredRuleException;
@@ -39,7 +42,9 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -111,6 +116,38 @@ class AlterEncryptRuleExecutorTest {
         assertDoesNotThrow(() -> metaDataManagerPersistService.alterRuleConfiguration(any(), argThat(this::assertToBeAlteredRuleConfiguration)));
     }
     
+    @Test
+    void assertBuildToBeDroppedRuleConfigurationWhenAssistedAndLikeQueriesRemoved() {
+        EncryptRule rule = mock(EncryptRule.class);
+        when(rule.getConfiguration()).thenReturn(createCurrentRuleConfigurationWithGeneratedEncryptors());
+        AlterEncryptRuleExecutor executor = new AlterEncryptRuleExecutor();
+        executor.setRule(rule);
+        EncryptColumnRuleConfiguration alteredColumn = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "foo_cipher"));
+        EncryptRuleConfiguration toBeAlteredRuleConfig = new EncryptRuleConfiguration(
+                Collections.singleton(new EncryptTableRuleConfiguration("t_encrypt", Collections.singleton(alteredColumn))), Collections.emptyMap());
+        EncryptRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(toBeAlteredRuleConfig);
+        assertTrue(actual.getTables().isEmpty());
+        assertThat(actual.getEncryptors().size(), is(2));
+        assertTrue(actual.getEncryptors().containsKey("foo_assisted"));
+        assertTrue(actual.getEncryptors().containsKey("foo_like"));
+    }
+    
+    @Test
+    void assertBuildToBeDroppedRuleConfigurationWhenColumnDefinitionUnchanged() {
+        EncryptRule rule = mock(EncryptRule.class);
+        when(rule.getConfiguration()).thenReturn(createCurrentRuleConfigurationWithGeneratedEncryptors());
+        AlterEncryptRuleExecutor executor = new AlterEncryptRuleExecutor();
+        executor.setRule(rule);
+        EncryptColumnRuleConfiguration alteredColumn = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "foo_cipher"));
+        alteredColumn.setAssistedQuery(new EncryptColumnItemRuleConfiguration("user_assisted", "foo_assisted"));
+        alteredColumn.setLikeQuery(new EncryptColumnItemRuleConfiguration("user_like", "foo_like"));
+        EncryptRuleConfiguration toBeAlteredRuleConfig = new EncryptRuleConfiguration(
+                Collections.singleton(new EncryptTableRuleConfiguration("t_encrypt", Collections.singleton(alteredColumn))), Collections.emptyMap());
+        EncryptRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(toBeAlteredRuleConfig);
+        assertTrue(actual.getTables().isEmpty());
+        assertTrue(actual.getEncryptors().isEmpty());
+    }
+    
     private ContextManager mockContextManager(final EncryptRule rule) {
         DatabaseType databaseType = mock(DatabaseType.class);
         ResourceMetaData resourceMetaData = mock(ResourceMetaData.class);
@@ -140,6 +177,18 @@ class AlterEncryptRuleExecutorTest {
     private EncryptRuleConfiguration createCurrentRuleConfiguration() {
         EncryptTableRuleConfiguration tableRuleConfig = new EncryptTableRuleConfiguration("t_encrypt", Collections.emptyList());
         return new EncryptRuleConfiguration(new LinkedList<>(Collections.singleton(tableRuleConfig)), Collections.emptyMap());
+    }
+    
+    private EncryptRuleConfiguration createCurrentRuleConfigurationWithGeneratedEncryptors() {
+        EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "foo_cipher"));
+        columnRuleConfig.setAssistedQuery(new EncryptColumnItemRuleConfiguration("user_assisted", "foo_assisted"));
+        columnRuleConfig.setLikeQuery(new EncryptColumnItemRuleConfiguration("user_like", "foo_like"));
+        Map<String, AlgorithmConfiguration> encryptors = new HashMap<>(3, 1F);
+        encryptors.put("foo_cipher", new AlgorithmConfiguration("MD5", new Properties()));
+        encryptors.put("foo_assisted", new AlgorithmConfiguration("MD5", new Properties()));
+        encryptors.put("foo_like", new AlgorithmConfiguration("MD5", new Properties()));
+        EncryptTableRuleConfiguration tableRuleConfig = new EncryptTableRuleConfiguration("t_encrypt", Collections.singleton(columnRuleConfig));
+        return new EncryptRuleConfiguration(new LinkedList<>(Collections.singleton(tableRuleConfig)), encryptors);
     }
     
     private boolean assertToBeDroppedRuleConfiguration(final EncryptRuleConfiguration actual) {

--- a/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutorTest.java
+++ b/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutorTest.java
@@ -133,6 +133,22 @@ class AlterEncryptRuleExecutorTest {
     }
     
     @Test
+    void assertBuildToBeDroppedRuleConfigurationWhenAlteredTableNameCaseDiffers() {
+        EncryptRule rule = mock(EncryptRule.class);
+        when(rule.getConfiguration()).thenReturn(createCurrentRuleConfigurationWithGeneratedEncryptors());
+        AlterEncryptRuleExecutor executor = new AlterEncryptRuleExecutor();
+        executor.setRule(rule);
+        EncryptColumnRuleConfiguration alteredColumn = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "foo_cipher"));
+        EncryptRuleConfiguration toBeAlteredRuleConfig = new EncryptRuleConfiguration(
+                Collections.singleton(new EncryptTableRuleConfiguration("T_ENCRYPT", Collections.singleton(alteredColumn))), Collections.emptyMap());
+        EncryptRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(toBeAlteredRuleConfig);
+        assertTrue(actual.getTables().isEmpty());
+        assertThat(actual.getEncryptors().size(), is(2));
+        assertTrue(actual.getEncryptors().containsKey("foo_assisted"));
+        assertTrue(actual.getEncryptors().containsKey("foo_like"));
+    }
+    
+    @Test
     void assertBuildToBeDroppedRuleConfigurationWhenColumnDefinitionUnchanged() {
         EncryptRule rule = mock(EncryptRule.class);
         when(rule.getConfiguration()).thenReturn(createCurrentRuleConfigurationWithGeneratedEncryptors());


### PR DESCRIPTION

Fixes #39206.

Changes proposed in this pull request:
  - `AlterEncryptRuleExecutor.buildToBeDroppedRuleConfiguration()` now synthesizes the post-alter configuration (unchanged tables plus the altered ones) before calling `UnusedAlgorithmFinder.findUnusedEncryptor`, so encryptors orphaned by an ALTER are dropped.
  - Previously it ignored its `toBeAlteredRuleConfig` parameter and checked the pre-alter configuration, where every encryptor is still in use, so nothing was dropped and `assist_*` / `like_*` encryptors leaked.
  - Aligns the ALTER encrypt path with the sibling `AlterMaskRuleExecutor`, which already merges unchanged and altered tables; `DropEncryptRuleExecutor` was already correct.
  - Adds unit tests for assisted/like removal (encryptors dropped) and an unchanged column definition (nothing dropped).

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`. <!-- module-scoped install -pl features/encrypt/distsql/handler -am passed; spotless/checkstyle/apache-rat clean -->
- [ ] I have made corresponding changes to the documentation. <!-- no user-facing docs affected; behavior fix -->
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)


