### PR TITLE
Fix SQL Server row number column binding

### DIFF
--- a/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/option/SQLServerFunctionOptionTest.java
+++ b/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/database/option/SQLServerFunctionOptionTest.java
@@ -19,6 +19,12 @@ package org.apache.shardingsphere.database.connector.sql92.sqlserver.metadata.da
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SQLServerFunctionOptionTest {
@@ -27,13 +33,12 @@ class SQLServerFunctionOptionTest {
     
     @Test
     void assertGetUnparenthesizedFunctionNames() {
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("CURRENT_TIMESTAMP"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("CURRENT_USER"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("ROWNUM"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("ROWNUM_"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("ROW_NUMBER"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("SESSION_USER"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("SYSTEM_USER"));
-        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("USER"));
+        Collection<String> actual = functionOption.getUnparenthesizedFunctionNames();
+        assertThat(actual.size(), is(5));
+        assertTrue(actual.containsAll(Arrays.asList("CURRENT_TIMESTAMP", "CURRENT_USER", "SESSION_USER", "SYSTEM_USER", "USER")));
+        assertTrue(actual.contains("current_timestamp"));
+        assertFalse(actual.contains("ROWNUM"));
+        assertFalse(actual.contains("ROWNUM_"));
+        assertFalse(actual.contains("ROW_NUMBER"));
     }
 }

--- a/parser/sql/engine/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/engine/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/engine/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/engine/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -1921,13 +1921,14 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
         int startIndex = ctx.topNum().getStart().getStartIndex();
         int stopIndex = ctx.topNum().getStop().getStopIndex();
         ASTNode topNum = visit(ctx.topNum());
+        String alias = null == ctx.alias() ? null : ((AliasSegment) visit(ctx.alias())).getIdentifier().getValue();
         if (topNum instanceof NumberLiteralValue) {
             NumberLiteralRowNumberValueSegment rowNumberSegment = new NumberLiteralRowNumberValueSegment(startIndex, stopIndex, ((NumberLiteralValue) topNum).getValue().longValue(), false);
-            return new TopProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), rowNumberSegment, null != ctx.alias() ? ctx.alias().getText() : null);
+            return new TopProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), rowNumberSegment, alias);
         }
         ParameterMarkerSegment parameterSegment = new ParameterMarkerRowNumberValueSegment(startIndex, stopIndex, ((ParameterMarkerValue) topNum).getValue(), false);
         parameterMarkerSegments.add(parameterSegment);
-        return new TopProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), (RowNumberValueSegment) parameterSegment, null != ctx.alias() ? ctx.alias().getText() : null);
+        return new TopProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), (RowNumberValueSegment) parameterSegment, alias);
     }
     
     @Override

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/pagination/top/TopProjectionSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/pagination/top/TopProjectionSegment.java
@@ -39,7 +39,6 @@ public final class TopProjectionSegment implements ProjectionSegment {
     
     @Override
     public String getColumnLabel() {
-        // TODO return column label according to database result
-        return "TOP";
+        return null == alias || alias.isEmpty() ? "TOP" : alias;
     }
 }

--- a/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/pagination/top/TopProjectionSegmentTest.java
+++ b/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/pagination/top/TopProjectionSegmentTest.java
@@ -15,24 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.database.connector.sql92.sqlserver.metadata.database.option;
+package org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.top;
 
