### PR TITLE
Replace MySQL insensitive policy with quoted insensitive policy

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactory.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactory.java
@@ -70,6 +70,26 @@ public final class IdentifierCasePolicyFactory {
     }
     
     /**
+     * Create case-preserving and case-insensitive policy set.
+     *
+     * @return case-preserving and case-insensitive policy set
+     */
+    public static IdentifierCasePolicySet newCasePreservingInsensitivePolicySet() {
+        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED,
+                UnaryOperator.identity(), UnaryOperator.identity(), IdentifierCasePolicyFactory::toLowerCase, each -> true));
+    }
+    
+    /**
+     * Create lower-case and case-insensitive policy set.
+     *
+     * @return lower-case and case-insensitive policy set
+     */
+    public static IdentifierCasePolicySet newLowerCaseInsensitivePolicySet() {
+        return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED,
+                IdentifierCasePolicyFactory::toLowerCase, IdentifierCasePolicyFactory::toLowerCase, IdentifierCasePolicyFactory::toLowerCase, each -> true));
+    }
+    
+    /**
      * Create quoted and unquoted case-insensitive policy set.
      *
      * @return quoted and unquoted case-insensitive policy set
@@ -77,15 +97,6 @@ public final class IdentifierCasePolicyFactory {
     public static IdentifierCasePolicySet newQuotedInsensitivePolicySet() {
         return new IdentifierCasePolicySet(new IdentifierCasePolicy(LookupMode.NORMALIZED, LookupMode.NORMALIZED, UnaryOperator.identity(),
                 IdentifierCasePolicyFactory::toLowerCase, IdentifierCasePolicyFactory::toLowerCase, each -> true));
-    }
-    
-    /**
-     * Create MySQL case-insensitive policy set.
-     *
-     * @return MySQL case-insensitive policy set
-     */
-    public static IdentifierCasePolicySet newMySQLInsensitivePolicySet() {
-        return newQuotedInsensitivePolicySet();
     }
     
     private static String toLowerCase(final String value) {

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactoryTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCasePolicyFactoryTest.java
@@ -57,16 +57,26 @@ class IdentifierCasePolicyFactoryTest {
     }
     
     @Test
-    void assertNewQuotedInsensitivePolicySet() {
-        IdentifierCasePolicy actual = IdentifierCasePolicyFactory.newQuotedInsensitivePolicySet().getPolicy(IdentifierScope.TABLE);
-        assertThat(actual.getLookupMode(QuoteCharacter.QUOTE), is(LookupMode.NORMALIZED));
-        assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
-        assertTrue(actual.matches("t_mask", "T_MASK", QuoteCharacter.BACK_QUOTE));
+    void assertNewCasePreservingInsensitivePolicySet() {
+        IdentifierCasePolicy actual = IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet().getPolicy(IdentifierScope.TABLE);
+        assertThat(actual.normalizeForDefinition("Foo", QuoteCharacter.QUOTE), is("Foo"));
+        assertThat(actual.normalizeForDefinition("Foo", QuoteCharacter.NONE), is("Foo"));
+        assertTrue(actual.matches("Foo", "FOO", QuoteCharacter.BACK_QUOTE));
+        assertTrue(actual.matches("Foo", "FOO", QuoteCharacter.NONE));
     }
     
     @Test
-    void assertNewMySQLInsensitivePolicySet() {
-        IdentifierCasePolicy actual = IdentifierCasePolicyFactory.newMySQLInsensitivePolicySet().getPolicy(IdentifierScope.TABLE);
+    void assertNewLowerCaseInsensitivePolicySet() {
+        IdentifierCasePolicy actual = IdentifierCasePolicyFactory.newLowerCaseInsensitivePolicySet().getPolicy(IdentifierScope.TABLE);
+        assertThat(actual.normalizeForDefinition("Foo", QuoteCharacter.QUOTE), is("foo"));
+        assertThat(actual.normalizeForDefinition("Foo", QuoteCharacter.NONE), is("foo"));
+        assertTrue(actual.matches("Foo", "FOO", QuoteCharacter.BACK_QUOTE));
+        assertTrue(actual.matches("Foo", "FOO", QuoteCharacter.NONE));
+    }
+    
+    @Test
+    void assertNewQuotedInsensitivePolicySet() {
+        IdentifierCasePolicy actual = IdentifierCasePolicyFactory.newQuotedInsensitivePolicySet().getPolicy(IdentifierScope.TABLE);
         assertThat(actual.getLookupMode(QuoteCharacter.QUOTE), is(LookupMode.NORMALIZED));
         assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
         assertTrue(actual.matches("t_mask", "T_MASK", QuoteCharacter.BACK_QUOTE));

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProvider.java
@@ -59,6 +59,9 @@ public final class MySQLIdentifierCasePolicyProvider implements IdentifierCasePo
     
     private IdentifierCasePolicySet createStorageObjectPolicySet(final IdentifierCasePolicySet policySet) {
         Map<IdentifierScope, IdentifierCasePolicy> scopedPolicies = new EnumMap<>(IdentifierScope.class);
+        for (IdentifierScope each : IdentifierScope.values()) {
+            scopedPolicies.put(each, policySet.getPolicy(each));
+        }
         IdentifierCasePolicy storageObjectPolicy = IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet().getPolicy(IdentifierScope.COLUMN);
         scopedPolicies.put(IdentifierScope.COLUMN, storageObjectPolicy);
         scopedPolicies.put(IdentifierScope.INDEX, storageObjectPolicy);
@@ -74,7 +77,9 @@ public final class MySQLIdentifierCasePolicyProvider implements IdentifierCasePo
             return IdentifierCasePolicyFactory.newLowerCaseInsensitivePolicySet();
         }
         if (2 == lowerCaseTableNames) {
-            return IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet();
+            Map<IdentifierScope, IdentifierCasePolicy> scopedPolicies = new EnumMap<>(IdentifierScope.class);
+            scopedPolicies.put(IdentifierScope.VIEW, IdentifierCasePolicyFactory.newLowerCaseInsensitivePolicySet().getPolicy(IdentifierScope.VIEW));
+            return new IdentifierCasePolicySet(IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet().getPolicy(IdentifierScope.TABLE), scopedPolicies);
         }
         return IdentifierCasePolicyFactory.newInsensitivePolicySet();
     }

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProvider.java
@@ -41,7 +41,7 @@ public final class MySQLIdentifierCasePolicyProvider implements IdentifierCasePo
     @Override
     public IdentifierCasePolicySet provide(final IdentifierCasePolicyProviderContext context) {
         if (null == context.getDataSource()) {
-            return createStorageObjectSensitivePolicySet(IdentifierCasePolicyFactory.newMySQLInsensitivePolicySet());
+            return createStorageObjectSensitivePolicySet(IdentifierCasePolicyFactory.newQuotedInsensitivePolicySet());
         }
         try (Connection connection = context.getDataSource().getConnection()) {
             if (null == connection) {
@@ -71,11 +71,11 @@ public final class MySQLIdentifierCasePolicyProvider implements IdentifierCasePo
     
     private IdentifierCasePolicySet createPolicySet(final int lowerCaseTableNames) {
         if (1 == lowerCaseTableNames || 2 == lowerCaseTableNames) {
-            return IdentifierCasePolicyFactory.newMySQLInsensitivePolicySet();
+            return IdentifierCasePolicyFactory.newQuotedInsensitivePolicySet();
         }
         if (0 == lowerCaseTableNames) {
             Map<IdentifierScope, IdentifierCasePolicy> scopedPolicies = new EnumMap<>(IdentifierScope.class);
-            scopedPolicies.put(IdentifierScope.SCHEMA, IdentifierCasePolicyFactory.newMySQLInsensitivePolicySet().getPolicy(IdentifierScope.SCHEMA));
+            scopedPolicies.put(IdentifierScope.SCHEMA, IdentifierCasePolicyFactory.newQuotedInsensitivePolicySet().getPolicy(IdentifierScope.SCHEMA));
             scopedPolicies.put(IdentifierScope.TABLE, IdentifierCasePolicyFactory.newSensitivePolicySet().getPolicy(IdentifierScope.TABLE));
             scopedPolicies.put(IdentifierScope.VIEW, IdentifierCasePolicyFactory.newSensitivePolicySet().getPolicy(IdentifierScope.VIEW));
             return new IdentifierCasePolicySet(IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.TABLE), scopedPolicies);

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProvider.java
@@ -41,44 +41,40 @@ public final class MySQLIdentifierCasePolicyProvider implements IdentifierCasePo
     @Override
     public IdentifierCasePolicySet provide(final IdentifierCasePolicyProviderContext context) {
         if (null == context.getDataSource()) {
-            return createStorageObjectSensitivePolicySet(IdentifierCasePolicyFactory.newQuotedInsensitivePolicySet());
+            return createStorageObjectPolicySet(IdentifierCasePolicyFactory.newQuotedInsensitivePolicySet());
         }
         try (Connection connection = context.getDataSource().getConnection()) {
             if (null == connection) {
-                return createStorageObjectSensitivePolicySet(IdentifierCasePolicyFactory.newInsensitivePolicySet());
+                return createStorageObjectPolicySet(IdentifierCasePolicyFactory.newInsensitivePolicySet());
             }
             try (
                     PreparedStatement preparedStatement = connection.prepareStatement(QUERY_LOWER_CASE_TABLE_NAMES);
                     ResultSet resultSet = preparedStatement.executeQuery()) {
-                return createStorageObjectSensitivePolicySet(resultSet.next() ? createPolicySet(resultSet.getInt(1)) : IdentifierCasePolicyFactory.newInsensitivePolicySet());
+                return createStorageObjectPolicySet(resultSet.next() ? createPolicySet(resultSet.getInt(1)) : IdentifierCasePolicyFactory.newInsensitivePolicySet());
             }
         } catch (final SQLException ignored) {
-            return createStorageObjectSensitivePolicySet(IdentifierCasePolicyFactory.newInsensitivePolicySet());
+            return createStorageObjectPolicySet(IdentifierCasePolicyFactory.newInsensitivePolicySet());
         }
     }
     
-    private IdentifierCasePolicySet createStorageObjectSensitivePolicySet(final IdentifierCasePolicySet policySet) {
+    private IdentifierCasePolicySet createStorageObjectPolicySet(final IdentifierCasePolicySet policySet) {
         Map<IdentifierScope, IdentifierCasePolicy> scopedPolicies = new EnumMap<>(IdentifierScope.class);
-        for (IdentifierScope each : IdentifierScope.values()) {
-            scopedPolicies.put(each, policySet.getPolicy(each));
-        }
-        IdentifierCasePolicy sensitivePolicy = IdentifierCasePolicyFactory.newSensitivePolicySet().getPolicy(IdentifierScope.COLUMN);
-        scopedPolicies.put(IdentifierScope.COLUMN, sensitivePolicy);
-        scopedPolicies.put(IdentifierScope.INDEX, sensitivePolicy);
-        scopedPolicies.put(IdentifierScope.CONSTRAINT, sensitivePolicy);
+        IdentifierCasePolicy storageObjectPolicy = IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet().getPolicy(IdentifierScope.COLUMN);
+        scopedPolicies.put(IdentifierScope.COLUMN, storageObjectPolicy);
+        scopedPolicies.put(IdentifierScope.INDEX, storageObjectPolicy);
+        scopedPolicies.put(IdentifierScope.CONSTRAINT, storageObjectPolicy);
         return new IdentifierCasePolicySet(policySet.getPolicy(IdentifierScope.TABLE), scopedPolicies);
     }
     
     private IdentifierCasePolicySet createPolicySet(final int lowerCaseTableNames) {
-        if (1 == lowerCaseTableNames || 2 == lowerCaseTableNames) {
-            return IdentifierCasePolicyFactory.newQuotedInsensitivePolicySet();
-        }
         if (0 == lowerCaseTableNames) {
-            Map<IdentifierScope, IdentifierCasePolicy> scopedPolicies = new EnumMap<>(IdentifierScope.class);
-            scopedPolicies.put(IdentifierScope.SCHEMA, IdentifierCasePolicyFactory.newQuotedInsensitivePolicySet().getPolicy(IdentifierScope.SCHEMA));
-            scopedPolicies.put(IdentifierScope.TABLE, IdentifierCasePolicyFactory.newSensitivePolicySet().getPolicy(IdentifierScope.TABLE));
-            scopedPolicies.put(IdentifierScope.VIEW, IdentifierCasePolicyFactory.newSensitivePolicySet().getPolicy(IdentifierScope.VIEW));
-            return new IdentifierCasePolicySet(IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.TABLE), scopedPolicies);
+            return IdentifierCasePolicyFactory.newSensitivePolicySet();
+        }
+        if (1 == lowerCaseTableNames) {
+            return IdentifierCasePolicyFactory.newLowerCaseInsensitivePolicySet();
+        }
+        if (2 == lowerCaseTableNames) {
+            return IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet();
         }
         return IdentifierCasePolicyFactory.newInsensitivePolicySet();
     }

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
@@ -64,6 +64,9 @@ class MySQLIdentifierCasePolicyProviderTest {
         assertThat(actual.getPolicy(IdentifierScope.COLUMN).normalizeForDefinition("FooColumn", QuoteCharacter.NONE), is("FooColumn"));
         assertThat(actual.getPolicy(IdentifierScope.INDEX).normalizeForDefinition("FooIndex", QuoteCharacter.NONE), is("FooIndex"));
         assertThat(actual.getPolicy(IdentifierScope.CONSTRAINT).normalizeForDefinition("FooConstraint", QuoteCharacter.NONE), is("FooConstraint"));
+        assertThat(actual.getPolicy(IdentifierScope.COLUMN).matches("foo_column", "FOO_COLUMN", QuoteCharacter.NONE), is(Boolean.TRUE));
+        assertThat(actual.getPolicy(IdentifierScope.INDEX).matches("foo_index", "FOO_INDEX", QuoteCharacter.NONE), is(Boolean.TRUE));
+        assertThat(actual.getPolicy(IdentifierScope.CONSTRAINT).matches("foo_constraint", "FOO_CONSTRAINT", QuoteCharacter.NONE), is(Boolean.TRUE));
     }
     
     @Test
@@ -93,12 +96,29 @@ class MySQLIdentifierCasePolicyProviderTest {
     void assertProvideWithLowerCaseTableNamesZeroUsesScopedPolicies() {
         IdentifierCasePolicyProviderContext context = new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 0));
         IdentifierCasePolicySet actual = provider.provide(context);
-        assertThat(actual.getPolicy(IdentifierScope.SCHEMA).matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE), is(Boolean.TRUE));
+        assertThat(actual.getPolicy(IdentifierScope.DATABASE).matches("foo_db", "FOO_DB", QuoteCharacter.NONE), is(Boolean.FALSE));
+        assertThat(actual.getPolicy(IdentifierScope.SCHEMA).matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE), is(Boolean.FALSE));
         assertThat(actual.getPolicy(IdentifierScope.TABLE).matches("foo_tbl", "FOO_TBL", QuoteCharacter.NONE), is(Boolean.FALSE));
         assertThat(actual.getPolicy(IdentifierScope.VIEW).matches("foo_view", "FOO_VIEW", QuoteCharacter.NONE), is(Boolean.FALSE));
-        assertThat(actual.getPolicy(IdentifierScope.COLUMN).matches("foo_col", "FOO_COL", QuoteCharacter.NONE), is(Boolean.FALSE));
-        assertThat(actual.getPolicy(IdentifierScope.INDEX).matches("foo_idx", "FOO_IDX", QuoteCharacter.NONE), is(Boolean.FALSE));
-        assertThat(actual.getPolicy(IdentifierScope.CONSTRAINT).matches("foo_fk", "FOO_FK", QuoteCharacter.NONE), is(Boolean.FALSE));
+        assertThat(actual.getPolicy(IdentifierScope.COLUMN).matches("foo_col", "FOO_COL", QuoteCharacter.NONE), is(Boolean.TRUE));
+        assertThat(actual.getPolicy(IdentifierScope.INDEX).matches("foo_idx", "FOO_IDX", QuoteCharacter.NONE), is(Boolean.TRUE));
+        assertThat(actual.getPolicy(IdentifierScope.CONSTRAINT).matches("foo_fk", "FOO_FK", QuoteCharacter.NONE), is(Boolean.TRUE));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("tableDefinitionArguments")
+    void assertTableDefinition(final String name, final int lowerCaseTableNames, final String expected) {
+        IdentifierCasePolicy actual = provider.provide(new IdentifierCasePolicyProviderContext(DATABASE_TYPE,
+                new FixtureDataSource(true, lowerCaseTableNames))).getPolicy(IdentifierScope.TABLE);
+        assertThat(actual.normalizeForDefinition("FooTable", QuoteCharacter.NONE), is(expected));
+        assertThat(actual.normalizeForDefinition("FooTable", QuoteCharacter.BACK_QUOTE), is(expected));
+    }
+    
+    private static Stream<Arguments> tableDefinitionArguments() {
+        return Stream.of(
+                Arguments.of("lower_case_table_names_0", 0, "FooTable"),
+                Arguments.of("lower_case_table_names_1", 1, "footable"),
+                Arguments.of("lower_case_table_names_2", 2, "FooTable"));
     }
     
     private static Object getDefaultValue(final Class<?> returnType) {

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
@@ -121,6 +121,22 @@ class MySQLIdentifierCasePolicyProviderTest {
                 Arguments.of("lower_case_table_names_2", 2, "FooTable"));
     }
     
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("viewDefinitionArguments")
+    void assertViewDefinition(final String name, final int lowerCaseTableNames, final String expected) {
+        IdentifierCasePolicy actual = provider.provide(new IdentifierCasePolicyProviderContext(DATABASE_TYPE,
+                new FixtureDataSource(true, lowerCaseTableNames))).getPolicy(IdentifierScope.VIEW);
+        assertThat(actual.normalizeForDefinition("FooView", QuoteCharacter.NONE), is(expected));
+        assertThat(actual.normalizeForDefinition("FooView", QuoteCharacter.BACK_QUOTE), is(expected));
+    }
+    
+    private static Stream<Arguments> viewDefinitionArguments() {
+        return Stream.of(
+                Arguments.of("lower_case_table_names_0", 0, "FooView"),
+                Arguments.of("lower_case_table_names_1", 1, "fooview"),
+                Arguments.of("lower_case_table_names_2", 2, "fooview"));
+    }
+    
     private static Object getDefaultValue(final Class<?> returnType) {
         if (!returnType.isPrimitive()) {
             return null;


### PR DESCRIPTION

Changes proposed in this pull request:
  - Replace MySQL insensitive policy with quoted insensitive policy

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
