### PR TITLE
Add common advisors yaml to get ContextManager when agent work with driver

### DIFF
--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/config/AdvisorConfigurationLoader.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/config/AdvisorConfigurationLoader.java
@@ -25,9 +25,9 @@ import org.apache.shardingsphere.agent.core.advisor.config.yaml.swapper.YamlAdvi
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
@@ -51,20 +51,22 @@ public final class AdvisorConfigurationLoader {
     public static Map<String, AdvisorConfiguration> load(final Collection<JarFile> pluginJars, final Collection<String> pluginTypes) {
         Map<String, AdvisorConfiguration> result = new HashMap<>();
         for (String each : pluginTypes) {
-            InputStream advisorsResourceStream = getResourceStream(pluginJars, each);
-            if (null == advisorsResourceStream) {
-                LOGGER.log(Level.WARNING, "The configuration file for advice of plugin `{0}` is not found", new String[]{each});
-            }
-            Optional.ofNullable(advisorsResourceStream)
-                    .ifPresent(optional -> mergeConfigurations(result, YamlAdvisorsConfigurationSwapper.swap(YamlAdvisorsConfigurationLoader.load(optional), each)));
-            if (null != advisorsResourceStream) {
-                try {
-                    advisorsResourceStream.close();
-                } catch (final IOException ignored) {
-                }
-            }
+            mergeConfigurations(result, loadAdvisorConfigurations(pluginJars, each));
         }
+        mergeConfigurations(result, loadAdvisorConfigurations(pluginJars, "common"));
         return result;
+    }
+    
+    private static Collection<AdvisorConfiguration> loadAdvisorConfigurations(final Collection<JarFile> pluginJars, final String pluginType) {
+        try (InputStream advisorsResourceStream = getResourceStream(pluginJars, pluginType)) {
+            if (null == advisorsResourceStream) {
+                LOGGER.log(Level.WARNING, "The configuration file for advice of plugin `{0}` is not found", new String[]{pluginType});
+                return Collections.emptyList();
+            }
+            return YamlAdvisorsConfigurationSwapper.swap(YamlAdvisorsConfigurationLoader.load(advisorsResourceStream), pluginType);
+        } catch (final IOException ignored) {
+            return Collections.emptyList();
+        }
     }
     
     private static InputStream getResourceStream(final Collection<JarFile> pluginJars, final String pluginType) {

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/builder/AgentBuilderFactory.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/builder/AgentBuilderFactory.java
@@ -45,8 +45,8 @@ public final class AgentBuilderFactory {
      * @param isEnhancedForProxy is enhanced for proxy
      * @return created agent builder
      */
-    public static AgentBuilder create(final Map<String, PluginConfiguration> pluginConfigs,
-                                      final Collection<JarFile> pluginJars, final Map<String, AdvisorConfiguration> advisorConfigs, final boolean isEnhancedForProxy) {
+    public static AgentBuilder create(final Map<String, PluginConfiguration> pluginConfigs, final Collection<JarFile> pluginJars, final Map<String, AdvisorConfiguration> advisorConfigs,
+                                      final boolean isEnhancedForProxy) {
         return new AgentBuilder.Default()
                 .with(new ByteBuddy().with(TypeValidation.ENABLED))
                 .ignore(ElementMatchers.isSynthetic())

--- a/agent/plugins/core/pom.xml
+++ b/agent/plugins/core/pom.xml
@@ -30,6 +30,15 @@
         <target.directory>${project.basedir}/target/lib</target.directory>
     </properties>
     
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-test-infra-framework</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
     <build>
         <plugins>
             <plugin>

--- a/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/advice/common/ShardingSphereDataSourceAdvice.java
+++ b/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/advice/common/ShardingSphereDataSourceAdvice.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.agent.plugin.metrics.core.advice.jdbc;
+package org.apache.shardingsphere.agent.plugin.core.advice.common;
 
 import org.apache.shardingsphere.agent.api.advice.TargetAdviceMethod;
 import org.apache.shardingsphere.agent.api.advice.TargetAdviceObject;

--- a/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/context/PluginContext.java
+++ b/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/context/PluginContext.java
@@ -55,7 +55,8 @@ public final class PluginContext {
      * @return true or false
      */
     public boolean isPluginEnabled() {
-        return getContextManager().map(optional -> optional.getMetaDataContexts().getMetaData().getProps().<Boolean>getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED)).orElse(false);
+        return getContextManager().map(optional -> optional.getMetaDataContexts().getMetaData().getProps().<Boolean>getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED))
+                .orElse(true);
     }
     
     /**

--- a/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/context/PluginContext.java
+++ b/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/context/PluginContext.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.agent.plugin.core.context;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.shardingsphere.agent.plugin.core.holder.ShardingSphereDataSourceContextHolder;
@@ -31,12 +32,11 @@ import java.util.Optional;
  * Plugin Context.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 @Setter
 public final class PluginContext {
     
     private static final PluginContext INSTANCE = new PluginContext();
-    
-    private ContextManager contextManager;
     
     private boolean isEnhancedForProxy;
     
@@ -55,13 +55,15 @@ public final class PluginContext {
      * @return true or false
      */
     public boolean isPluginEnabled() {
-        if (null == contextManager) {
-            contextManager = getContextManager().orElse(null);
-        }
-        return null == contextManager || contextManager.getMetaDataContexts().getMetaData().getProps().<Boolean>getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED);
+        return getContextManager().map(optional -> optional.getMetaDataContexts().getMetaData().getProps().<Boolean>getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED)).orElse(false);
     }
     
-    private Optional<ContextManager> getContextManager() {
+    /**
+     * Get context manager.
+     *
+     * @return context manager
+     */
+    public Optional<ContextManager> getContextManager() {
         if (isEnhancedForProxy) {
             return Optional.ofNullable(ProxyContext.getInstance().getContextManager());
         }

--- a/agent/plugins/core/src/main/resources/META-INF/conf/common-advisors.yaml
+++ b/agent/plugins/core/src/main/resources/META-INF/conf/common-advisors.yaml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+advisors:
+  - target: org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource
+    advice: org.apache.shardingsphere.agent.plugin.core.advice.common.ShardingSphereDataSourceAdvice
+    pointcuts:
+      - name: createContextManager
+        type: method
+      - name: close
+        type: method
+        paramLength: 0

--- a/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/advice/common/ShardingSphereDataSourceAdviceTest.java
+++ b/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/advice/common/ShardingSphereDataSourceAdviceTest.java
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.agent.plugin.metrics.core.advice.jdbc;
+package org.apache.shardingsphere.agent.plugin.core.advice.common;
 
 import org.apache.shardingsphere.agent.api.advice.TargetAdviceMethod;
 import org.apache.shardingsphere.agent.plugin.core.context.ShardingSphereDataSourceContext;
+import org.apache.shardingsphere.agent.plugin.core.fixture.TargetAdviceObjectFixture;
 import org.apache.shardingsphere.agent.plugin.core.holder.ShardingSphereDataSourceContextHolder;
 import org.apache.shardingsphere.agent.plugin.core.util.AgentReflectionUtils;
-import org.apache.shardingsphere.agent.plugin.metrics.core.fixture.TargetAdviceObjectFixture;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.UUID;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;

--- a/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/context/PluginContextTest.java
+++ b/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/context/PluginContextTest.java
@@ -21,28 +21,62 @@ import org.apache.shardingsphere.agent.plugin.core.holder.ShardingSphereDataSour
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.configuration.plugins.Plugins;
+
+import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class PluginContextTest {
     
+    private boolean originalIsEnhancedForProxy;
+    
+    private ContextManager originalProxyContextManager;
+    
+    @BeforeEach
+    void setUp() throws ReflectiveOperationException {
+        ShardingSphereDataSourceContextHolder.getShardingSphereDataSourceContexts().clear();
+        PluginContext pluginContext = PluginContext.getInstance();
+        originalIsEnhancedForProxy = pluginContext.isEnhancedForProxy();
+        pluginContext.setEnhancedForProxy(false);
+        Field contextManagerField = ProxyContext.class.getDeclaredField("contextManager");
+        originalProxyContextManager = (ContextManager) Plugins.getMemberAccessor().get(contextManagerField, ProxyContext.getInstance());
+        Plugins.getMemberAccessor().set(contextManagerField, ProxyContext.getInstance(), null);
+    }
+    
+    @AfterEach
+    void tearDown() throws ReflectiveOperationException {
+        ShardingSphereDataSourceContextHolder.getShardingSphereDataSourceContexts().clear();
+        PluginContext.getInstance().setEnhancedForProxy(originalIsEnhancedForProxy);
+        Plugins.getMemberAccessor().set(ProxyContext.class.getDeclaredField("contextManager"), ProxyContext.getInstance(), originalProxyContextManager);
+    }
+    
     @Test
     void assertIsPluginEnabledWithEmptyDataSourceContextHolder() {
-        assertFalse(PluginContext.getInstance().isPluginEnabled());
+        assertTrue(PluginContext.getInstance().isPluginEnabled());
+    }
+    
+    @Test
+    void assertIsPluginEnabledWithShardingSphereDataSourceContextEnabled() {
+        ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
+        when(contextManager.getMetaDataContexts().getMetaData().getProps().<Boolean>getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED)).thenReturn(true);
+        ShardingSphereDataSourceContextHolder.put("foo_instance", new ShardingSphereDataSourceContext("foo_db", contextManager));
+        assertTrue(PluginContext.getInstance().isPluginEnabled());
     }
     
     @Test
     void assertIsPluginEnabledWithShardingSphereDataSourceContextDisabled() {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(contextManager.getMetaDataContexts().getMetaData().getProps().<Boolean>getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED)).thenReturn(false);
-        ShardingSphereDataSourceContextHolder.getShardingSphereDataSourceContexts().clear();
         ShardingSphereDataSourceContextHolder.put("foo_instance", new ShardingSphereDataSourceContext("foo_db", contextManager));
         assertFalse(PluginContext.getInstance().isPluginEnabled());
-        ShardingSphereDataSourceContextHolder.getShardingSphereDataSourceContexts().clear();
     }
     
     @Test

--- a/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/context/PluginContextTest.java
+++ b/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/context/PluginContextTest.java
@@ -21,70 +21,28 @@ import org.apache.shardingsphere.agent.plugin.core.holder.ShardingSphereDataSour
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.internal.configuration.plugins.Plugins;
-
-import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class PluginContextTest {
     
-    private ContextManager originalPluginContextManager;
-    
-    private boolean originalIsEnhancedForProxy;
-    
-    private ContextManager originalProxyContextManager;
-    
-    @BeforeEach
-    void setUp() throws ReflectiveOperationException {
-        ShardingSphereDataSourceContextHolder.getShardingSphereDataSourceContexts().clear();
-        PluginContext pluginContext = PluginContext.getInstance();
-        Field contextManagerField = PluginContext.class.getDeclaredField("contextManager");
-        originalPluginContextManager = (ContextManager) Plugins.getMemberAccessor().get(contextManagerField, pluginContext);
-        Plugins.getMemberAccessor().set(contextManagerField, pluginContext, null);
-        Field isEnhancedForProxyField = PluginContext.class.getDeclaredField("isEnhancedForProxy");
-        originalIsEnhancedForProxy = (boolean) Plugins.getMemberAccessor().get(isEnhancedForProxyField, pluginContext);
-        Plugins.getMemberAccessor().set(isEnhancedForProxyField, pluginContext, false);
-        Field proxyContextManagerField = ProxyContext.class.getDeclaredField("contextManager");
-        originalProxyContextManager = (ContextManager) Plugins.getMemberAccessor().get(proxyContextManagerField, ProxyContext.getInstance());
-        Plugins.getMemberAccessor().set(proxyContextManagerField, ProxyContext.getInstance(), null);
-    }
-    
-    @AfterEach
-    void tearDown() throws ReflectiveOperationException {
-        ShardingSphereDataSourceContextHolder.getShardingSphereDataSourceContexts().clear();
-        PluginContext pluginContext = PluginContext.getInstance();
-        Plugins.getMemberAccessor().set(PluginContext.class.getDeclaredField("contextManager"), pluginContext, originalPluginContextManager);
-        Plugins.getMemberAccessor().set(PluginContext.class.getDeclaredField("isEnhancedForProxy"), pluginContext, originalIsEnhancedForProxy);
-        Plugins.getMemberAccessor().set(ProxyContext.class.getDeclaredField("contextManager"), ProxyContext.getInstance(), originalProxyContextManager);
-    }
-    
     @Test
     void assertIsPluginEnabledWithEmptyDataSourceContextHolder() {
-        assertTrue(PluginContext.getInstance().isPluginEnabled());
-    }
-    
-    @Test
-    void assertIsPluginEnabledWithExistingContextManager() {
-        ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
-        when(contextManager.getMetaDataContexts().getMetaData().getProps().<Boolean>getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED)).thenReturn(true);
-        PluginContext.getInstance().setContextManager(contextManager);
-        assertTrue(PluginContext.getInstance().isPluginEnabled());
+        assertFalse(PluginContext.getInstance().isPluginEnabled());
     }
     
     @Test
     void assertIsPluginEnabledWithShardingSphereDataSourceContextDisabled() {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(contextManager.getMetaDataContexts().getMetaData().getProps().<Boolean>getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED)).thenReturn(false);
-        ShardingSphereDataSourceContextHolder.put("instance_1", new ShardingSphereDataSourceContext("logic_db", contextManager));
+        ShardingSphereDataSourceContextHolder.getShardingSphereDataSourceContexts().clear();
+        ShardingSphereDataSourceContextHolder.put("foo_instance", new ShardingSphereDataSourceContext("foo_db", contextManager));
         assertFalse(PluginContext.getInstance().isPluginEnabled());
+        ShardingSphereDataSourceContextHolder.getShardingSphereDataSourceContexts().clear();
     }
     
     @Test

--- a/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/fixture/TargetAdviceObjectFixture.java
+++ b/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/fixture/TargetAdviceObjectFixture.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.agent.plugin.core.fixture;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.agent.api.advice.TargetAdviceObject;
+
+/**
+ * Target advice object fixture.
+ */
+@Getter
+@Setter
+public final class TargetAdviceObjectFixture implements TargetAdviceObject {
+    
+    private Object attachment;
+}

--- a/agent/plugins/metrics/type/prometheus/src/main/resources/META-INF/conf/prometheus-advisors.yaml
+++ b/agent/plugins/metrics/type/prometheus/src/main/resources/META-INF/conf/prometheus-advisors.yaml
@@ -150,11 +150,3 @@ advisors:
     pointcuts:
       - name: rollback
         type: method
-  - target: org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource
-    advice: org.apache.shardingsphere.agent.plugin.metrics.core.advice.jdbc.ShardingSphereDataSourceAdvice
-    pointcuts:
-      - name: createContextManager
-        type: method
-      - name: close
-        type: method
-        paramLength: 0


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add common advisors yaml to get ContextManager when agent work with driver

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
