### PR TITLE
Fix openGauss LIMIT offset, row-count parameter marker order (#34961)

### DIFF
--- a/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -1544,8 +1544,8 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementParser
     private LimitSegment createLimitSegmentWhenRowCountOrOffsetAbsent(final SelectLimitContext ctx) {
         if (null != ctx.limitClause()) {
             if (null != ctx.limitClause().selectOffsetValue()) {
-                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());
                 LimitValueSegment offset = (LimitValueSegment) visit(ctx.limitClause().selectOffsetValue());
+                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());
                 return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, limit);
             }
             if (null != ctx.limitClause().selectFetchValue()) {

--- a/parser/sql/engine/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitorTest.java
+++ b/parser/sql/engine/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitorTest.java
@@ -23,6 +23,8 @@ import org.apache.shardingsphere.sql.parser.engine.api.SQLStatementVisitorEngine
 import org.apache.shardingsphere.sql.parser.engine.core.ParseASTNode;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.LimitSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.ParameterMarkerLimitValueSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.FunctionTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
@@ -63,6 +65,16 @@ class OpenGaussStatementVisitorTest {
         assertThat(functionTableSegment.getAliasSegment().get().getIdentifier().getValue(), is("s"));
         Collection<String> actualColumns = functionTableSegment.getColumns().stream().map(each -> each.getIdentifier().getValue()).collect(Collectors.toList());
         assertThat(actualColumns, contains("r"));
+    }
+    
+    @Test
+    void assertVisitLimitWithOffsetAndRowCountParameterMarkers() {
+        SelectStatement statement = parseSelectStatement("SELECT * FROM t ORDER BY id LIMIT ?, ?");
+        LimitSegment limit = statement.getLimit().get();
+        ParameterMarkerLimitValueSegment offset = (ParameterMarkerLimitValueSegment) limit.getOffset().get();
+        ParameterMarkerLimitValueSegment rowCount = (ParameterMarkerLimitValueSegment) limit.getRowCount().get();
+        assertThat(offset.getParameterIndex(), is(0));
+        assertThat(rowCount.getParameterIndex(), is(1));
     }
     
     private SelectStatement parseSelectStatement(final String sql) {


### PR DESCRIPTION
### What
Fixes the openGauss `LIMIT ?, ?` parameter marker order reported in #34961.

### Root cause
`OpenGaussStatementVisitor.createLimitSegmentWhenRowCountOrOffsetAbsent` visited `selectLimitValue` (row-count) **before** `selectOffsetValue` (offset). Parameter marker indices are assigned in visit order (`visitParameterMarker` returns `parameterMarkerSegments.size()` at visit time), so for the MySQL-style `LIMIT offset, row-count` the lexical first `?` (offset) was assigned index 1 and the second `?` (row-count) index 0 — reversed. For example `setInt(1, 2)` (offset) / `setInt(2, 1)` (count) produced "return 2 rows from offset 1" instead of "skip 2, return 1".

### Fix
Visit the offset before the row-count so marker indices follow lexical order. This matches the reference implementation in `DorisStatementVisitor.visitLimitClause`. Only the visit order of two adjacent lines is swapped; the `LimitSegment` construction is unchanged.

### Tests
Added `OpenGaussStatementVisitorTest.assertVisitLimitWithOffsetAndRowCountParameterMarkers`: parses `SELECT * FROM t ORDER BY id LIMIT ?, ?` and asserts `offset.parameterIndex == 0`, `rowCount.parameterIndex == 1`. Fails before the change (offset=1, rowCount=0), passes after.

### Verification
- `./mvnw -pl parser/sql/engine/dialect/opengauss -am install -DskipTests` — BUILD SUCCESS.
- `./mvnw -pl parser/sql/engine/dialect/opengauss test` — all tests green.
- Style gates (Spotless / Checkstyle / PMD / SpotBugs) pass on the changed module.

### Credit
Thanks to @daguimu for the original diagnosis in #38647 (closed only for staleness/style), and to @terrymanu for confirming the fix direction. This is a fresh, rebased PR with the style gates satisfied.

Fixes #34961
