### PR TITLE
Remove obsolete TODO from MySQL COM_STMT_PREPARE_OK packet

### DIFF
--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/prepare/MySQLComStmtPrepareOKPacket.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/prepare/MySQLComStmtPrepareOKPacket.java
@@ -43,7 +43,6 @@ public final class MySQLComStmtPrepareOKPacket extends MySQLPacket {
     protected void write(final MySQLPacketPayload payload) {
         payload.writeInt1(STATUS);
         payload.writeInt4(statementId);
-        // TODO Column Definition Block should be added in future when the meta data of the columns is cached.
         payload.writeInt2(columnCount);
         payload.writeInt2(parameterCount);
         payload.writeReserved(1);


### PR DESCRIPTION
Column definition packets are already emitted by MySQLComStmtPrepareExecutor, so the comment no longer describes missing behavior.