-import com.cedarsoftware.util.CaseInsensitiveSet;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.function.DialectFunctionOption;
+import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collection;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-/**
- * Function option of SQLServer.
- */
-public final class SQLServerFunctionOption implements DialectFunctionOption {
+class TopProjectionSegmentTest {
     
-    private static final Collection<String> UNPARENTHESIZED_FUNCTION_NAMES = new CaseInsensitiveSet<>(Arrays.asList(
-            "CURRENT_TIMESTAMP", "CURRENT_USER", "SESSION_USER", "SYSTEM_USER", "USER"));
+    @Test
+    void assertGetColumnLabelWithoutAlias() {
+        assertThat(new TopProjectionSegment(0, 0, null, null).getColumnLabel(), is("TOP"));
+    }
     
-    @Override
-    public Collection<String> getUnparenthesizedFunctionNames() {
-        return UNPARENTHESIZED_FUNCTION_NAMES;
+    @Test
+    void assertGetColumnLabelWithEmptyAlias() {
+        assertThat(new TopProjectionSegment(0, 0, null, "").getColumnLabel(), is("TOP"));
+    }
+    
+    @Test
+    void assertGetColumnLabelWithAlias() {
+        assertThat(new TopProjectionSegment(0, 0, null, "rownum_").getColumnLabel(), is("rownum_"));
     }
 }

--- a/test/it/binder/src/test/resources/cases/dml/select.xml
+++ b/test/it/binder/src/test/resources/cases/dml/select.xml
@@ -1766,4 +1766,52 @@
             <parameter-marker-expression parameter-index="0" start-index="147" stop-index="147" />
         </parameters>
     </select>
+    
+    <select sql-case-id="select_with_top_and_delimited_row_number_alias" parameters="10, 5">
+        <projections start-index="7" stop-index="20">
+            <column-projection name="rownum_" start-index="7" stop-index="20" start-delimiter="[" end-delimiter="]">
+                <owner name="row_" start-index="7" stop-index="10" />
+            </column-projection>
+        </projections>
+        <from>
+            <subquery-table alias="row_" start-index="27" stop-index="115">
+                <subquery>
+                    <select>
+                        <projections start-index="35" stop-index="94">
+                            <top-projection alias="rownum_" start-index="35" stop-index="94">
+                                <top-value value="10" parameter-index="0" start-index="40" stop-index="40" />
+                            </top-projection>
+                        </projections>
+                        <from>
+                            <simple-table name="t_order" alias="o" start-index="101" stop-index="109">
+                                <table-bound>
+                                    <original-database name="foo_db_1" />
+                                    <original-schema name="dbo" />
+                                </table-bound>
+                            </simple-table>
+                        </from>
+                    </select>
+                </subquery>
+            </subquery-table>
+        </from>
+        <where start-index="117" stop-index="140">
+            <expr>
+                <binary-operation-expression start-index="123" stop-index="140">
+                    <left>
+                        <column name="rownum_" start-index="123" stop-index="136" start-delimiter="[" end-delimiter="]">
+                            <owner name="row_" start-index="123" stop-index="126" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <parameter-marker-expression parameter-index="1" start-index="140" stop-index="140" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+        <parameters>
+            <parameter-marker-expression parameter-index="0" start-index="40" stop-index="40" />
+            <parameter-marker-expression parameter-index="1" start-index="140" stop-index="140" />
+        </parameters>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/binder/src/test/resources/sqls/dml/select.xml
+++ b/test/it/binder/src/test/resources/sqls/dml/select.xml
@@ -32,4 +32,5 @@
     <sql-case id="select_with_left_join_where_outer_column" value="SELECT t1.user_id, t1.user_name, t2.order_id, t2.creation_date FROM t_user t1 LEFT JOIN t_order t2 ON t1.user_id = t2.user_id WHERE t1.user_name = ?" db-types="MySQL" case-types="PLACEHOLDER"/>
     <sql-case id="select_with_left_join_having_outer_column" value="SELECT COUNT(*) AS count FROM t_order o LEFT JOIN t_user u ON o.user_id = u.user_id GROUP BY u.user_id HAVING u.user_id IS NOT NULL" db-types="MySQL"/>
     <sql-case id="select_with_outer_join_operator" value="SELECT o.order_id FROM t_order o, t_order_item i WHERE o.order_id = i.order_id(+)" db-types="Oracle"/>
+    <sql-case id="select_with_top_and_delimited_row_number_alias" value="SELECT row_.[rownum_] FROM (SELECT TOP (?) ROW_NUMBER() OVER (ORDER BY o.order_id) AS [rownum_] FROM t_order o) row_ WHERE row_.[rownum_] &gt; ?" db-types="SQLServer" case-types="PLACEHOLDER"/>
 </sql-cases>


### PR DESCRIPTION
Remove row-number identifiers from unparenthesized function metadata and preserve normalized TOP projection aliases for binding and pagination.

