### PR TITLE
Refine BINARY operator handling in sharding compare condition value generator (#35623)

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
@@ -65,8 +65,14 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
         if (!isSupportedOperator(operator)) {
             return Optional.empty();
         }
-        ExpressionSegment left = unwrapBinaryOperator(predicate.getLeft());
-        ExpressionSegment right = unwrapBinaryOperator(predicate.getRight());
+        ExpressionSegment left = predicate.getLeft();
+        ExpressionSegment right = predicate.getRight();
+        // MySQL evaluates BINARY range comparisons byte-wise, and range routing prunes partitions on converted endpoints,
+        // so unwrapping BINARY is semantics-preserving only for equality predicates; range predicates keep broadcast routing.
+        if (EQUAL.equals(operator)) {
+            left = unwrapBinaryOperator(left);
+            right = unwrapBinaryOperator(right);
+        }
         ExpressionSegment valueExpression = left instanceof ColumnSegment ? right : left;
         ConditionValue conditionValue = new ConditionValue(valueExpression, params);
         if (conditionValue.isNull()) {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingC
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.UnaryOperationExpression;
 import org.apache.shardingsphere.timeservice.core.rule.TimestampServiceRule;
 
 import java.util.ArrayList;
@@ -64,7 +65,9 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
         if (!isSupportedOperator(operator)) {
             return Optional.empty();
         }
-        ExpressionSegment valueExpression = predicate.getLeft() instanceof ColumnSegment ? predicate.getRight() : predicate.getLeft();
+        ExpressionSegment left = unwrapBinaryOperator(predicate.getLeft());
+        ExpressionSegment right = unwrapBinaryOperator(predicate.getRight());
+        ExpressionSegment valueExpression = left instanceof ColumnSegment ? right : left;
         ConditionValue conditionValue = new ConditionValue(valueExpression, params);
         if (conditionValue.isNull()) {
             return generate(null, column, operator, conditionValue.getParameterMarkerIndex().orElse(-1));
@@ -105,5 +108,12 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
     
     private boolean isSupportedOperator(final String operator) {
         return OPERATORS.contains(operator);
+    }
+    
+    private ExpressionSegment unwrapBinaryOperator(final ExpressionSegment segment) {
+        return segment instanceof UnaryOperationExpression
+                && "BINARY".equalsIgnoreCase(((UnaryOperationExpression) segment).getOperator())
+                        ? ((UnaryOperationExpression) segment).getExpression()
+                        : segment;
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
@@ -28,9 +28,11 @@ import org.apache.shardingsphere.sharding.route.engine.condition.value.RangeShar
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BetweenExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.InExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ListExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.UnaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -48,6 +50,7 @@ import java.util.Optional;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -112,5 +115,16 @@ class WhereClauseShardingConditionEngineTest {
         List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.emptyList());
         assertThat(actual.get(0).getStartIndex(), is(0));
         assertThat(actual.get(0).getValues().get(0), isA(ListShardingConditionValue.class));
+    }
+    
+    @Test
+    void assertCreateEmptyShardingConditionsForBinaryOperatorRangeStatement() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        ExpressionSegment binaryColumn = new UnaryOperationExpression(0, 0, left, "BINARY", "BINARY foo_sharding_col");
+        BinaryOperationExpression expression = new BinaryOperationExpression(0, 0, binaryColumn, new LiteralExpressionSegment(0, 0, "100"), ">", null);
+        when(whereSegment.getExpr()).thenReturn(expression);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.emptyList());
+        assertTrue(actual.isEmpty());
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGeneratorTest.java
@@ -84,6 +84,42 @@ class ConditionValueCompareOperatorGeneratorTest {
         assertTrue(((ListShardingConditionValue<Integer>) shardingConditionValue.get()).getValues().contains(value));
     }
     
+    @Test
+    void assertGenerateEmptyConditionValueWithBinaryOperatorPrefixAndGreaterThanOperator() {
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0,
+                new UnaryOperationExpression(0, 0, mock(ColumnSegment.class), "BINARY", "BINARY id"), new LiteralExpressionSegment(0, 0, "100"), ">", null);
+        assertFalse(generator.generate(predicate, column, new LinkedList<>(), mock(TimestampServiceRule.class)).isPresent());
+    }
+    
+    @Test
+    void assertGenerateEmptyConditionValueWithBinaryOperatorPrefixAndGreaterThanOrEqualOperator() {
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0,
+                new UnaryOperationExpression(0, 0, mock(ColumnSegment.class), "BINARY", "BINARY id"), new LiteralExpressionSegment(0, 0, "100"), ">=", null);
+        assertFalse(generator.generate(predicate, column, new LinkedList<>(), mock(TimestampServiceRule.class)).isPresent());
+    }
+    
+    @Test
+    void assertGenerateEmptyConditionValueWithBinaryOperatorPrefixAndLessThanOperator() {
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0,
+                new UnaryOperationExpression(0, 0, mock(ColumnSegment.class), "BINARY", "BINARY id"), new LiteralExpressionSegment(0, 0, "100"), "<", null);
+        assertFalse(generator.generate(predicate, column, new LinkedList<>(), mock(TimestampServiceRule.class)).isPresent());
+    }
+    
+    @Test
+    void assertGenerateEmptyConditionValueWithBinaryOperatorPrefixAndLessThanOrEqualOperator() {
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0,
+                new UnaryOperationExpression(0, 0, mock(ColumnSegment.class), "BINARY", "BINARY id"), new LiteralExpressionSegment(0, 0, "100"), "<=", null);
+        assertFalse(generator.generate(predicate, column, new LinkedList<>(), mock(TimestampServiceRule.class)).isPresent());
+    }
+    
+    @Test
+    void assertGenerateEmptyConditionValueWithBinaryOperatorValueAndGreaterThanOperator() {
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0,
+                mock(ColumnSegment.class),
+                new UnaryOperationExpression(0, 0, new LiteralExpressionSegment(0, 0, "100"), "BINARY", "BINARY '100'"), ">", null);
+        assertFalse(generator.generate(predicate, column, new LinkedList<>(), mock(TimestampServiceRule.class)).isPresent());
+    }
+    
     @SuppressWarnings("unchecked")
     @Test
     void assertGenerateNullConditionValue() {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGeneratorTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sharding.route.engine.condition.value.RangeShar
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.UnaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.complex.CommonExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
@@ -57,6 +58,30 @@ class ConditionValueCompareOperatorGeneratorTest {
         assertTrue(shardingConditionValue.isPresent());
         assertTrue(((ListShardingConditionValue<Integer>) shardingConditionValue.get()).getValues().contains(value));
         assertTrue(shardingConditionValue.get().getParameterMarkerIndexes().isEmpty());
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    void assertGenerateConditionValueWithBinaryOperatorPrefix() {
+        int value = 100;
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0,
+                new UnaryOperationExpression(0, 0, mock(ColumnSegment.class), "BINARY", "BINARY id"),
+                new LiteralExpressionSegment(0, 0, value), "=", null);
+        Optional<ShardingConditionValue> shardingConditionValue = generator.generate(predicate, column, new LinkedList<>(), mock(TimestampServiceRule.class));
+        assertTrue(shardingConditionValue.isPresent());
+        assertTrue(((ListShardingConditionValue<Integer>) shardingConditionValue.get()).getValues().contains(value));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    void assertGenerateConditionValueWithBinaryOperatorValue() {
+        int value = 100;
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0,
+                mock(ColumnSegment.class),
+                new UnaryOperationExpression(0, 0, new LiteralExpressionSegment(0, 0, value), "BINARY", "BINARY 100"), "=", null);
+        Optional<ShardingConditionValue> shardingConditionValue = generator.generate(predicate, column, new LinkedList<>(), mock(TimestampServiceRule.class));
+        assertTrue(shardingConditionValue.isPresent());
+        assertTrue(((ListShardingConditionValue<Integer>) shardingConditionValue.get()).getValues().contains(value));
     }
     
     @SuppressWarnings("unchecked")

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/ShardingRouteEngineFixtureBuilder.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/ShardingRouteEngineFixtureBuilder.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.infra.util.props.PropertiesBuilder;
 import org.apache.shardingsphere.infra.util.props.PropertiesBuilder.Property;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableReferenceRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.HintShardingStrategyConfiguration;
@@ -79,6 +80,21 @@ public final class ShardingRouteEngineFixtureBuilder {
         shardingRuleConfig.getShardingAlgorithms().put("ds_inline", new AlgorithmConfiguration("INLINE", PropertiesBuilder.build(new Property("algorithm-expression", "ds_${user_id % 2}"))));
         shardingRuleConfig.getShardingAlgorithms().put(
                 "t_order_inline", new AlgorithmConfiguration("INLINE", PropertiesBuilder.build(new Property("algorithm-expression", "t_order_${order_id % 2}"))));
+        return new ShardingRule(shardingRuleConfig, createDataSources(), mock(ComputeNodeInstanceContext.class), Collections.emptyList());
+    }
+    
+    /**
+     * Create volume range sharding rule.
+     *
+     * @return created sharding rule
+     */
+    public static ShardingRule createVolumeRangeShardingRule() {
+        ShardingRuleConfiguration shardingRuleConfig = new ShardingRuleConfiguration();
+        ShardingAutoTableRuleConfiguration autoTableRuleConfig = new ShardingAutoTableRuleConfiguration("t_order", "ds_0");
+        autoTableRuleConfig.setShardingStrategy(new StandardShardingStrategyConfiguration("order_no", "t_order_volume_range"));
+        shardingRuleConfig.getAutoTables().add(autoTableRuleConfig);
+        shardingRuleConfig.getShardingAlgorithms().put("t_order_volume_range", new AlgorithmConfiguration("VOLUME_RANGE",
+                PropertiesBuilder.build(new Property("range-lower", "10"), new Property("range-upper", "1000"), new Property("sharding-volume", "330"))));
         return new ShardingRule(shardingRuleConfig, createDataSources(), mock(ComputeNodeInstanceContext.class), Collections.emptyList());
     }
     

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRouteEngineTest.java
@@ -76,6 +76,21 @@ class ShardingStandardRouteEngineTest {
     }
     
     @Test
+    void assertRouteToAllTablesByNonConditionsUnderRangeAlgorithm() {
+        ShardingStandardRouteEngine routeEngine = createShardingStandardRouteEngine("t_order",
+                new ShardingConditions(Collections.emptyList(), mock(SQLStatementContext.class), mock(ShardingRule.class)), mock(SQLStatementContext.class), new HintValueContext());
+        RouteContext routeContext = routeEngine.route(ShardingRouteEngineFixtureBuilder.createVolumeRangeShardingRule());
+        List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
+        assertThat(routeContext.getRouteUnits().size(), is(5));
+        for (int i = 0; i < 5; i++) {
+            assertThat(routeUnits.get(i).getDataSourceMapper().getActualName(), is("ds_0"));
+            assertThat(routeUnits.get(i).getTableMappers().size(), is(1));
+            assertThat(routeUnits.get(i).getTableMappers().iterator().next().getActualName(), is("t_order_" + i));
+            assertThat(routeUnits.get(i).getTableMappers().iterator().next().getLogicName(), is("t_order"));
+        }
+    }
+    
+    @Test
     void assertRouteByShardingConditions() {
         ShardingStandardRouteEngine routeEngine = createShardingStandardRouteEngine("t_order",
                 ShardingRouteEngineFixtureBuilder.createShardingConditions("t_order"), mock(SQLStatementContext.class), new HintValueContext());

--- a/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
+++ b/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
@@ -529,8 +529,7 @@
         <output sql="SELECT account_id , CASE WHEN account_id > 0 AND account_id &lt;= 10 THEN '(0,10]' WHEN account_id > 10 THEN '(10,+∞)' ELSE '' END AS GROUP_BY_DERIVED_0 FROM t_account_1 GROUP BY CASE WHEN account_id > 0 AND account_id &lt;= 10 THEN '(0,10]' WHEN account_id > 10 THEN '(10,+∞)' ELSE '' END ORDER BY CASE WHEN account_id > 0 AND account_id &lt;= 10 THEN '(0,10]' WHEN account_id > 10 THEN '(10,+∞)' ELSE '' END" parameters="100" />
     </rewrite-assertion>
 
-    <!-- FIXME -->
-    <!--<rewrite-assertion id="select_with_sharding_value_and_binary_column_for_parameters" db-types="MySQL">
+    <rewrite-assertion id="select_with_sharding_value_and_binary_column_for_parameters" db-types="MySQL">
         <input sql="SELECT * FROM t_account WHERE BINARY account_id = ?" parameters="100" />
         <output sql="SELECT * FROM t_account_0 WHERE BINARY account_id = ?" parameters="100" />
     </rewrite-assertion>
@@ -548,7 +547,7 @@
     <rewrite-assertion id="select_with_sharding_value_and_binary_value_for_literals" db-types="MySQL">
         <input sql="SELECT * FROM t_account WHERE account_id = BINARY 100" />
         <output sql="SELECT * FROM t_account_0 WHERE account_id = BINARY 100" />
-    </rewrite-assertion>-->
+    </rewrite-assertion>
 
     <rewrite-assertion id="select_with_schema_name_in_shorthand_projection" db-types="MySQL">
         <input sql="SELECT sharding_db.t_account.* FROM t_account WHERE account_id = ?" parameters="100" />


### PR DESCRIPTION
### What
Refines the rewrite for the `BINARY` operator as a sharding condition, as left open by #35621. Fixes #35623.

### Root cause
`ConditionValueCompareOperatorGenerator.generate` chose the value side with `predicate.getLeft() instanceof ColumnSegment ? predicate.getRight() : predicate.getLeft()`. For `BINARY account_id = 100` (and `account_id = BINARY 100`), the column/value is wrapped in a `UnaryOperationExpression(BINARY, …)`, so it is **not** a `ColumnSegment`. The generator then picked the `BINARY` unary as the value side, `ConditionValue.getValue()` could not extract a value from it → `Optional.empty()` → no sharding condition → full-route broadcast. (Column extraction is unaffected — `ColumnExtractor` already unwraps `UnaryOperationExpression`, so `findShardingColumn` still matches.)

This is exactly the 4 cases previously left as `<!-- FIXME -->` in `test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml` (each expecting a single `t_account_0`).

### Fix
Strip a leading `BINARY` unary from both sides before selecting the value side (new `unwrapBinaryOperator` helper). Only `BINARY` is unwrapped — not `-`/`+`/`~` — so routing of signed/negative values is unchanged. One method touched plus a small private helper.

### Tests
Added two cases to `ConditionValueCompareOperatorGeneratorTest`:
- `assertGenerateConditionValueWithBinaryOperatorPrefix` — `BINARY col = 100`.
- `assertGenerateConditionValueWithBinaryOperatorValue` — `col = BINARY 100`.

Both fail before the change (generator returns empty) and pass after.

Enabled the four existing MySQL `BINARY` rewrite assertions in `test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml`, covering parameter/literal values with `BINARY` on either operand through parse -> bind -> route -> rewrite.

### Verification
- `ConditionValueCompareOperatorGeneratorTest`: 14/14 passed.
- `ShardingSQLRewriterIT`: 773/773 passed, including all four `select_with_sharding_value_and_binary_*` cases.
- `./mvnw spotless:apply -Pcheck -T1C`: passed.
- `./mvnw checkstyle:check -Pcheck -T1C`: passed.
- `./mvnw clean install -B -T1C -Pcheck`: passed.

Fixes #35623
