### PR TITLE
Correct version persistence logic for standalone mode

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/config/database/DatabaseRulePersistService.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/config/database/DatabaseRulePersistService.java
@@ -114,7 +114,7 @@ public final class DatabaseRulePersistService {
     
     private Collection<MetaDataVersion> persistTuples(final Collection<RuleNodeTuple> tuples) {
         return tuples.stream().map(each -> new MetaDataVersion(each.getNodePath(),
-                Math.max(MetaDataVersion.INIT_VERSION, versionPersistService.persist(new VersionNodePath(each.getNodePath()), each.getContent()) - 1))).collect(Collectors.toList());
+                versionPersistService.persist(new VersionNodePath(each.getNodePath()), each.getContent()))).collect(Collectors.toList());
     }
     
     /**

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/config/database/DatabaseRulePersistServiceTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/config/database/DatabaseRulePersistServiceTest.java
@@ -82,7 +82,7 @@ class DatabaseRulePersistServiceTest {
         when(repository.getChildrenKeys("/metadata/foo_db/rules/fixture/unique/versions")).thenReturn(Collections.singletonList("10"));
         Collection<MetaDataVersion> actual = persistService.persist("foo_db", Collections.singleton(new MockedRuleConfiguration("test")));
         assertThat(actual.size(), is(1));
-        assertThat(actual.iterator().next().getActiveVersion(), is(10));
+        assertThat(actual.iterator().next().getActiveVersion(), is(11));
     }
     
     @Test


### PR DESCRIPTION

Changes proposed in this pull request:
  - Correct version persistence logic for standalone mode

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
