### PR TITLE
Harden MCP validation and E2E reliability

### DIFF
--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -232,22 +232,30 @@ jobs:
           curl --silent --output /dev/null --request POST http://127.0.0.1:18088/mcp
           results_root="${RUNNER_TEMP}/mcp-conformance-results"
           mkdir -p "${results_root}"
+          available_scenarios="$(
+            node .mcp-conformance/dist/index.js list --server --spec-version 2025-11-25 \
+              | sed -nE 's/^ - ([^ ]+).*/\1/p'
+          )"
           scenario_count=0
           while IFS= read -r scenario; do
             [[ -z "${scenario}" || "${scenario}" == \#* ]] && continue
             scenario_count=$((scenario_count + 1))
+            if ! grep -Fxq -- "${scenario}" <<< "${available_scenarios}"; then
+              echo "MCP conformance scenario '${scenario}' is unavailable for protocol version 2025-11-25." >&2
+              exit 1
+            fi
             node .mcp-conformance/dist/index.js server \
               --url http://127.0.0.1:18088/mcp \
               --scenario "${scenario}" \
-              --spec-version 2025-11-25 \
               --output-dir "${results_root}/${scenario}"
+            checks_file="$(find "${results_root}/${scenario}" -type f -name checks.json -print -quit 2>/dev/null || true)"
+            if [[ -z "${checks_file}" ]] || ! jq -e 'type == "array" and length > 0' "${checks_file}" >/dev/null; then
+              echo "MCP conformance scenario '${scenario}' produced no checks." >&2
+              exit 1
+            fi
           done < test/e2e/mcp/src/test/resources/conformance/server-scenarios.txt
           if [[ "${scenario_count}" -eq 0 ]]; then
             echo "No MCP conformance scenarios were selected." >&2
-            exit 1
-          fi
-          if ! find "${results_root}" -mindepth 1 -type f -print -quit | grep -q .; then
-            echo "MCP conformance produced no result files." >&2
             exit 1
           fi
       - name: Upload MCP Conformance Artifacts

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/prepare/MySQLComStmtPrepareOKPacket.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/prepare/MySQLComStmtPrepareOKPacket.java
@@ -43,7 +43,6 @@ public final class MySQLComStmtPrepareOKPacket extends MySQLPacket {
     protected void write(final MySQLPacketPayload payload) {
         payload.writeInt1(STATUS);
         payload.writeInt4(statementId);
-        // TODO Column Definition Block should be added in future when the meta data of the columns is cached.
         payload.writeInt2(columnCount);
         payload.writeInt2(parameterCount);
         payload.writeReserved(1);

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,11 +40,6 @@ import java.util.stream.Collectors;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPToolDescriptorCatalogValidator {
-    
-    private static final Collection<String> SUPPORTED_INPUT_SCHEMA_TOP_LEVEL_FIELDS = Set.of("type", "properties", "required", "additionalProperties");
-    
-    private static final Collection<String> SUPPORTED_INPUT_SCHEMA_FIELDS = Set.of(
-            "type", "properties", "required", "additionalProperties", "items", "enum", "minimum", "maximum", "default", "description", "examples");
     
     private static final String SEARCH_METADATA = "database_gateway_search_metadata";
     
@@ -80,7 +74,7 @@ public final class MCPToolDescriptorCatalogValidator {
         for (MCPToolDescriptor each : descriptors) {
             ShardingSpherePreconditions.checkState(null == registered.putIfAbsent(each.getName(), each),
                     () -> new IllegalStateException(String.format("Duplicate MCP tool descriptor `%s`.", each.getName())));
-            validateToolInputSchema(each);
+            MCPToolInputSchemaValidator.validate(each);
             MCPToolOutputSchemaValidator.validate(each);
             validateToolDescriptorContract(each, runtimes.get(each.getName()));
             validateDestructiveToolDescriptor(each, runtimes.get(each.getName()));
@@ -99,60 +93,6 @@ public final class MCPToolDescriptorCatalogValidator {
                         () -> new IllegalStateException(String.format("Tool `%s` runtime sideEffectScope `%s` is unsupported.", each.getToolName(), eachScope)));
             }
         }
-    }
-    
-    private static void validateToolInputSchema(final MCPToolDescriptor descriptor) {
-        Map<String, Object> inputSchema = descriptor.getInputSchema();
-        for (String each : inputSchema.keySet()) {
-            ShardingSpherePreconditions.checkState(SUPPORTED_INPUT_SCHEMA_TOP_LEVEL_FIELDS.contains(each),
-                    () -> new IllegalStateException(String.format("Tool `%s` inputSchema contains unsupported top-level field `%s`.", descriptor.getName(), each)));
-        }
-        ShardingSpherePreconditions.checkState("object".equals(inputSchema.get("type")),
-                () -> new IllegalStateException(String.format("Tool `%s` inputSchema must be an object.", descriptor.getName())));
-        Object properties = inputSchema.get("properties");
-        ShardingSpherePreconditions.checkState(properties instanceof Map, () -> new IllegalStateException(String.format("Tool `%s` inputSchema must declare properties.", descriptor.getName())));
-        ShardingSpherePreconditions.checkState(inputSchema.get("required") instanceof Collection,
-                () -> new IllegalStateException(String.format("Tool `%s` inputSchema required must be an array.", descriptor.getName())));
-        ShardingSpherePreconditions.checkState(inputSchema.get("additionalProperties") instanceof Boolean,
-                () -> new IllegalStateException(String.format("Tool `%s` inputSchema additionalProperties must be a boolean.", descriptor.getName())));
-        validateNestedInputSchemaFields(descriptor, inputSchema, "inputSchema");
-        MCPToolDescriptorValidationUtils.validateModelFacingSchemaFields(descriptor, inputSchema);
-    }
-    
-    private static void validateNestedInputSchemaFields(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
-        validateInputSchemaProperties(descriptor, schema.get("properties"), path + ".properties");
-        validateInputSchemaMapField(descriptor, schema.get("items"), path + ".items");
-        validateInputSchemaMapField(descriptor, schema.get("additionalProperties"), path + ".additionalProperties");
-    }
-    
-    private static void validateInputSchemaProperties(final MCPToolDescriptor descriptor, final Object properties, final String path) {
-        if (!(properties instanceof Map)) {
-            return;
-        }
-        for (Entry<?, ?> entry : ((Map<?, ?>) properties).entrySet()) {
-            validateInputSchemaMapField(descriptor, entry.getValue(), path + "." + entry.getKey());
-            if (entry.getValue() instanceof Map) {
-                Object description = ((Map<?, ?>) entry.getValue()).get("description");
-                MCPToolDescriptorValidationUtils.checkDescription(null == description ? "" : description.toString(),
-                        String.format("Tool `%s` inputSchema property `%s.%s` description", descriptor.getName(), path, entry.getKey()));
-            }
-        }
-    }
-    
-    private static void validateInputSchemaMapField(final MCPToolDescriptor descriptor, final Object value, final String path) {
-        if (!(value instanceof Map)) {
-            return;
-        }
-        validateInputSchemaMap(descriptor, (Map<?, ?>) value, path);
-    }
-    
-    private static void validateInputSchemaMap(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
-        for (Object each : schema.keySet()) {
-            String fieldName = String.valueOf(each);
-            ShardingSpherePreconditions.checkState(SUPPORTED_INPUT_SCHEMA_FIELDS.contains(fieldName),
-                    () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` contains unsupported field `%s`.", descriptor.getName(), path, fieldName)));
-        }
-        validateNestedInputSchemaFields(descriptor, schema, path);
     }
     
     private static void validateToolDescriptorContract(final MCPToolDescriptor descriptor, final MCPToolRuntimeDescriptor runtimeDescriptor) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolInputSchemaValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolInputSchemaValidator.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.descriptor;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
+import org.apache.shardingsphere.mcp.api.capability.tool.MCPToolDescriptor;
+
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/**
+ * Validator for MCP tool input schema contracts supported by the runtime.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MCPToolInputSchemaValidator {
+    
+    private static final Collection<String> SUPPORTED_TOP_LEVEL_FIELDS = Set.of("type", "properties", "required", "additionalProperties");
+    
+    private static final Collection<String> SUPPORTED_FIELDS = Set.of(
+            "type", "properties", "required", "additionalProperties", "items", "enum", "minimum", "maximum", "default", "description", "examples");
+    
+    private static final Collection<String> SUPPORTED_TYPES = Set.of("string", "integer", "number", "boolean", "array", "object");
+    
+    /**
+     * Validate one tool input schema.
+     *
+     * @param descriptor tool descriptor
+     */
+    public static void validate(final MCPToolDescriptor descriptor) {
+        Map<String, Object> inputSchema = descriptor.getInputSchema();
+        for (String each : inputSchema.keySet()) {
+            ShardingSpherePreconditions.checkState(SUPPORTED_TOP_LEVEL_FIELDS.contains(each),
+                    () -> new IllegalStateException(String.format("Tool `%s` inputSchema contains unsupported top-level field `%s`.", descriptor.getName(), each)));
+        }
+        ShardingSpherePreconditions.checkState("object".equals(inputSchema.get("type")),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema must be an object.", descriptor.getName())));
+        ShardingSpherePreconditions.checkState(inputSchema.get("properties") instanceof Map,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema must declare properties.", descriptor.getName())));
+        ShardingSpherePreconditions.checkState(inputSchema.get("required") instanceof Collection,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema required must be an array.", descriptor.getName())));
+        ShardingSpherePreconditions.checkState(inputSchema.get("additionalProperties") instanceof Boolean,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema additionalProperties must be a boolean.", descriptor.getName())));
+        MCPToolDescriptorValidationUtils.validateModelFacingSchemaFields(descriptor, inputSchema);
+        validateSchema(descriptor, inputSchema, "inputSchema");
+    }
+    
+    private static void validateSchema(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        for (Object each : schema.keySet()) {
+            String fieldName = String.valueOf(each);
+            ShardingSpherePreconditions.checkState(SUPPORTED_FIELDS.contains(fieldName),
+                    () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` contains unsupported field `%s`.", descriptor.getName(), path, fieldName)));
+        }
+        validateType(descriptor, schema, path);
+        validateProperties(descriptor, schema, path);
+        validateRequired(descriptor, schema, path);
+        validateItems(descriptor, schema, path);
+        validateAdditionalProperties(descriptor, schema, path);
+        validateEnum(descriptor, schema, path);
+        validateInteger(descriptor, schema, path);
+        validateAnnotations(descriptor, schema, path);
+    }
+    
+    private static void validateType(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        if (!schema.containsKey("type")) {
+            return;
+        }
+        Object type = schema.get("type");
+        ShardingSpherePreconditions.checkState(type instanceof String && SUPPORTED_TYPES.contains(type),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` uses unsupported type `%s`.", descriptor.getName(), path, type)));
+    }
+    
+    private static void validateProperties(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        if (!schema.containsKey("properties")) {
+            return;
+        }
+        ShardingSpherePreconditions.checkState("object".equals(schema.get("type")),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` must use type `object` with properties.", descriptor.getName(), path)));
+        Object properties = schema.get("properties");
+        ShardingSpherePreconditions.checkState(properties instanceof Map,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.properties` must be an object.", descriptor.getName(), path)));
+        for (Entry<?, ?> entry : ((Map<?, ?>) properties).entrySet()) {
+            ShardingSpherePreconditions.checkState(entry.getKey() instanceof String,
+                    () -> new IllegalStateException(String.format("Tool `%s` inputSchema property name at `%s.properties` must be a string.", descriptor.getName(), path)));
+            String propertyPath = path + ".properties." + entry.getKey();
+            ShardingSpherePreconditions.checkState(entry.getValue() instanceof Map,
+                    () -> new IllegalStateException(String.format("Tool `%s` inputSchema property `%s` must be an object.", descriptor.getName(), propertyPath)));
+            Map<?, ?> property = (Map<?, ?>) entry.getValue();
+            validateSchema(descriptor, property, propertyPath);
+            Object description = property.get("description");
+            MCPToolDescriptorValidationUtils.checkDescription(null == description ? "" : (String) description,
+                    String.format("Tool `%s` inputSchema property `%s` description", descriptor.getName(), propertyPath));
+        }
+    }
+    
+    private static void validateRequired(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        if (!schema.containsKey("required")) {
+            return;
+        }
+        ShardingSpherePreconditions.checkState("object".equals(schema.get("type")),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` must use type `object` with required properties.", descriptor.getName(), path)));
+        Object required = schema.get("required");
+        ShardingSpherePreconditions.checkState(required instanceof Collection,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.required` must be an array.", descriptor.getName(), path)));
+        Collection<?> requiredProperties = (Collection<?>) required;
+        ShardingSpherePreconditions.checkState(requiredProperties.stream().allMatch(String.class::isInstance),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.required` must contain only strings.", descriptor.getName(), path)));
+        ShardingSpherePreconditions.checkState(requiredProperties.stream().distinct().count() == requiredProperties.size(),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.required` must contain unique property names.", descriptor.getName(), path)));
+        Object properties = schema.get("properties");
+        ShardingSpherePreconditions.checkState(properties instanceof Map && ((Map<?, ?>) properties).keySet().containsAll(requiredProperties),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.required` references an undeclared property.", descriptor.getName(), path)));
+    }
+    
+    private static void validateItems(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        if (!schema.containsKey("items")) {
+            return;
+        }
+        ShardingSpherePreconditions.checkState("array".equals(schema.get("type")),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` must use type `array` with items.", descriptor.getName(), path)));
+        Object items = schema.get("items");
+        ShardingSpherePreconditions.checkState(items instanceof Map,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.items` must be an object.", descriptor.getName(), path)));
+        validateSchema(descriptor, (Map<?, ?>) items, path + ".items");
+    }
+    
+    private static void validateAdditionalProperties(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        if (!schema.containsKey("additionalProperties")) {
+            return;
+        }
+        ShardingSpherePreconditions.checkState("object".equals(schema.get("type")),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` must use type `object` with additionalProperties.", descriptor.getName(), path)));
+        Object additionalProperties = schema.get("additionalProperties");
+        ShardingSpherePreconditions.checkState(additionalProperties instanceof Boolean || additionalProperties instanceof Map,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.additionalProperties` must be a boolean or object.", descriptor.getName(), path)));
+        if (additionalProperties instanceof Map) {
+            validateSchema(descriptor, (Map<?, ?>) additionalProperties, path + ".additionalProperties");
+        }
+    }
+    
+    private static void validateEnum(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        if (!schema.containsKey("enum")) {
+            return;
+        }
+        Object enumValues = schema.get("enum");
+        ShardingSpherePreconditions.checkState(enumValues instanceof Collection && !((Collection<?>) enumValues).isEmpty(),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.enum` must be a non-empty array.", descriptor.getName(), path)));
+        Collection<?> values = (Collection<?>) enumValues;
+        ShardingSpherePreconditions.checkState(values.stream().distinct().count() == values.size(),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.enum` must contain unique values.", descriptor.getName(), path)));
+    }
+    
+    private static void validateInteger(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        boolean hasMinimum = schema.containsKey("minimum");
+        boolean hasMaximum = schema.containsKey("maximum");
+        boolean hasDefault = schema.containsKey("default");
+        if (!hasMinimum && !hasMaximum) {
+            if (hasDefault && "integer".equals(schema.get("type"))) {
+                validateIntegerDefault(descriptor, schema, path, false);
+            }
+            return;
+        }
+        ShardingSpherePreconditions.checkState("integer".equals(schema.get("type")),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` only supports minimum, maximum and default for type `integer`.", descriptor.getName(), path)));
+        ShardingSpherePreconditions.checkState(hasMinimum == hasMaximum,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` must declare minimum and maximum together.", descriptor.getName(), path)));
+        validateIntegerRange(descriptor, schema, path);
+        if (hasDefault) {
+            validateIntegerDefault(descriptor, schema, path, true);
+        }
+    }
+    
+    private static void validateIntegerRange(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        Object minimum = schema.get("minimum");
+        Object maximum = schema.get("maximum");
+        ShardingSpherePreconditions.checkState(isSupportedIntegerValue(minimum) && isSupportedIntegerValue(maximum),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` minimum and maximum must be integers in the Java int range.", descriptor.getName(), path)));
+        ShardingSpherePreconditions.checkState(toBigInteger(minimum).compareTo(toBigInteger(maximum)) <= 0,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s` minimum must not exceed maximum.", descriptor.getName(), path)));
+    }
+    
+    private static void validateIntegerDefault(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path, final boolean hasRange) {
+        Object defaultValue = schema.get("default");
+        ShardingSpherePreconditions.checkState(isSupportedIntegerValue(defaultValue),
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.default` must be an integer in the Java int range.", descriptor.getName(), path)));
+        if (!hasRange) {
+            return;
+        }
+        BigInteger actual = toBigInteger(defaultValue);
+        BigInteger minimum = toBigInteger(schema.get("minimum"));
+        BigInteger maximum = toBigInteger(schema.get("maximum"));
+        ShardingSpherePreconditions.checkState(actual.compareTo(minimum) >= 0 && actual.compareTo(maximum) <= 0,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.default` must be within the declared range.", descriptor.getName(), path)));
+    }
+    
+    private static void validateAnnotations(final MCPToolDescriptor descriptor, final Map<?, ?> schema, final String path) {
+        ShardingSpherePreconditions.checkState(!schema.containsKey("description") || schema.get("description") instanceof String,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.description` must be a string.", descriptor.getName(), path)));
+        ShardingSpherePreconditions.checkState(!schema.containsKey("examples") || schema.get("examples") instanceof Collection,
+                () -> new IllegalStateException(String.format("Tool `%s` inputSchema at `%s.examples` must be an array.", descriptor.getName(), path)));
+    }
+    
+    private static boolean isSupportedIntegerValue(final Object value) {
+        if (!(value instanceof Byte || value instanceof Short || value instanceof Integer || value instanceof Long || value instanceof BigInteger)) {
+            return false;
+        }
+        BigInteger actual = toBigInteger(value);
+        return actual.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) >= 0 && actual.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) <= 0;
+    }
+    
+    private static BigInteger toBigInteger(final Object value) {
+        return value instanceof BigInteger ? (BigInteger) value : BigInteger.valueOf(((Number) value).longValue());
+    }
+}

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSynchronizationSupport.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSynchronizationSupport.java
@@ -79,18 +79,19 @@ public final class WorkflowSynchronizationSupport {
             if (WorkflowLifecycle.STATUS_PASSED.equals(validationReport.getOverallStatus())) {
                 return;
             }
-            if (remainingWaitNanos <= pollIntervalNanos) {
+            if (0L == remainingWaitNanos) {
                 break;
             }
-            waitForNextValidation();
-            remainingWaitNanos -= pollIntervalNanos;
+            long waitNanos = Math.min(remainingWaitNanos, pollIntervalNanos);
+            waitForNextValidation(waitNanos);
+            remainingWaitNanos -= waitNanos;
         }
         throw createSynchronizationException(validationReport);
     }
     
-    private void waitForNextValidation() {
+    private void waitForNextValidation(final long waitNanos) {
         try {
-            TimeUnit.NANOSECONDS.sleep(pollIntervalNanos);
+            TimeUnit.NANOSECONDS.sleep(waitNanos);
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
             throw new WorkflowSynchronizationException(WorkflowIssueCode.RULE_STATE_MISMATCH, "Workflow synchronization was interrupted.", List.of());

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorComponentValidatorsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorComponentValidatorsTest.java
@@ -26,14 +26,18 @@ import org.apache.shardingsphere.mcp.api.capability.tool.MCPToolAnnotations;
 import org.apache.shardingsphere.mcp.api.capability.tool.MCPToolDescriptor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MCPDescriptorComponentValidatorsTest {
@@ -86,6 +90,71 @@ class MCPDescriptorComponentValidatorsTest {
         assertThat(actual.getMessage(), is("Tool `database_gateway_test_tool` inputSchema additionalProperties must be a boolean."));
     }
     
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidInputSchemaCases")
+    void assertToolInputSchemaValidatorWithInvalidInputSchema(final String name, final Map<String, Object> inputSchema, final String expectedMessage) {
+        IllegalStateException actual = assertThrows(IllegalStateException.class, () -> MCPToolInputSchemaValidator.validate(createToolDescriptor(inputSchema)));
+        assertThat(actual.getMessage(), is(expectedMessage));
+    }
+    
+    private static Stream<Arguments> invalidInputSchemaCases() {
+        return Stream.of(
+                Arguments.of("unsupported type", createInputSchemaWithQuery(Map.of("type", "unsupported", "description", "Query."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query` uses unsupported type `unsupported`."),
+                Arguments.of("property is not an object", createInputSchemaWithQuery("string", List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema property `inputSchema.properties.query` must be an object."),
+                Arguments.of("required contains non-string", createInputSchemaWithQuery(Map.of("type", "string", "description", "Query."), List.of(1)),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.required` must contain only strings."),
+                Arguments.of("required contains duplicate", createInputSchemaWithQuery(Map.of("type", "string", "description", "Query."), List.of("query", "query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.required` must contain unique property names."),
+                Arguments.of("required references undeclared property", createInputSchemaWithQuery(Map.of("type", "string", "description", "Query."), List.of("missing")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.required` references an undeclared property."),
+                Arguments.of("items is not an object",
+                        createInputSchemaWithQuery(Map.of("type", "array", "items", "string", "description", "Queries."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query.items` must be an object."),
+                Arguments.of("additional properties has unsupported type",
+                        createInputSchemaWithQuery(Map.of("type", "object", "additionalProperties", "string", "description", "Query."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query.additionalProperties` must be a boolean or object."),
+                Arguments.of("enum is not an array",
+                        createInputSchemaWithQuery(Map.of("type", "string", "enum", "query", "description", "Query."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query.enum` must be a non-empty array."),
+                Arguments.of("enum is empty",
+                        createInputSchemaWithQuery(Map.of("type", "string", "enum", List.of(), "description", "Query."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query.enum` must be a non-empty array."),
+                Arguments.of("enum contains duplicate",
+                        createInputSchemaWithQuery(Map.of("type", "string", "enum", List.of("query", "query"), "description", "Query."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query.enum` must contain unique values."),
+                Arguments.of("description is not a string", createInputSchemaWithQuery(Map.of("type", "string", "description", 1), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query.description` must be a string."),
+                Arguments.of("examples is not an array", createInputSchemaWithQuery(Map.of("type", "string", "description", "Query.", "examples", "query"), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query.examples` must be an array."),
+                Arguments.of("range is incomplete",
+                        createInputSchemaWithQuery(Map.of("type", "integer", "minimum", 0, "description", "Limit."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query` must declare minimum and maximum together."),
+                Arguments.of("range is not integer",
+                        createInputSchemaWithQuery(Map.of("type", "integer", "minimum", 0.5D, "maximum", 10, "description", "Limit."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query` minimum and maximum must be integers in the Java int range."),
+                Arguments.of("range is reversed",
+                        createInputSchemaWithQuery(Map.of("type", "integer", "minimum", 10, "maximum", 0, "description", "Limit."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query` minimum must not exceed maximum."),
+                Arguments.of("range exceeds supported values",
+                        createInputSchemaWithQuery(Map.of("type", "integer", "minimum", Long.MIN_VALUE, "maximum", 0, "description", "Limit."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query` minimum and maximum must be integers in the Java int range."),
+                Arguments.of("default is outside range",
+                        createInputSchemaWithQuery(Map.of("type", "integer", "minimum", 0, "maximum", 10, "default", 11, "description", "Limit."), List.of("query")),
+                        "Tool `database_gateway_test_tool` inputSchema at `inputSchema.properties.query.default` must be within the declared range."));
+    }
+    
+    private static Map<String, Object> createInputSchemaWithQuery(final Object querySchema, final List<?> required) {
+        return Map.of("type", "object", "properties", Map.of("query", querySchema), "required", required, "additionalProperties", false);
+    }
+    
+    @Test
+    void assertToolInputSchemaValidatorWithStringDefault() {
+        Map<String, Object> inputSchema = createInputSchemaWithQuery(Map.of("type", "string", "default", "query", "description", "Query."), List.of("query"));
+        assertDoesNotThrow(() -> MCPToolInputSchemaValidator.validate(createToolDescriptor(inputSchema)));
+    }
+    
     @Test
     void assertToolOutputSchemaValidator() {
         MCPToolDescriptor descriptor = new MCPToolDescriptor("database_gateway_test_tool", "Test Tool", "Run a test tool.",
@@ -133,6 +202,10 @@ class MCPDescriptorComponentValidatorsTest {
     
     private MCPToolDescriptor createToolDescriptor() {
         return new MCPToolDescriptor("database_gateway_test_tool", "Test Tool", "Run a test tool.", createInputSchema(), createOutputSchema(), createAnnotations(), Map.of());
+    }
+    
+    private MCPToolDescriptor createToolDescriptor(final Map<String, Object> inputSchema) {
+        return new MCPToolDescriptor("database_gateway_test_tool", "Test Tool", "Run a test tool.", inputSchema, createOutputSchema(), createAnnotations(), Map.of());
     }
     
     private MCPToolAnnotations createAnnotations() {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSynchronizationSupportTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSynchronizationSupportTest.java
@@ -62,7 +62,29 @@ class WorkflowSynchronizationSupportTest {
                 }));
         assertThat(actual.getIssueCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
         assertThat(actual.getMessage(), is("Rule metadata is not visible from Proxy DistSQL."));
-        assertThat(attempts.get(), is(3));
+        assertThat(attempts.get(), is(4));
+    }
+    
+    @Test
+    void assertSynchronizeWhenWindowIsNotDivisibleByPollInterval() {
+        AtomicInteger attempts = new AtomicInteger();
+        WorkflowSynchronizationSupport workflowSynchronizationSupport = new WorkflowSynchronizationSupport(Duration.ofNanos(5L), Duration.ofNanos(2L));
+        assertThrows(WorkflowSynchronizationException.class, () -> workflowSynchronizationSupport.synchronize(() -> {
+            attempts.incrementAndGet();
+            return createValidationReport(WorkflowLifecycle.STATUS_FAILED);
+        }));
+        assertThat(attempts.get(), is(4));
+    }
+    
+    @Test
+    void assertSynchronizeWhenPollIntervalExceedsWindow() {
+        AtomicInteger attempts = new AtomicInteger();
+        WorkflowSynchronizationSupport workflowSynchronizationSupport = new WorkflowSynchronizationSupport(Duration.ofNanos(1L), Duration.ofNanos(2L));
+        assertThrows(WorkflowSynchronizationException.class, () -> workflowSynchronizationSupport.synchronize(() -> {
+            attempts.incrementAndGet();
+            return createValidationReport(WorkflowLifecycle.STATUS_FAILED);
+        }));
+        assertThat(attempts.get(), is(2));
     }
     
     @Test

--- a/test/e2e/mcp/pom.xml
+++ b/test/e2e/mcp/pom.xml
@@ -115,11 +115,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-jdbc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunner.java
@@ -80,7 +80,11 @@ public final class LLMMCPConversationRunner {
         List<LLMChatMessage> messages = createInitialMessages(scenario);
         LLMMCPConversationArtifacts artifacts = new LLMMCPConversationArtifacts(modelName);
         try {
-            openInteractionClient();
+            try {
+                mcpInteractionClient.open();
+            } catch (final IOException | IllegalStateException ex) {
+                return createFailureBundle(scenario, artifacts, "mcp_runtime_unavailable", "MCP runtime failed to initialize.");
+            }
             LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
             LLMMCPConversationTurnPlanner turnPlanner = new LLMMCPConversationTurnPlanner();
             boolean finalAnswerRequested = false;
@@ -114,10 +118,7 @@ public final class LLMMCPConversationRunner {
             Thread.currentThread().interrupt();
             return createFailureBundle(scenario, artifacts, "model_service_unavailable", "Conversation was interrupted.");
         } catch (final IllegalStateException ex) {
-            String failureType = ex.getMessage().startsWith("MCP") || ex.getMessage().startsWith("Failed to initialize MCP")
-                    ? "mcp_runtime_unavailable"
-                    : "model_service_unavailable";
-            return createFailureBundle(scenario, artifacts, failureType, ex.getMessage());
+            return createFailureBundle(scenario, artifacts, "model_service_unavailable", ex.getMessage());
         } finally {
             closeInteractionClient();
         }
@@ -279,6 +280,8 @@ public final class LLMMCPConversationRunner {
         } catch (final IllegalArgumentException ex) {
             artifacts.addInteractionTrace(MCPInteractionTraceRecord.createInvalidAction(artifacts.nextSequence(), "tool_call", toolName, arguments, "invalid_tool_arguments"));
             return Optional.of(createFailureBundle(scenario, artifacts, "invalid_tool_arguments", "Model provided invalid tool arguments."));
+        } catch (final IllegalStateException ex) {
+            return Optional.of(createFailureBundle(scenario, artifacts, "mcp_runtime_unavailable", ex.getMessage()));
         }
         long latencyMillis = System.currentTimeMillis() - startTime;
         artifacts.addRuntimeLogLine("action=" + toolName + " args=" + JsonUtils.toJsonString(arguments));
@@ -310,14 +313,6 @@ public final class LLMMCPConversationRunner {
     
     private LLME2EArtifactBundle createFailureBundle(final LLME2EScenario scenario, final LLMMCPConversationArtifacts artifacts, final String failureType, final String message) {
         return artifacts.createArtifactBundle(scenario, LLME2EAssertionReport.failure(failureType, message));
-    }
-    
-    private void openInteractionClient() throws InterruptedException {
-        try {
-            mcpInteractionClient.open();
-        } catch (final IOException ex) {
-            throw new IllegalStateException("MCP runtime failed to initialize.", ex);
-        }
     }
     
     private void closeInteractionClient() {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerFailureTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerFailureTest.java
@@ -116,6 +116,16 @@ class LLMMCPConversationRunnerFailureTest extends AbstractLLMMCPConversationRunn
     }
     
     @Test
+    void assertRunWithMcpRuntimeInitializationFailure() throws IOException, InterruptedException {
+        doThrow(new IllegalStateException("Failed to initialize MCP session.")).when(getMCPInteractionClient()).open();
+        
+        LLME2EArtifactBundle actual = createRunner(1).run(createScenario(List.of("database_gateway_execute_query")));
+        
+        assertThat(actual.getAssertionReport().getFailureType(), is("mcp_runtime_unavailable"));
+        assertThat(actual.getAssertionReport().getMessage(), is("MCP runtime failed to initialize."));
+    }
+    
+    @Test
     void assertRunWithInterruptedMcpOpen() throws IOException, InterruptedException {
         doThrow(new InterruptedException("boom")).when(getMCPInteractionClient()).open();
         try {
@@ -188,10 +198,10 @@ class LLMMCPConversationRunnerFailureTest extends AbstractLLMMCPConversationRunn
     }
     
     @Test
-    void assertRunClassifiesModelFailureByMessage() throws IOException, InterruptedException {
+    void assertRunClassifiesModelFailureBySource() throws IOException, InterruptedException {
         when(getLLMChatClient().complete(anyList(), anyList(), eq("auto"), eq(false))).thenThrow(new IllegalStateException("MCP-shaped model failure."));
         LLME2EArtifactBundle actual = createRunner(1).run(createScenario(List.of("database_gateway_execute_query")));
-        assertThat(actual.getAssertionReport().getFailureType(), is("mcp_runtime_unavailable"));
+        assertThat(actual.getAssertionReport().getFailureType(), is("model_service_unavailable"));
     }
     
     @Test


### PR DESCRIPTION
- validate supported MCP tool input schemas before catalog exposure
- honor full synchronization windows and classify failures by source
- enforce conformance result checks and remove the unused Hive test dependency