### PR TITLE
Fix MCP E2E conformance discovery and Hive test dependency

### DIFF
--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -234,7 +234,7 @@ jobs:
           mkdir -p "${results_root}"
           available_scenarios="$(
             node .mcp-conformance/dist/index.js list --server --spec-version 2025-11-25 \
-              | sed -nE 's/^ - ([^ ]+).*/\1/p'
+              | sed -nE 's/^[[:space:]]+- ([^ ]+).*/\1/p'
           )"
           scenario_count=0
           while IFS= read -r scenario; do

--- a/test/e2e/mcp/pom.xml
+++ b/test/e2e/mcp/pom.xml
@@ -115,6 +115,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Parse the conformance runner's indented scenario list correctly and restore the Hive JDBC test dependency required by MCP production Proxy E2E tests.
