### PR TITLE
Add StorageUnitConfiguration to encapsulate DataSourcePoolProperties

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/config/database/DatabaseConfiguration.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/config/database/DatabaseConfiguration.java
@@ -23,7 +23,10 @@ import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUn
 
 import javax.sql.DataSource;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * Database configuration.
@@ -43,6 +46,16 @@ public interface DatabaseConfiguration {
      * @return storage units
      */
     Map<String, StorageUnit> getStorageUnits();
+    
+    /**
+     * Get storage unit configurations.
+     *
+     * @return storage unit configurations
+     */
+    default Map<String, StorageUnitConfiguration> getStorageUnitConfigurations() {
+        return getStorageUnits().entrySet().stream().collect(Collectors.toMap(
+                Entry::getKey, entry -> new StorageUnitConfiguration(entry.getValue().getDataSourcePoolProperties()), (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
+    }
     
     /**
      * Get data sources.

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/config/database/StorageUnitConfiguration.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/config/database/StorageUnitConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.config.database;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
+
+/**
+ * Storage unit configuration.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class StorageUnitConfiguration {
+    
+    private final DataSourcePoolProperties dataSourcePoolProperties;
+}

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/config/database/impl/DataSourceGeneratedDatabaseConfiguration.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/config/database/impl/DataSourceGeneratedDatabaseConfiguration.java
@@ -19,10 +19,9 @@ package org.apache.shardingsphere.infra.config.database.impl;
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.database.DatabaseConfiguration;
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
-import org.apache.shardingsphere.infra.datasource.pool.config.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.creator.DataSourcePoolCreator;
-import org.apache.shardingsphere.infra.datasource.pool.props.creator.DataSourcePoolPropertiesCreator;
 import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.infra.metadata.database.resource.node.StorageNode;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
@@ -48,15 +47,18 @@ public final class DataSourceGeneratedDatabaseConfiguration implements DatabaseC
     
     private final Map<StorageNode, DataSource> dataSources;
     
-    public DataSourceGeneratedDatabaseConfiguration(final Map<String, DataSourceConfiguration> dataSourceConfigs, final Collection<RuleConfiguration> ruleConfigs,
+    private final Map<String, StorageUnitConfiguration> storageUnitConfigurations;
+    
+    public DataSourceGeneratedDatabaseConfiguration(final Map<String, StorageUnitConfiguration> storageUnitConfigs, final Collection<RuleConfiguration> ruleConfigs,
                                                     final boolean isInstanceConnectionEnabled) {
         ruleConfigurations = ruleConfigs;
-        Map<String, DataSourcePoolProperties> dataSourcePoolPropertiesMap = dataSourceConfigs.entrySet().stream()
-                .collect(Collectors.toMap(Entry::getKey, entry -> DataSourcePoolPropertiesCreator.create(entry.getValue()), (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
+        Map<String, DataSourcePoolProperties> dataSourcePoolPropertiesMap = storageUnitConfigs.entrySet().stream().collect(Collectors.toMap(
+                Entry::getKey, entry -> entry.getValue().getDataSourcePoolProperties(), (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
         Map<String, StorageNode> storageUnitNodeMap = StorageUnitNodeMapCreator.create(dataSourcePoolPropertiesMap, isInstanceConnectionEnabled);
         Map<StorageNode, DataSource> storageNodeDataSources = createStorageNodeDataSourceMap(dataSourcePoolPropertiesMap, storageUnitNodeMap);
         storageUnits = createStorageUnits(dataSourcePoolPropertiesMap, storageUnitNodeMap, storageNodeDataSources);
         dataSources = storageNodeDataSources;
+        storageUnitConfigurations = storageUnitConfigs;
     }
     
     private Map<StorageNode, DataSource> createStorageNodeDataSourceMap(final Map<String, DataSourcePoolProperties> dataSourcePoolPropertiesMap, final Map<String, StorageNode> storageUnitNodeMap) {

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapper.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapper.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.yaml.config.swapper.resource;
 
 import com.google.common.base.Preconditions;
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.creator.DataSourcePoolCreator;
 import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
@@ -83,6 +84,16 @@ public final class YamlDataSourceConfigurationSwapper {
         return new DataSourcePoolProperties(yamlConfig.get(DATA_SOURCE_CLASS_NAME_KEY).toString(), getProperties(yamlConfig));
     }
     
+    /**
+     * Swap to storage unit configuration.
+     *
+     * @param yamlConfig YAML configuration
+     * @return storage unit configuration
+     */
+    public StorageUnitConfiguration swapToStorageUnitConfiguration(final Map<String, Object> yamlConfig) {
+        return new StorageUnitConfiguration(swapToDataSourcePoolProperties(yamlConfig));
+    }
+    
     @SuppressWarnings({"rawtypes", "unchecked"})
     private Map<String, Object> getProperties(final Map<String, Object> yamlConfig) {
         Map<String, Object> result = new HashMap<>(yamlConfig);
@@ -106,5 +117,15 @@ public final class YamlDataSourceConfigurationSwapper {
         Map<String, Object> result = new HashMap<>(props.getAllStandardProperties());
         result.put(DATA_SOURCE_CLASS_NAME_KEY, props.getPoolClassName());
         return result;
+    }
+    
+    /**
+     * Swap to map from storage unit configuration.
+     *
+     * @param storageUnitConfig storage unit configuration
+     * @return data source map
+     */
+    public Map<String, Object> swapToMap(final StorageUnitConfiguration storageUnitConfig) {
+        return swapToMap(storageUnitConfig.getDataSourcePoolProperties());
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/config/database/StorageUnitConfigurationTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/config/database/StorageUnitConfigurationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.config.database;
+
+import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class StorageUnitConfigurationTest {
+    
+    @Test
+    void assertDataSourcePoolProperties() {
+        DataSourcePoolProperties expected = new DataSourcePoolProperties("foo_class", Collections.emptyMap());
+        assertThat(new StorageUnitConfiguration(expected).getDataSourcePoolProperties(), is(expected));
+    }
+}

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/config/database/impl/DataSourceGeneratedDatabaseConfigurationTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/config/database/impl/DataSourceGeneratedDatabaseConfigurationTest.java
@@ -18,9 +18,11 @@
 package org.apache.shardingsphere.infra.config.database.impl;
 
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.config.ConnectionConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.config.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.config.PoolConfiguration;
+import org.apache.shardingsphere.infra.datasource.pool.props.creator.DataSourcePoolPropertiesCreator;
 import org.apache.shardingsphere.infra.fixture.FixtureRuleConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.resource.node.StorageNode;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
@@ -91,8 +93,23 @@ class DataSourceGeneratedDatabaseConfigurationTest {
     }
     
     private DataSourceGeneratedDatabaseConfiguration createDatabaseConfiguration(final String dataSourceClassName) {
-        DataSourceConfiguration dataSourceConfig = new DataSourceConfiguration(new ConnectionConfiguration(dataSourceClassName, null, "jdbc:mock://127.0.0.1/foo_db", "root", ""),
+        StorageUnitConfiguration storageUnitConfig = new StorageUnitConfiguration(DataSourcePoolPropertiesCreator.create(createDataSourceConfiguration(dataSourceClassName)));
+        return new DataSourceGeneratedDatabaseConfiguration(Collections.singletonMap("foo_db", storageUnitConfig), Collections.singleton(new FixtureRuleConfiguration("foo_rule")), true);
+    }
+    
+    private DataSourceConfiguration createDataSourceConfiguration(final String dataSourceClassName) {
+        return new DataSourceConfiguration(new ConnectionConfiguration(dataSourceClassName, null, "jdbc:mock://127.0.0.1/foo_db", "root", ""),
                 new PoolConfiguration(2000L, 1000L, 1000L, 2, 1, false, new Properties()));
-        return new DataSourceGeneratedDatabaseConfiguration(Collections.singletonMap("foo_db", dataSourceConfig), Collections.singleton(new FixtureRuleConfiguration("foo_rule")), true);
+    }
+    
+    @Test
+    void assertNewWithStorageUnitConfigurations() {
+        DataSourceConfiguration dataSourceConfig = createDataSourceConfiguration(MockedDataSource.class.getName());
+        StorageUnitConfiguration storageUnitConfig = new StorageUnitConfiguration(DataSourcePoolPropertiesCreator.create(dataSourceConfig));
+        DataSourceGeneratedDatabaseConfiguration actual = new DataSourceGeneratedDatabaseConfiguration(
+                Collections.singletonMap("foo_db", storageUnitConfig), Collections.singleton(new FixtureRuleConfiguration("foo_rule")), true);
+        assertThat(actual.getStorageUnitConfigurations().get("foo_db"), is(storageUnitConfig));
+        assertStorageUnits(actual.getStorageUnits().get("foo_db"));
+        assertDataSources((MockedDataSource) actual.getDataSources().get(new StorageNode("foo_db")));
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/config/database/impl/DataSourceProvidedDatabaseConfigurationTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/config/database/impl/DataSourceProvidedDatabaseConfigurationTest.java
@@ -42,6 +42,7 @@ class DataSourceProvidedDatabaseConfigurationTest {
                 Collections.singletonMap("foo_ds", new MockedDataSource()), Collections.singleton(new FixtureRuleConfiguration("foo_rule")));
         assertRuleConfigurations(actual);
         assertStorageUnits(actual.getStorageUnits().get("foo_ds"));
+        assertThat(actual.getStorageUnitConfigurations().get("foo_ds").getDataSourcePoolProperties(), is(actual.getStorageUnits().get("foo_ds").getDataSourcePoolProperties()));
         assertDataSources((MockedDataSource) actual.getDataSources().get(new StorageNode("foo_ds")));
     }
     

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapperTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapperTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.yaml.config.swapper.resource;
 
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource;
@@ -142,5 +143,19 @@ class YamlDataSourceConfigurationSwapperTest {
         customProps.put("customKey2", "customValue2");
         result.put("customPoolProps", customProps);
         return result;
+    }
+    
+    @Test
+    void assertSwapToStorageUnitConfiguration() {
+        StorageUnitConfiguration actual = swapper.swapToStorageUnitConfiguration(createPropertyMap("foo_ds"));
+        assertThat(actual.getDataSourcePoolProperties().getPoolClassName(), is(MockedDataSource.class.getName()));
+        assertThat(actual.getDataSourcePoolProperties().getAllLocalProperties().get("url"), is("jdbc:mock://127.0.0.1/foo_ds"));
+    }
+    
+    @Test
+    void assertSwapStorageUnitConfigurationToMap() {
+        DataSourcePoolProperties props = new DataSourcePoolProperties(MockedDataSource.class.getName(), createProperties());
+        Map<String, Object> actual = swapper.swapToMap(new StorageUnitConfiguration(props));
+        assertThat(actual, is(swapper.swapToMap(props)));
     }
 }

--- a/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/api/CDCJobAPITest.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/api/CDCJobAPITest.java
@@ -58,6 +58,7 @@ import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.OneOffJobBoo
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.api.JobConfigurationAPI;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceType;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
@@ -107,6 +108,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -151,7 +153,7 @@ class CDCJobAPITest {
         when(PipelineJobIdUtils.parseContextKey(anyString())).thenReturn(new PipelineContextKey("foo_db", InstanceType.PROXY));
         when(PipelineAPIFactory.getPipelineGovernanceFacade(any())).thenReturn(mock(PipelineGovernanceFacade.class, RETURNS_DEEP_STUBS));
         YamlDataSourceConfigurationSwapper dataSourceSwapper = mock(YamlDataSourceConfigurationSwapper.class);
-        when(dataSourceSwapper.swapToMap(any())).thenReturn(createStandardDataSourceProperties());
+        when(dataSourceSwapper.swapToMap(nullable(DataSourcePoolProperties.class))).thenReturn(createStandardDataSourceProperties());
         CDCJobAPI result = new CDCJobAPI();
         Plugins.getMemberAccessor().set(CDCJobAPI.class.getDeclaredField("dataSourceConfigSwapper"), result, dataSourceSwapper);
         Plugins.getMemberAccessor().set(CDCJobAPI.class.getDeclaredField("ruleConfigSwapperEngine"), result, mock(YamlRuleConfigurationSwapperEngine.class));

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/factory/init/type/RegisterCenterMetaDataContextsInitFactory.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/factory/init/type/RegisterCenterMetaDataContextsInitFactory.java
@@ -20,13 +20,13 @@ package org.apache.shardingsphere.mode.metadata.factory.init.type;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.database.DatabaseConfiguration;
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.config.database.impl.DataSourceGeneratedDatabaseConfiguration;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.database.DatabaseTypeEngine;
-import org.apache.shardingsphere.infra.datasource.pool.config.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.destroyer.DataSourcePoolDestroyer;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstanceContext;
 import org.apache.shardingsphere.infra.instance.metadata.jdbc.JDBCInstanceMetaData;
@@ -90,9 +90,9 @@ public final class RegisterCenterMetaDataContextsInitFactory extends MetaDataCon
     private DatabaseConfiguration createEffectiveDatabaseConfiguration(final String databaseName, final Map<String, DatabaseConfiguration> databaseConfigs,
                                                                        final boolean isInstanceConnectionEnabled) {
         closeGeneratedDataSources(databaseName, databaseConfigs);
-        Map<String, DataSourceConfiguration> dataSources = persistFacade.loadDataSourceConfigurations(databaseName);
+        Map<String, StorageUnitConfiguration> storageUnitConfigs = persistFacade.loadStorageUnitConfigurations(databaseName);
         Collection<RuleConfiguration> databaseRuleConfigs = persistFacade.getDatabaseRuleService().load(databaseName);
-        return new DataSourceGeneratedDatabaseConfiguration(dataSources, databaseRuleConfigs, isInstanceConnectionEnabled);
+        return new DataSourceGeneratedDatabaseConfiguration(storageUnitConfigs, databaseRuleConfigs, isInstanceConnectionEnabled);
     }
     
     private void closeGeneratedDataSources(final String databaseName, final Map<String, ? extends DatabaseConfiguration> databaseConfigs) {

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/MetaDataPersistFacade.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/MetaDataPersistFacade.java
@@ -19,11 +19,11 @@ package org.apache.shardingsphere.mode.metadata.persist;
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.database.DatabaseConfiguration;
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.rule.decorator.RuleConfigurationDecorator;
 import org.apache.shardingsphere.infra.datasource.pool.config.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.props.creator.DataSourcePoolPropertiesCreator;
-import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mode.metadata.persist.config.database.DataSourceUnitPersistService;
@@ -98,11 +98,11 @@ public final class MetaDataPersistFacade {
      * @param rules rules
      */
     public void persistConfigurations(final String databaseName, final DatabaseConfiguration databaseConfig, final Map<String, DataSource> dataSources, final Collection<ShardingSphereRule> rules) {
-        Map<String, DataSourcePoolProperties> propsMap = getDataSourcePoolPropertiesMap(databaseConfig);
-        if (propsMap.isEmpty() && databaseConfig.getRuleConfigurations().isEmpty()) {
+        Map<String, StorageUnitConfiguration> storageUnitConfigs = databaseConfig.getStorageUnitConfigurations();
+        if (storageUnitConfigs.isEmpty() && databaseConfig.getRuleConfigurations().isEmpty()) {
             databaseMetaDataFacade.getDatabase().add(databaseName);
         } else {
-            dataSourceUnitService.persist(databaseName, propsMap);
+            dataSourceUnitService.persistStorageUnitConfigurations(databaseName, storageUnitConfigs);
             databaseRuleService.persist(databaseName, decorateRuleConfigurations(databaseName, dataSources, rules));
         }
     }
@@ -118,9 +118,14 @@ public final class MetaDataPersistFacade {
         return result;
     }
     
-    private Map<String, DataSourcePoolProperties> getDataSourcePoolPropertiesMap(final DatabaseConfiguration databaseConfig) {
-        return databaseConfig.getStorageUnits().entrySet().stream()
-                .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getDataSourcePoolProperties(), (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
+    /**
+     * Load storage unit configurations.
+     *
+     * @param databaseName database name
+     * @return storage unit configurations
+     */
+    public Map<String, StorageUnitConfiguration> loadStorageUnitConfigurations(final String databaseName) {
+        return dataSourceUnitService.loadStorageUnitConfigurations(databaseName);
     }
     
     /**
@@ -130,7 +135,7 @@ public final class MetaDataPersistFacade {
      * @return data source configurations
      */
     public Map<String, DataSourceConfiguration> loadDataSourceConfigurations(final String databaseName) {
-        return dataSourceUnitService.load(databaseName).entrySet().stream().collect(Collectors.toMap(Entry::getKey,
-                entry -> DataSourcePoolPropertiesCreator.createConfiguration(entry.getValue()), (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
+        return loadStorageUnitConfigurations(databaseName).entrySet().stream().collect(Collectors.toMap(Entry::getKey,
+                entry -> DataSourcePoolPropertiesCreator.createConfiguration(entry.getValue().getDataSourcePoolProperties()), (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
     }
 }

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/config/database/DataSourceUnitPersistService.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/config/database/DataSourceUnitPersistService.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mode.metadata.persist.config.database;
 
 import com.google.common.base.Strings;
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 import org.apache.shardingsphere.infra.yaml.config.swapper.resource.YamlDataSourceConfigurationSwapper;
@@ -57,10 +58,10 @@ public final class DataSourceUnitPersistService {
      * @return data source pool properties map
      */
     public Map<String, DataSourcePoolProperties> load(final String databaseName) {
-        Collection<String> childrenKeys = repository.getChildrenKeys(NodePathGenerator.toPath(new StorageUnitNodePath(databaseName, null)));
-        Map<String, DataSourcePoolProperties> result = new LinkedHashMap<>(childrenKeys.size(), 1F);
-        for (String each : childrenKeys) {
-            load(databaseName, each).ifPresent(dataSourcePoolProps -> result.put(each, dataSourcePoolProps));
+        Map<String, StorageUnitConfiguration> storageUnitConfigs = loadStorageUnitConfigurations(databaseName);
+        Map<String, DataSourcePoolProperties> result = new LinkedHashMap<>(storageUnitConfigs.size(), 1F);
+        for (Entry<String, StorageUnitConfiguration> entry : storageUnitConfigs.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().getDataSourcePoolProperties());
         }
         return result;
     }
@@ -72,8 +73,34 @@ public final class DataSourceUnitPersistService {
      * @param dataSourceName data source name
      * @return data source pool properties
      */
-    @SuppressWarnings("unchecked")
     public Optional<DataSourcePoolProperties> load(final String databaseName, final String dataSourceName) {
+        return loadStorageUnitConfiguration(databaseName, dataSourceName).map(StorageUnitConfiguration::getDataSourcePoolProperties);
+    }
+    
+    /**
+     * Load storage unit configurations.
+     *
+     * @param databaseName database name
+     * @return storage unit configurations
+     */
+    public Map<String, StorageUnitConfiguration> loadStorageUnitConfigurations(final String databaseName) {
+        Collection<String> childrenKeys = repository.getChildrenKeys(NodePathGenerator.toPath(new StorageUnitNodePath(databaseName, null)));
+        Map<String, StorageUnitConfiguration> result = new LinkedHashMap<>(childrenKeys.size(), 1F);
+        for (String each : childrenKeys) {
+            loadStorageUnitConfiguration(databaseName, each).ifPresent(storageUnitConfig -> result.put(each, storageUnitConfig));
+        }
+        return result;
+    }
+    
+    /**
+     * Load storage unit configuration.
+     *
+     * @param databaseName database name
+     * @param dataSourceName data source name
+     * @return storage unit configuration
+     */
+    @SuppressWarnings("unchecked")
+    public Optional<StorageUnitConfiguration> loadStorageUnitConfiguration(final String databaseName, final String dataSourceName) {
         VersionNodePath versionNodePath = new VersionNodePath(new StorageUnitNodePath(databaseName, dataSourceName));
         String activeVersion = repository.query(versionNodePath.getActiveVersionPath());
         if (Strings.isNullOrEmpty(activeVersion)) {
@@ -83,7 +110,7 @@ public final class DataSourceUnitPersistService {
         if (Strings.isNullOrEmpty(dataSourceContent)) {
             return Optional.empty();
         }
-        return Optional.of(yamlDataSourceConfigurationSwapper.swapToDataSourcePoolProperties(YamlEngine.unmarshal(dataSourceContent, Map.class)));
+        return Optional.of(yamlDataSourceConfigurationSwapper.swapToStorageUnitConfiguration(YamlEngine.unmarshal(dataSourceContent, Map.class)));
     }
     
     /**
@@ -93,7 +120,21 @@ public final class DataSourceUnitPersistService {
      * @param dataSourcePropsMap to be persisted data source properties map
      */
     public void persist(final String databaseName, final Map<String, DataSourcePoolProperties> dataSourcePropsMap) {
+        Map<String, StorageUnitConfiguration> storageUnitConfigs = new LinkedHashMap<>(dataSourcePropsMap.size(), 1F);
         for (Entry<String, DataSourcePoolProperties> entry : dataSourcePropsMap.entrySet()) {
+            storageUnitConfigs.put(entry.getKey(), new StorageUnitConfiguration(entry.getValue()));
+        }
+        persistStorageUnitConfigurations(databaseName, storageUnitConfigs);
+    }
+    
+    /**
+     * Persist storage unit configurations.
+     *
+     * @param databaseName database name
+     * @param storageUnitConfigs storage unit configurations
+     */
+    public void persistStorageUnitConfigurations(final String databaseName, final Map<String, StorageUnitConfiguration> storageUnitConfigs) {
+        for (Entry<String, StorageUnitConfiguration> entry : storageUnitConfigs.entrySet()) {
             VersionNodePath versionNodePath = new VersionNodePath(new StorageUnitNodePath(databaseName, entry.getKey()));
             versionPersistService.persist(versionNodePath, YamlEngine.marshal(yamlDataSourceConfigurationSwapper.swapToMap(entry.getValue())));
         }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/init/type/RegisterCenterMetaDataContextsInitFactoryTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/init/type/RegisterCenterMetaDataContextsInitFactoryTest.java
@@ -96,7 +96,7 @@ class RegisterCenterMetaDataContextsInitFactoryTest {
                 MockedConstruction<MetaDataPersistFacade> ignoredFacade = mockConstruction(MetaDataPersistFacade.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS),
                         (mock, context) -> {
                             when(mock.getPropsService().load()).thenReturn(new Properties());
-                            when(mock.loadDataSourceConfigurations(anyString())).thenReturn(Collections.emptyMap());
+                            when(mock.loadStorageUnitConfigurations(anyString())).thenReturn(Collections.emptyMap());
                             when(mock.getDatabaseMetaDataFacade().getDatabase().loadAllDatabaseNames()).thenReturn(databaseNames);
                             when(mock.getStatisticsService().load(any())).thenReturn(new ShardingSphereStatistics());
                         });
@@ -105,6 +105,9 @@ class RegisterCenterMetaDataContextsInitFactoryTest {
             assertThat(actual.getMetaData().getAllDatabases(), hasSize(2));
             assertThat(destroyerMocked.constructed(), hasSize(1));
             verify(destroyerMocked.constructed().get(0)).asyncDestroy();
+            verify(ignoredFacade.constructed().get(0)).loadStorageUnitConfigurations("with_units");
+            verify(ignoredFacade.constructed().get(0)).loadStorageUnitConfigurations("without_units");
+            verify(ignoredFacade.constructed().get(0)).loadStorageUnitConfigurations("missing_config");
         }
     }
     

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/MetaDataPersistFacadeTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/MetaDataPersistFacadeTest.java
@@ -18,12 +18,12 @@
 package org.apache.shardingsphere.mode.metadata.persist;
 
 import org.apache.shardingsphere.infra.config.database.DatabaseConfiguration;
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.rule.decorator.RuleConfigurationDecorator;
 import org.apache.shardingsphere.infra.datasource.pool.config.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.props.creator.DataSourcePoolPropertiesCreator;
 import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
-import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.infra.metadata.database.schema.manager.GenericSchemaManager;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -106,34 +106,42 @@ class MetaDataPersistFacadeTest {
     @Test
     void assertPersistConfigurationsWithDatabaseRuleConfigurations() {
         DatabaseConfiguration databaseConfig = mock(DatabaseConfiguration.class, RETURNS_DEEP_STUBS);
-        when(databaseConfig.getStorageUnits()).thenReturn(Collections.emptyMap());
+        when(databaseConfig.getStorageUnitConfigurations()).thenReturn(Collections.emptyMap());
         when(databaseConfig.getRuleConfigurations().isEmpty()).thenReturn(false);
         ShardingSphereRule rule = mock(ShardingSphereRule.class);
         RuleConfiguration ruleConfig = mock(RuleConfiguration.class);
         when(rule.getConfiguration()).thenReturn(ruleConfig);
         when(TypedSPILoader.findService(RuleConfigurationDecorator.class, ruleConfig.getClass())).thenReturn(Optional.of(mock(RuleConfigurationDecorator.class)));
         metaDataPersistFacade.persistConfigurations("foo_db", databaseConfig, Collections.emptyMap(), Collections.singleton(rule));
-        verify(dataSourceUnitService).persist("foo_db", Collections.emptyMap());
+        verify(dataSourceUnitService).persistStorageUnitConfigurations("foo_db", Collections.emptyMap());
         verify(databaseRuleService).persist(eq("foo_db"), any());
     }
     
     @Test
     void assertPersistConfigurationsWithDataSourcePoolProperties() {
         DatabaseConfiguration databaseConfig = mock(DatabaseConfiguration.class, RETURNS_DEEP_STUBS);
-        when(databaseConfig.getStorageUnits()).thenReturn(Collections.singletonMap("foo_ds", mock(StorageUnit.class, RETURNS_DEEP_STUBS)));
+        when(databaseConfig.getStorageUnitConfigurations()).thenReturn(Collections.singletonMap("foo_ds", mock(StorageUnitConfiguration.class)));
         metaDataPersistFacade.persistConfigurations("foo_db", databaseConfig, Collections.emptyMap(), Collections.emptyList());
-        verify(dataSourceUnitService).persist(eq("foo_db"), any());
+        verify(dataSourceUnitService).persistStorageUnitConfigurations(eq("foo_db"), any());
         verify(databaseRuleService).persist("foo_db", Collections.emptyList());
     }
     
     @Test
     void assertLoadDataSourceConfigurations() {
         DataSourcePoolProperties dataSourcePoolProps = mock(DataSourcePoolProperties.class);
-        when(dataSourceUnitService.load("foo_db")).thenReturn(Collections.singletonMap("foo_ds", dataSourcePoolProps));
+        when(dataSourceUnitService.loadStorageUnitConfigurations("foo_db"))
+                .thenReturn(Collections.singletonMap("foo_ds", new StorageUnitConfiguration(dataSourcePoolProps)));
         DataSourceConfiguration dataSourceConfig = mock(DataSourceConfiguration.class);
         when(DataSourcePoolPropertiesCreator.createConfiguration(dataSourcePoolProps)).thenReturn(dataSourceConfig);
         Map<String, DataSourceConfiguration> actual = metaDataPersistFacade.loadDataSourceConfigurations("foo_db");
         assertThat(actual.size(), is(1));
         assertThat(actual.get("foo_ds"), is(dataSourceConfig));
+    }
+    
+    @Test
+    void assertLoadStorageUnitConfigurations() {
+        Map<String, StorageUnitConfiguration> expected = Collections.singletonMap("foo_ds", mock(StorageUnitConfiguration.class));
+        when(dataSourceUnitService.loadStorageUnitConfigurations("foo_db")).thenReturn(expected);
+        assertThat(metaDataPersistFacade.loadStorageUnitConfigurations("foo_db"), is(expected));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/config/database/DataSourceUnitPersistServiceTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/config/database/DataSourceUnitPersistServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mode.metadata.persist.config.database;
 
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.mode.spi.repository.PersistRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,5 +99,38 @@ class DataSourceUnitPersistServiceTest {
     void assertDelete() {
         persistService.delete("foo_db", "foo_ds");
         verify(repository).delete("/metadata/foo_db/data_sources/units/foo_ds");
+    }
+    
+    @Test
+    void assertLoadStorageUnitConfigurations() {
+        when(repository.getChildrenKeys("/metadata/foo_db/data_sources/units")).thenReturn(Collections.singletonList("foo_ds"));
+        when(repository.query("/metadata/foo_db/data_sources/units/foo_ds/active_version")).thenReturn("10");
+        when(repository.query("/metadata/foo_db/data_sources/units/foo_ds/versions/10")).thenReturn("{dataSourceClassName: org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource}");
+        Map<String, StorageUnitConfiguration> actual = persistService.loadStorageUnitConfigurations("foo_db");
+        assertThat(actual.size(), is(1));
+        assertThat(actual.get("foo_ds").getDataSourcePoolProperties().getPoolClassName(), is("org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource"));
+    }
+    
+    @Test
+    void assertLoadStorageUnitConfigurationWhenActiveVersionIsEmpty() {
+        when(repository.query("/metadata/foo_db/data_sources/units/foo_ds/active_version")).thenReturn("");
+        assertFalse(persistService.loadStorageUnitConfiguration("foo_db", "foo_ds").isPresent());
+    }
+    
+    @Test
+    void assertLoadStorageUnitConfigurationWhenContentIsEmpty() {
+        when(repository.query("/metadata/foo_db/data_sources/units/foo_ds/active_version")).thenReturn("10");
+        when(repository.query("/metadata/foo_db/data_sources/units/foo_ds/versions/10")).thenReturn("");
+        assertFalse(persistService.loadStorageUnitConfiguration("foo_db", "foo_ds").isPresent());
+    }
+    
+    @Test
+    void assertPersistStorageUnitConfigurations() {
+        DataSourcePoolProperties props = new DataSourcePoolProperties("org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource", Collections.emptyMap());
+        Map<String, StorageUnitConfiguration> storageUnitConfigs = Collections.singletonMap("foo_ds", new StorageUnitConfiguration(props));
+        persistService.persistStorageUnitConfigurations("foo_db", storageUnitConfigs);
+        verify(repository).persist("/metadata/foo_db/data_sources/units/foo_ds/versions/0",
+                "dataSourceClassName: org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource\n");
+        verify(repository).persist("/metadata/foo_db/data_sources/units/foo_ds/active_version", "0");
     }
 }

--- a/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
+++ b/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
@@ -260,4 +260,14 @@ class ClusterMetaDataManagerPersistServiceTest {
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(loadedDatabase), mock(), mock(), new ConfigurationProperties(new Properties()));
         when(metaDataContextManager.getMetaDataContexts()).thenReturn(new MetaDataContexts(metaData, null));
     }
+    
+    @Test
+    void assertUnregisterNonExistentStorageUnit() {
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
+        when(database.getName()).thenReturn("foo_db");
+        when(metaDataPersistFacade.getDataSourceUnitService().load("foo_db")).thenReturn(Collections.emptyMap());
+        metaDataManagerPersistService.unregisterStorageUnits(database, Collections.singleton("foo_ds"));
+        verify(metaDataPersistFacade.getDataSourceUnitService()).load("foo_db");
+        verify(metaDataPersistFacade.getDataSourceUnitService(), never()).delete(any(), any());
+    }
 }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyConfigurationSwapper.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyConfigurationSwapper.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.proxy.backend.config.yaml.swapper;
 
 import org.apache.shardingsphere.infra.config.database.DatabaseConfiguration;
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.config.database.impl.DataSourceGeneratedDatabaseConfiguration;
 import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
@@ -80,9 +81,17 @@ public final class YamlProxyConfigurationSwapper {
     private Map<String, DatabaseConfiguration> swapDatabaseConfigurations(final Map<String, YamlProxyDatabaseConfiguration> databaseConfigs, final boolean isInstanceConnectionEnabled) {
         Map<String, DatabaseConfiguration> result = new LinkedHashMap<>(databaseConfigs.size(), 1F);
         for (Entry<String, YamlProxyDatabaseConfiguration> entry : databaseConfigs.entrySet()) {
-            Map<String, DataSourceConfiguration> databaseDataSourceConfigs = swapDataSourceConfigurations(entry.getValue().getDataSources());
+            Map<String, StorageUnitConfiguration> storageUnitConfigs = swapStorageUnitConfigurations(entry.getValue().getDataSources());
             Collection<RuleConfiguration> databaseRuleConfigs = ruleConfigSwapperEngine.swapToRuleConfigurations(entry.getValue().getRules());
-            result.put(entry.getKey(), new DataSourceGeneratedDatabaseConfiguration(databaseDataSourceConfigs, databaseRuleConfigs, isInstanceConnectionEnabled));
+            result.put(entry.getKey(), new DataSourceGeneratedDatabaseConfiguration(storageUnitConfigs, databaseRuleConfigs, isInstanceConnectionEnabled));
+        }
+        return result;
+    }
+    
+    private Map<String, StorageUnitConfiguration> swapStorageUnitConfigurations(final Map<String, YamlProxyDataSourceConfiguration> yamlConfigs) {
+        Map<String, StorageUnitConfiguration> result = new LinkedHashMap<>(yamlConfigs.size(), 1F);
+        for (Entry<String, YamlProxyDataSourceConfiguration> entry : yamlConfigs.entrySet()) {
+            result.put(entry.getKey(), dataSourceConfigSwapper.swapToStorageUnitConfiguration(entry.getValue()));
         }
         return result;
     }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyDataSourceConfigurationSwapper.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyDataSourceConfigurationSwapper.java
@@ -17,9 +17,11 @@
 
 package org.apache.shardingsphere.proxy.backend.config.yaml.swapper;
 
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.config.ConnectionConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.config.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.config.PoolConfiguration;
+import org.apache.shardingsphere.infra.datasource.pool.props.creator.DataSourcePoolPropertiesCreator;
 import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyDataSourceConfiguration;
 
 /**
@@ -35,6 +37,16 @@ public final class YamlProxyDataSourceConfigurationSwapper {
      */
     public DataSourceConfiguration swap(final YamlProxyDataSourceConfiguration yamlConfig) {
         return new DataSourceConfiguration(swapConnectionConfiguration(yamlConfig), swapPoolConfiguration(yamlConfig));
+    }
+    
+    /**
+     * Swap YAML proxy data source configuration to storage unit configuration.
+     *
+     * @param yamlConfig YAML proxy data source configuration
+     * @return storage unit configuration
+     */
+    public StorageUnitConfiguration swapToStorageUnitConfiguration(final YamlProxyDataSourceConfiguration yamlConfig) {
+        return new StorageUnitConfiguration(DataSourcePoolPropertiesCreator.create(swap(yamlConfig)));
     }
     
     private ConnectionConfiguration swapConnectionConfiguration(final YamlProxyDataSourceConfiguration yamlConfig) {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyConfigurationSwapperTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyConfigurationSwapperTest.java
@@ -21,11 +21,13 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.authority.config.AuthorityRuleConfiguration;
 import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.database.DatabaseConfiguration;
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.resource.node.StorageNode;
 import org.apache.shardingsphere.proxy.backend.config.ProxyConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader;
 import org.apache.shardingsphere.proxy.backend.config.YamlProxyConfiguration;
+import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyDataSourceConfiguration;
 import org.apache.shardingsphere.readwritesplitting.config.ReadwriteSplittingRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.config.rule.ReadwriteSplittingDataSourceGroupRuleConfiguration;
 import org.junit.jupiter.api.Test;
@@ -48,6 +50,7 @@ class YamlProxyConfigurationSwapperTest {
         YamlProxyConfiguration yamlProxyConfig = ProxyConfigurationLoader.load("/conf/swap");
         ProxyConfiguration actual = new YamlProxyConfigurationSwapper().swap(yamlProxyConfig);
         assertDataSources(actual);
+        assertStorageUnitConfigurations(actual);
         assertDatabaseRules(actual);
         assertAuthorityRuleConfiguration(actual);
         assertProxyConfigurationProps(actual);
@@ -104,5 +107,25 @@ class YamlProxyConfigurationSwapperTest {
         Properties actual = proxyConfig.getGlobalConfiguration().getProperties();
         assertThat(actual.size(), is(1));
         assertThat(actual.getProperty("bar"), is("bar_value"));
+    }
+    
+    private void assertStorageUnitConfigurations(final ProxyConfiguration proxyConfig) {
+        StorageUnitConfiguration actual = proxyConfig.getDatabaseConfigurations().get("swapper_test").getStorageUnitConfigurations().get("foo_db");
+        assertThat(actual.getDataSourcePoolProperties().getAllStandardProperties().get("url"), is("jdbc:h2:mem:foo_db;DB_CLOSE_DELAY=-1"));
+    }
+    
+    private void assertGlobalDataSources(final ProxyConfiguration proxyConfig) {
+        HikariDataSource actual = (HikariDataSource) proxyConfig.getGlobalConfiguration().getDataSources().get("global_ds");
+        assertThat(actual.getJdbcUrl(), is("jdbc:h2:mem:foo_db;DB_CLOSE_DELAY=-1"));
+        assertThat(actual.getUsername(), is("sa"));
+    }
+    
+    @Test
+    void assertSwapGlobalDataSources() throws IOException {
+        YamlProxyConfiguration yamlProxyConfig = ProxyConfigurationLoader.load("/conf/swap");
+        YamlProxyDataSourceConfiguration globalDataSourceConfig =
+                yamlProxyConfig.getDatabaseConfigurations().get("swapper_test").getDataSources().get("foo_db");
+        yamlProxyConfig.getServerConfiguration().setDataSources(Collections.singletonMap("global_ds", globalDataSourceConfig));
+        assertGlobalDataSources(new YamlProxyConfigurationSwapper().swap(yamlProxyConfig));
     }
 }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyDataSourceConfigurationSwapperTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyDataSourceConfigurationSwapperTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.config.yaml.swapper;
 
+import org.apache.shardingsphere.infra.config.database.StorageUnitConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.config.ConnectionConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.config.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.config.PoolConfiguration;
@@ -61,5 +62,14 @@ class YamlProxyDataSourceConfigurationSwapperTest {
         assertThat(actualPool.getMaxPoolSize(), is(5));
         assertThat(actualPool.getMinPoolSize(), is(4));
         assertTrue(actualPool.getReadOnly());
+    }
+    
+    @Test
+    void assertSwapToStorageUnitConfiguration() throws IOException {
+        YamlProxyConfiguration yamlProxyConfig = ProxyConfigurationLoader.load("/conf/swap");
+        YamlProxyDataSourceConfiguration yamlConfig = yamlProxyConfig.getDatabaseConfigurations().get("swapper_test").getDataSources().get("foo_db");
+        StorageUnitConfiguration actual = new YamlProxyDataSourceConfigurationSwapper().swapToStorageUnitConfiguration(yamlConfig);
+        assertThat(actual.getDataSourcePoolProperties().getAllStandardProperties().get("url"), is("jdbc:h2:mem:foo_db;DB_CLOSE_DELAY=-1"));
+        assertThat(actual.getDataSourcePoolProperties().getAllStandardProperties().get("maxPoolSize"), is(5));
     }
 }


### PR DESCRIPTION

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add StorageUnitConfiguration to encapsulate DataSourcePoolProperties

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
