### PR TITLE
Fix zero-length MySQL binary TIME decoding

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -32,6 +32,7 @@
 1. Proxy: Fix empty array literal decoding in PostgreSQL array parameter decoder - [#39137](https://github.com/apache/shardingsphere/pull/39137)
 1. Proxy: Fix incorrect generated key handling for explicit auto-increment values - [#38810](https://github.com/apache/shardingsphere/pull/38810)
 1. Proxy: Fix microseconds decoded as nanoseconds in MySQL binary TIME value - [#39138](https://github.com/apache/shardingsphere/pull/39138)
+1. Proxy: Avoid consuming following prepared statement parameter bytes for zero-length MySQL binary TIME values - [#39221](https://github.com/apache/shardingsphere/issues/39221)
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
 1. Proxy: Add MySQL exception mapping for ColumnNotFoundException - [#39126](https://github.com/apache/shardingsphere/pull/39126)
 1. Proxy: Fix MySQL prepared statement parameter signedness decoding - [#39204](https://github.com/apache/shardingsphere/pull/39204)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -32,7 +32,7 @@
 1. Proxy: Fix empty array literal decoding in PostgreSQL array parameter decoder - [#39137](https://github.com/apache/shardingsphere/pull/39137)
 1. Proxy: Fix incorrect generated key handling for explicit auto-increment values - [#38810](https://github.com/apache/shardingsphere/pull/38810)
 1. Proxy: Fix microseconds decoded as nanoseconds in MySQL binary TIME value - [#39138](https://github.com/apache/shardingsphere/pull/39138)
-1. Proxy: Avoid consuming following prepared statement parameter bytes for zero-length MySQL binary TIME values - [#39221](https://github.com/apache/shardingsphere/issues/39221)
+1. Proxy: Avoid consuming following prepared statement parameter bytes for zero-length MySQL binary TIME values - [#39233](https://github.com/apache/shardingsphere/pull/39233)
 1. Proxy: Fix MySQL BLOB data corruption when string-like prepared statement parameters target BLOB columns - [#39072](https://github.com/apache/shardingsphere/pull/39072)
 1. Proxy: Add MySQL exception mapping for ColumnNotFoundException - [#39126](https://github.com/apache/shardingsphere/pull/39126)
 1. Proxy: Fix MySQL prepared statement parameter signedness decoding - [#39204](https://github.com/apache/shardingsphere/pull/39204)

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValue.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValue.java
@@ -35,8 +35,6 @@ public final class MySQLTimeBinaryProtocolValue implements MySQLBinaryProtocolVa
     @Override
     public Object read(final MySQLPacketPayload payload, final boolean unsigned) throws SQLException {
         int length = payload.readInt1();
-        payload.readInt1();
-        payload.readInt4();
         switch (length) {
             case 0:
                 return new Timestamp(0L);
@@ -52,6 +50,8 @@ public final class MySQLTimeBinaryProtocolValue implements MySQLBinaryProtocolVa
     }
     
     private Timestamp getTimestamp(final MySQLPacketPayload payload) {
+        payload.readInt1();
+        payload.readInt4();
         Timestamp result = Timestamp.valueOf(LocalDateTime.of(0, 1, 1, payload.readInt1(), payload.readInt1(), payload.readInt1()));
         result.setNanos(0);
         return result;

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValueTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValueTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.database.protocol.mysql.packet.command.query.binary.execute.protocol;
 
+import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.database.protocol.mysql.payload.MySQLPacketPayload;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +28,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Time;
@@ -67,9 +69,16 @@ class MySQLTimeBinaryProtocolValueTest {
     }
     
     @Test
+    void assertReadZeroLengthDoesNotConsumeNextParameterBytes() throws SQLException {
+        byte[] data = {0x00, (byte) 0xd2, 0x04, 0x00, 0x00};
+        MySQLPacketPayload realPayload = new MySQLPacketPayload(Unpooled.wrappedBuffer(data), StandardCharsets.UTF_8);
+        assertThat(binaryProtocolValue.read(realPayload, false), is(new Timestamp(0L)));
+        assertThat(realPayload.readInt4(), is(1234));
+    }
+    
+    @Test
     void assertReadWithUnsupportedLength() {
-        when(payload.readInt1()).thenReturn(100, 0);
-        when(payload.readInt4()).thenReturn(0);
+        when(payload.readInt1()).thenReturn(100);
         SQLFeatureNotSupportedException actual = assertThrows(SQLFeatureNotSupportedException.class, () -> binaryProtocolValue.read(payload, false));
         assertThat(actual.getMessage(), is("Wrong length `100` of MYSQL_TYPE_DATE"));
     }
@@ -95,7 +104,6 @@ class MySQLTimeBinaryProtocolValueTest {
     
     private static Stream<Arguments> readArguments() {
         return Stream.of(
-                Arguments.of("zero_length", new int[]{0, 0, 0, 0, 0}, new int[]{0, 0}, new Timestamp(0L)),
                 Arguments.of("eight_bytes", new int[]{8, 0, 10, 59, 0}, new int[]{0, 0}, createTimestamp(0)),
                 Arguments.of("twelve_bytes", new int[]{12, 0, 10, 59, 0}, new int[]{0, 1000}, createTimestamp(1_000_000)),
                 Arguments.of("twelve_bytes_fractional_second", new int[]{12, 0, 10, 59, 0}, new int[]{0, 230000}, createTimestamp(230_000_000)));


### PR DESCRIPTION
Fixes #39221.

Changes proposed in this pull request:
  - Return zero-length MySQL binary TIME values before reading sign and days fields.
  - Preserve the existing length-8 and length-12 decoding paths.
  - Add a real `MySQLPacketPayload` regression test that proves the following int4 value 1234 remains unread.
  - Update the Release Notes.

Verification:
  - Reproduced the pre-fix failure with the real 5-byte payload `00 D2 04 00 00`: `IndexOutOfBoundsException` while reading days.
  - Passed `MySQLTimeBinaryProtocolValueTest` with 100% class, line, and branch coverage for the target class.
  - Passed all tests in `database/protocol/dialect/mysql`.
  - Passed Spotless, Checkstyle, and `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e` locally with JDK 25.

Requested assignment and the remaining `in: proxy` and `in: protocol` labels in #39221; `type: bug` and `db: MySQL` are already applied.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)