### PR TITLE
Separate normalization and lookup policies for identifiers

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicy.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicy.java
@@ -24,7 +24,7 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 /**
- * Policy of identifier case matching.
+ * Policy of identifier case normalization and matching.
  */
 @RequiredArgsConstructor
 public final class IdentifierCasePolicy {
@@ -33,7 +33,11 @@ public final class IdentifierCasePolicy {
     
     private final LookupMode unquotedLookupMode;
     
-    private final UnaryOperator<String> normalizer;
+    private final UnaryOperator<String> quotedDefinitionNormalizer;
+    
+    private final UnaryOperator<String> unquotedDefinitionNormalizer;
+    
+    private final UnaryOperator<String> lookupNormalizer;
     
     private final Predicate<String> unquotedStoredNamePredicate;
     
@@ -48,13 +52,24 @@ public final class IdentifierCasePolicy {
     }
     
     /**
-     * Normalize identifier value.
+     * Normalize identifier value for definition.
      *
      * @param value identifier value
-    * @return normalized identifier value
-    */
-    public String normalize(final String value) {
-        return normalizer.apply(value);
+     * @param quoteCharacter quote character
+     * @return normalized identifier value
+     */
+    public String normalizeForDefinition(final String value, final QuoteCharacter quoteCharacter) {
+        return QuoteCharacter.NONE == quoteCharacter ? unquotedDefinitionNormalizer.apply(value) : quotedDefinitionNormalizer.apply(value);
+    }
+    
+    /**
+     * Normalize identifier value for lookup.
+     *
+     * @param value identifier value
+     * @return normalized identifier value
+     */
+    public String normalizeForLookup(final String value) {
+        return lookupNormalizer.apply(value);
     }
     
     /**
@@ -63,14 +78,14 @@ public final class IdentifierCasePolicy {
      * @param storedName stored identifier name
      * @param actualIdentifier input identifier value
      * @param quoteCharacter quote character
-    * @return whether matched
-    */
+     * @return whether matched
+     */
     public boolean matches(final String storedName, final String actualIdentifier, final QuoteCharacter quoteCharacter) {
         if (QuoteCharacter.NONE != quoteCharacter) {
             return LookupMode.EXACT == quotedLookupMode
                     ? storedName.equals(actualIdentifier)
-                    : normalize(storedName).equals(normalize(actualIdentifier));
+                    : normalizeForLookup(storedName).equals(normalizeForLookup(actualIdentifier));
         }
-        return unquotedStoredNamePredicate.test(storedName) && normalize(storedName).equals(normalize(actualIdentifier));
+        return unquotedStoredNamePredicate.test(storedName) && normalizeForLookup(storedName).equals(normalizeForLookup(actualIdentifier));
     }
 }

--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactory.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactory.java
@@ -35,8 +35,8 @@ public final class IdentifierCasePolicyFactory {
      * @return lower-case policy set
      */
     public static IdentifierCasePolicySet newLowerCasePolicySet() {
-        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED, IdentifierCasePolicyFactory::toLowerCase,
-                IdentifierCasePolicyFactory::isLowerCase));
+        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED, UnaryOperator.identity(),
+                IdentifierCasePolicyFactory::toLowerCase, IdentifierCasePolicyFactory::toLowerCase, IdentifierCasePolicyFactory::isLowerCase));
     }
     
     /**
@@ -45,8 +45,8 @@ public final class IdentifierCasePolicyFactory {
      * @return upper-case policy set
      */
     public static IdentifierCasePolicySet newUpperCasePolicySet() {
-        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED, IdentifierCasePolicyFactory::toUpperCase,
-                IdentifierCasePolicyFactory::isUpperCase));
+        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED, UnaryOperator.identity(),
+                IdentifierCasePolicyFactory::toUpperCase, IdentifierCasePolicyFactory::toUpperCase, IdentifierCasePolicyFactory::isUpperCase));
     }
     
     /**
@@ -55,7 +55,8 @@ public final class IdentifierCasePolicyFactory {
      * @return case-sensitive policy set
      */
     public static IdentifierCasePolicySet newSensitivePolicySet() {
-        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.EXACT, UnaryOperator.identity(), each -> true));
+        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.EXACT,
+                UnaryOperator.identity(), UnaryOperator.identity(), UnaryOperator.identity(), each -> true));
     }
     
     /**
@@ -64,7 +65,8 @@ public final class IdentifierCasePolicyFactory {
      * @return case-insensitive policy set
      */
     public static IdentifierCasePolicySet newInsensitivePolicySet() {
-        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED, IdentifierCasePolicyFactory::toLowerCase, each -> true));
+        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED, UnaryOperator.identity(),
+                IdentifierCasePolicyFactory::toLowerCase, IdentifierCasePolicyFactory::toLowerCase, each -> true));
     }
     
     /**
@@ -73,7 +75,8 @@ public final class IdentifierCasePolicyFactory {
      * @return quoted and unquoted case-insensitive policy set
      */
     public static IdentifierCasePolicySet newQuotedInsensitivePolicySet() {
-        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED, IdentifierCasePolicyFactory::toLowerCase, each -> true));
+        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED, UnaryOperator.identity(),
+                IdentifierCasePolicyFactory::toLowerCase, IdentifierCasePolicyFactory::toLowerCase, each -> true));
     }
     
     /**

--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierNormalizeEngine.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierNormalizeEngine.java
@@ -58,10 +58,7 @@ public final class IdentifierNormalizeEngine {
     public static String normalize(final IdentifierCasePolicy policy, final String identifier) {
         QuoteCharacter quoteCharacter = QuoteCharacter.getQuoteCharacter(identifier);
         String unwrappedIdentifier = quoteCharacter.unwrap(identifier);
-        if (QuoteCharacter.NONE != quoteCharacter) {
-            return unwrappedIdentifier;
-        }
-        return LookupMode.NORMALIZED == policy.getLookupMode(QuoteCharacter.NONE) ? policy.normalize(unwrappedIdentifier) : unwrappedIdentifier;
+        return policy.normalizeForDefinition(unwrappedIdentifier, quoteCharacter);
     }
     
     /**

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactoryTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactoryTest.java
@@ -30,14 +30,14 @@ class IdentifierCasePolicyFactoryTest {
     @Test
     void assertNewLowerCasePolicySet() {
         IdentifierCasePolicy actual = IdentifierCasePolicyFactory.newLowerCasePolicySet().getPolicy(IdentifierScope.TABLE);
-        assertThat(actual.normalize("Foo"), is("foo"));
+        assertThat(actual.normalizeForDefinition("Foo", QuoteCharacter.NONE), is("foo"));
         assertFalse(actual.matches("Foo", "FOO", QuoteCharacter.NONE));
     }
     
     @Test
     void assertNewUpperCasePolicySet() {
         IdentifierCasePolicy actual = IdentifierCasePolicyFactory.newUpperCasePolicySet().getPolicy(IdentifierScope.TABLE);
-        assertThat(actual.normalize("Foo"), is("FOO"));
+        assertThat(actual.normalizeForDefinition("Foo", QuoteCharacter.NONE), is("FOO"));
         assertFalse(actual.matches("Foo", "foo", QuoteCharacter.NONE));
     }
     

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicySetTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicySetTest.java
@@ -31,7 +31,7 @@ class IdentifierCasePolicySetTest {
     @Test
     void assertGetPolicy() {
         IdentifierCasePolicy expectedRule = new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED,
-                each -> each.toLowerCase(Locale.ENGLISH), each -> true);
+                each -> each, each -> each.toLowerCase(Locale.ENGLISH), each -> each.toLowerCase(Locale.ENGLISH), each -> true);
         IdentifierCasePolicy actualRule = new IdentifierCasePolicySet(expectedRule).getPolicy(IdentifierScope.TABLE);
         assertThat(actualRule, is(expectedRule));
     }
@@ -39,8 +39,8 @@ class IdentifierCasePolicySetTest {
     @Test
     void assertGetPolicyWithScopeOverride() {
         IdentifierCasePolicy defaultRule = new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED,
-                each -> each.toLowerCase(Locale.ENGLISH), each -> true);
-        IdentifierCasePolicy schemaRule = new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.EXACT, each -> each, each -> true);
+                each -> each, each -> each.toLowerCase(Locale.ENGLISH), each -> each.toLowerCase(Locale.ENGLISH), each -> true);
+        IdentifierCasePolicy schemaRule = new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.EXACT, each -> each, each -> each, each -> each, each -> true);
         Map<IdentifierScope, IdentifierCasePolicy> scopedRules = new EnumMap<>(IdentifierScope.class);
         scopedRules.put(IdentifierScope.SCHEMA, schemaRule);
         IdentifierCasePolicySet actualPolicySet = new IdentifierCasePolicySet(defaultRule, scopedRules);

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class IdentifierCasePolicyTest {
     
     private final IdentifierCasePolicy policy = new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED,
-            each -> each.toLowerCase(Locale.ENGLISH), each -> each.equals(each.toLowerCase(Locale.ENGLISH)));
+            each -> each, each -> each.toLowerCase(Locale.ENGLISH), each -> each.toUpperCase(Locale.ENGLISH), each -> each.equals(each.toLowerCase(Locale.ENGLISH)));
     
     @Test
     void assertGetLookupModeWithQuotedIdentifier() {
@@ -46,14 +46,24 @@ class IdentifierCasePolicyTest {
     }
     
     @Test
-    void assertNormalize() {
-        assertThat(policy.normalize("Foo"), is("foo"));
+    void assertNormalizeDefinitionWithQuotedIdentifier() {
+        assertThat(policy.normalizeForDefinition("Foo", QuoteCharacter.QUOTE), is("Foo"));
+    }
+    
+    @Test
+    void assertNormalizeDefinitionWithUnquotedIdentifier() {
+        assertThat(policy.normalizeForDefinition("Foo", QuoteCharacter.NONE), is("foo"));
+    }
+    
+    @Test
+    void assertNormalizeLookup() {
+        assertThat(policy.normalizeForLookup("Foo"), is("FOO"));
     }
     
     @Test
     void assertMatchesWithQuotedNormalizedLookup() {
         IdentifierCasePolicy actual = new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED,
-                each -> each.toLowerCase(Locale.ENGLISH), each -> each.equals(each.toLowerCase(Locale.ENGLISH)));
+                each -> each, each -> each.toLowerCase(Locale.ENGLISH), each -> each.toLowerCase(Locale.ENGLISH), each -> each.equals(each.toLowerCase(Locale.ENGLISH)));
         assertTrue(actual.matches("t_mask", "T_MASK", QuoteCharacter.BACK_QUOTE));
     }
     

--- a/database/connector/dialect/firebird/src/main/java/org/apache/shardingsphere/database/connector/firebird/metadata/identifier/FirebirdIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/firebird/src/main/java/org/apache/shardingsphere/database/connector/firebird/metadata/identifier/FirebirdIdentifierCasePolicyProvider.java
@@ -32,7 +32,8 @@ public final class FirebirdIdentifierCasePolicyProvider implements IdentifierCas
     
     @Override
     public IdentifierCasePolicySet provide(final IdentifierCasePolicyProviderContext context) {
-        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED, FirebirdIdentifierCasePolicyProvider::toUpperCase, each -> true));
+        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED,
+                each -> each, FirebirdIdentifierCasePolicyProvider::toUpperCase, FirebirdIdentifierCasePolicyProvider::toUpperCase, each -> true));
     }
     
     @Override

--- a/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/identifier/FirebirdIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/identifier/FirebirdIdentifierCasePolicyProviderTest.java
@@ -50,7 +50,7 @@ class FirebirdIdentifierCasePolicyProviderTest {
     void assertProvide() {
         IdentifierCasePolicy actual = provider.provide(new IdentifierCasePolicyProviderContext(databaseType, null)).getPolicy(IdentifierScope.TABLE);
         assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
-        assertThat(actual.normalize("Foo"), is("FOO"));
+        assertThat(actual.normalizeForDefinition("Foo", QuoteCharacter.NONE), is("FOO"));
         assertTrue(actual.matches("FOO", "foo", QuoteCharacter.NONE));
         assertTrue(actual.matches("Foo", "foo", QuoteCharacter.NONE));
         assertFalse(actual.matches("Foo", "foo", QuoteCharacter.QUOTE));

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
@@ -61,9 +61,9 @@ class MySQLIdentifierCasePolicyProviderTest {
         assertThat(actual.getPolicy(IdentifierScope.TABLE).getLookupMode(QuoteCharacter.BACK_QUOTE), is(expectedQuotedLookupMode));
         assertThat(actual.getPolicy(IdentifierScope.TABLE).getLookupMode(QuoteCharacter.NONE), is(expectedUnquotedLookupMode));
         assertThat(actual.getPolicy(IdentifierScope.TABLE).matches("foo", "FOO", QuoteCharacter.NONE), is(expectedMatch));
-        assertThat(actual.getPolicy(IdentifierScope.COLUMN).normalize("FooColumn"), is("FooColumn"));
-        assertThat(actual.getPolicy(IdentifierScope.INDEX).normalize("FooIndex"), is("FooIndex"));
-        assertThat(actual.getPolicy(IdentifierScope.CONSTRAINT).normalize("FooConstraint"), is("FooConstraint"));
+        assertThat(actual.getPolicy(IdentifierScope.COLUMN).normalizeForDefinition("FooColumn", QuoteCharacter.NONE), is("FooColumn"));
+        assertThat(actual.getPolicy(IdentifierScope.INDEX).normalizeForDefinition("FooIndex", QuoteCharacter.NONE), is("FooIndex"));
+        assertThat(actual.getPolicy(IdentifierScope.CONSTRAINT).normalizeForDefinition("FooConstraint", QuoteCharacter.NONE), is("FooConstraint"));
     }
     
     @Test

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContext.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContext.java
@@ -19,11 +19,9 @@ package org.apache.shardingsphere.infra.metadata.identifier;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 /**
@@ -69,7 +67,7 @@ public final class DatabaseIdentifierContext {
      * @return normalized protocol identifier
      */
     public String normalizeProtocol(final IdentifierScope identifierScope, final IdentifierValue identifier) {
-        return normalize(protocolPolicySet.getPolicy(identifierScope), identifier);
+        return protocolPolicySet.getPolicy(identifierScope).normalizeForDefinition(identifier.getValue(), identifier.getQuoteCharacter());
     }
     
     /**
@@ -80,13 +78,7 @@ public final class DatabaseIdentifierContext {
      * @return normalized storage identifier
      */
     public String normalizeStorage(final IdentifierScope identifierScope, final IdentifierValue identifier) {
-        return normalize(storagePolicySet.getPolicy(identifierScope), identifier);
-    }
-    
-    private String normalize(final IdentifierCasePolicy policy, final IdentifierValue identifier) {
-        return QuoteCharacter.NONE == identifier.getQuoteCharacter() && LookupMode.NORMALIZED == policy.getLookupMode(identifier.getQuoteCharacter())
-                ? policy.normalize(identifier.getValue())
-                : identifier.getValue();
+        return storagePolicySet.getPolicy(identifierScope).normalizeForDefinition(identifier.getValue(), identifier.getQuoteCharacter());
     }
     
     /**

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndex.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndex.java
@@ -186,7 +186,7 @@ public final class IdentifierIndex<T> {
     }
     
     private T getByNormalizedIdentifier(final Snapshot<T> currentSnapshot, final IdentifierCasePolicy policy, final String identifier) {
-        NormalizedBucket<T> normalizedBucket = currentSnapshot.getNormalizedBuckets().get(policy.normalize(identifier));
+        NormalizedBucket<T> normalizedBucket = currentSnapshot.getNormalizedBuckets().get(policy.normalizeForLookup(identifier));
         if (null == normalizedBucket) {
             return null;
         }
@@ -208,7 +208,7 @@ public final class IdentifierIndex<T> {
     }
     
     private Optional<T> findByQuotedNormalizedIdentifier(final Snapshot<T> currentSnapshot, final IdentifierCasePolicy policy, final IdentifierValue identifierValue) {
-        NormalizedBucket<T> normalizedBucket = currentSnapshot.getNormalizedBuckets().get(policy.normalize(identifierValue.getValue()));
+        NormalizedBucket<T> normalizedBucket = currentSnapshot.getNormalizedBuckets().get(policy.normalizeForLookup(identifierValue.getValue()));
         if (null == normalizedBucket) {
             return Optional.empty();
         }
@@ -255,12 +255,12 @@ public final class IdentifierIndex<T> {
     }
     
     private void addNormalizedIdentifier(final Map<String, Collection<String>> values, final IdentifierCasePolicy policy, final String name) {
-        String normalizedName = policy.normalize(name);
+        String normalizedName = policy.normalizeForLookup(name);
         values.computeIfAbsent(normalizedName, key -> new LinkedList<>()).add(name);
     }
     
     private void removeNormalizedIdentifier(final Map<String, Collection<String>> values, final IdentifierCasePolicy policy, final String name) {
-        String normalizedName = policy.normalize(name);
+        String normalizedName = policy.normalizeForLookup(name);
         Collection<String> candidateIdentifiers = values.get(normalizedName);
         if (null == candidateIdentifiers) {
             return;

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -136,7 +136,7 @@ class DatabaseIdentifierContextFactoryTest {
                 createConfigurationProperties(MetadataIdentifierCaseSensitivity.INSENSITIVE));
         assertThat(actual.normalizeProtocol(IdentifierScope.TABLE, new IdentifierValue("Foo")), is("FOO"));
         assertThat(actual.normalizeStorage(IdentifierScope.TABLE, new IdentifierValue("Foo")), is("foo"));
-        assertThat(actual.getMetaDataPolicy(IdentifierScope.TABLE).normalize("Foo"), is("foo"));
+        assertThat(actual.getMetaDataPolicy(IdentifierScope.TABLE).normalizeForLookup("Foo"), is("foo"));
     }
     
     @Test
@@ -146,7 +146,7 @@ class DatabaseIdentifierContextFactoryTest {
                 createConfigurationProperties(MetadataIdentifierCaseSensitivity.INSENSITIVE));
         assertThat(actual.normalizeProtocol(IdentifierScope.TABLE, new IdentifierValue("Foo")), is("FOO"));
         assertThat(actual.normalizeStorage(IdentifierScope.TABLE, new IdentifierValue("Foo")), is("foo"));
-        assertThat(actual.getMetaDataPolicy(IdentifierScope.TABLE).normalize("Foo"), is("foo"));
+        assertThat(actual.getMetaDataPolicy(IdentifierScope.TABLE).normalizeForLookup("Foo"), is("foo"));
     }
     
     @ParameterizedTest(name = "{0}")

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextTest.java
@@ -72,11 +72,11 @@ class DatabaseIdentifierContextTest {
     
     private IdentifierCasePolicy createLowerRule() {
         return new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED,
-                each -> each.toLowerCase(Locale.ENGLISH), each -> true);
+                each -> each, each -> each.toLowerCase(Locale.ENGLISH), each -> each.toLowerCase(Locale.ENGLISH), each -> true);
     }
     
     private IdentifierCasePolicy createUpperRule() {
         return new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED,
-                each -> each.toUpperCase(Locale.ENGLISH), each -> true);
+                each -> each, each -> each.toUpperCase(Locale.ENGLISH), each -> each.toUpperCase(Locale.ENGLISH), each -> true);
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndexTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndexTest.java
@@ -204,17 +204,18 @@ class IdentifierIndexTest {
     }
     
     private IdentifierCasePolicy createExactRule() {
-        return new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.EXACT, each -> each, each -> true);
+        return new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.EXACT, each -> each, each -> each, each -> each, each -> true);
     }
     
     private IdentifierCasePolicy createPostgreSQLRule() {
         return new IdentifierCasePolicy(LookupMode.EXACT, LookupMode.NORMALIZED,
-                each -> each.toLowerCase(Locale.ENGLISH), each -> each.equals(each.toLowerCase(Locale.ENGLISH)));
+                each -> each, each -> each.toLowerCase(Locale.ENGLISH), each -> each.toLowerCase(Locale.ENGLISH),
+                each -> each.equals(each.toLowerCase(Locale.ENGLISH)));
     }
     
     private IdentifierCasePolicy createMySQLInsensitiveRule() {
         return new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED,
-                each -> each.toLowerCase(Locale.ENGLISH), each -> true);
+                each -> each, each -> each.toLowerCase(Locale.ENGLISH), each -> each.toLowerCase(Locale.ENGLISH), each -> true);
     }
     
     private Map<String, String> createSingleValueMap(final String key, final String value) {

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngineTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngineTest.java
@@ -240,7 +240,8 @@ class SingleRouteEngineTest {
     
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
-        IdentifierCasePolicy identifierCasePolicy = new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED, each -> each.toLowerCase(Locale.ENGLISH), each -> true);
+        IdentifierCasePolicy identifierCasePolicy = new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED,
+                each -> each, each -> each.toLowerCase(Locale.ENGLISH), each -> each.toLowerCase(Locale.ENGLISH), each -> true);
         when(result.getIdentifierContext()).thenReturn(new DatabaseIdentifierContext(new IdentifierCasePolicySet(identifierCasePolicy)));
         return result;
     }

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/SingleRuleTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/SingleRuleTest.java
@@ -408,7 +408,8 @@ class SingleRuleTest {
     
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
-        IdentifierCasePolicy identifierCasePolicy = new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED, each -> each.toLowerCase(Locale.ENGLISH), each -> true);
+        IdentifierCasePolicy identifierCasePolicy = new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED,
+                each -> each, each -> each.toLowerCase(Locale.ENGLISH), each -> each.toLowerCase(Locale.ENGLISH), each -> true);
         when(result.getIdentifierContext()).thenReturn(new DatabaseIdentifierContext(new IdentifierCasePolicySet(identifierCasePolicy)));
         when(result.getName()).thenReturn("foo_db");
         return result;


### PR DESCRIPTION

Changes proposed in this pull request:
  - Separate normalization and lookup policies for identifiers

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
