### PR TITLE
Replace databaseType with identifierContext for column name derivation

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptTokenGenerateBuilder.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptTokenGenerateBuilder.java
@@ -39,6 +39,7 @@ import org.apache.shardingsphere.encrypt.rewrite.token.generator.select.EncryptI
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rewrite.context.SQLRewriteContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.SQLTokenGenerator;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.builder.SQLTokenGeneratorBuilder;
@@ -63,13 +64,14 @@ public final class EncryptTokenGenerateBuilder implements SQLTokenGeneratorBuild
     @Override
     public Collection<SQLTokenGenerator> getSQLTokenGenerators() {
         Collection<SQLTokenGenerator> result = new LinkedList<>();
-        addSQLTokenGenerator(result, new EncryptSelectProjectionTokenGenerator(rule));
-        addSQLTokenGenerator(result, new EncryptInsertSelectProjectionTokenGenerator(rule));
         ShardingSphereDatabase database = sqlRewriteContext.getDatabase();
+        DatabaseIdentifierContext identifierContext = database.getIdentifierContext();
+        addSQLTokenGenerator(result, new EncryptSelectProjectionTokenGenerator(rule, identifierContext));
+        addSQLTokenGenerator(result, new EncryptInsertSelectProjectionTokenGenerator(rule, identifierContext));
         addSQLTokenGenerator(result, new EncryptInsertAssignmentTokenGenerator(rule, database));
         addSQLTokenGenerator(result, new EncryptUpdateAssignmentTokenGenerator(rule, database));
-        addSQLTokenGenerator(result, new EncryptPredicateColumnTokenGenerator(rule));
-        addSQLTokenGenerator(result, new EncryptInsertPredicateColumnTokenGenerator(rule));
+        addSQLTokenGenerator(result, new EncryptPredicateColumnTokenGenerator(rule, identifierContext));
+        addSQLTokenGenerator(result, new EncryptInsertPredicateColumnTokenGenerator(rule, identifierContext));
         addSQLTokenGenerator(result, new EncryptPredicateValueTokenGenerator(rule, database, encryptConditions));
         addSQLTokenGenerator(result, new EncryptInsertPredicateValueTokenGenerator(rule, database, encryptConditions));
         addSQLTokenGenerator(result, new EncryptInsertValuesTokenGenerator(rule, database, sqlRewriteContext));
@@ -77,7 +79,7 @@ public final class EncryptTokenGenerateBuilder implements SQLTokenGeneratorBuild
         addSQLTokenGenerator(result, new EncryptInsertCipherNameTokenGenerator(rule));
         addSQLTokenGenerator(result, new EncryptInsertDerivedColumnsTokenGenerator(rule));
         addSQLTokenGenerator(result, new EncryptInsertOnUpdateTokenGenerator(rule, database));
-        addSQLTokenGenerator(result, new EncryptGroupByItemTokenGenerator(rule));
+        addSQLTokenGenerator(result, new EncryptGroupByItemTokenGenerator(rule, identifierContext));
         addSQLTokenGenerator(result, new EncryptIndexColumnTokenGenerator(rule));
         addSQLTokenGenerator(result, new EncryptCreateTableTokenGenerator(rule));
         addSQLTokenGenerator(result, new EncryptAlterTableTokenGenerator(rule));

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGenerator.java
@@ -106,7 +106,7 @@ public final class EncryptAssignmentTokenGenerator {
     
     private String getColumnName(final ColumnSegment columnSegment, final EncryptDerivedColumnSuffix derivedColumnSuffix, final String actualColumnName) {
         return TableSourceType.TEMPORARY_TABLE == columnSegment.getColumnBoundInfo().getTableSourceType()
-                ? derivedColumnSuffix.getDerivedColumnName(columnSegment.getIdentifier().getValue(), databaseType)
+                ? derivedColumnSuffix.getDerivedColumnName(columnSegment.getIdentifier().getValue(), database.getIdentifierContext())
                 : actualColumnName;
     }
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptInsertPredicateColumnTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptInsertPredicateColumnTokenGenerator.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.InsertStatementContext;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.CollectionSQLTokenGenerator;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 
@@ -38,6 +39,8 @@ public final class EncryptInsertPredicateColumnTokenGenerator implements Collect
     
     private final EncryptRule rule;
     
+    private final DatabaseIdentifierContext identifierContext;
+    
     @Override
     public boolean isGenerateSQLToken(final SQLStatementContext sqlStatementContext) {
         return sqlStatementContext instanceof InsertStatementContext && null != ((InsertStatementContext) sqlStatementContext).getInsertSelectContext()
@@ -46,7 +49,7 @@ public final class EncryptInsertPredicateColumnTokenGenerator implements Collect
     
     @Override
     public Collection<SQLToken> generateSQLTokens(final InsertStatementContext sqlStatementContext) {
-        EncryptPredicateColumnTokenGenerator generator = new EncryptPredicateColumnTokenGenerator(rule);
+        EncryptPredicateColumnTokenGenerator generator = new EncryptPredicateColumnTokenGenerator(rule, identifierContext);
         return generator.generateSQLTokens(sqlStatementContext.getInsertSelectContext().getSelectStatementContext());
     }
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGenerator.java
@@ -37,6 +37,7 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.CollectionSQLTokenGenerator;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.generic.SubstitutableColumnNameToken;
@@ -65,6 +66,8 @@ import java.util.Optional;
 public final class EncryptPredicateColumnTokenGenerator implements CollectionSQLTokenGenerator<SQLStatementContext> {
     
     private final EncryptRule rule;
+    
+    private final DatabaseIdentifierContext identifierContext;
     
     @Override
     public boolean isGenerateSQLToken(final SQLStatementContext sqlStatementContext) {
@@ -137,7 +140,7 @@ public final class EncryptPredicateColumnTokenGenerator implements CollectionSQL
     private Collection<Projection> createColumnProjections(final String actualColumnName, final ColumnSegment columnSegment, final EncryptDerivedColumnSuffix derivedColumnSuffix,
                                                            final DatabaseType databaseType) {
         String columnName = TableSourceType.TEMPORARY_TABLE == columnSegment.getColumnBoundInfo().getTableSourceType()
-                ? derivedColumnSuffix.getDerivedColumnName(columnSegment.getIdentifier().getValue(), databaseType)
+                ? derivedColumnSuffix.getDerivedColumnName(columnSegment.getIdentifier().getValue(), identifierContext)
                 : actualColumnName;
         QuoteCharacter quoteCharacter = TableSourceType.TEMPORARY_TABLE == columnSegment.getColumnBoundInfo().getTableSourceType()
                 ? columnSegment.getIdentifier().getQuoteCharacter()

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptInsertSelectProjectionTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptInsertSelectProjectionTokenGenerator.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.InsertStatementContext;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.CollectionSQLTokenGenerator;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.aware.PreviousSQLTokensAware;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
@@ -42,6 +43,8 @@ public final class EncryptInsertSelectProjectionTokenGenerator implements Collec
     
     private List<SQLToken> previousSQLTokens;
     
+    private final DatabaseIdentifierContext identifierContext;
+    
     @Override
     public boolean isGenerateSQLToken(final SQLStatementContext sqlStatementContext) {
         return sqlStatementContext instanceof InsertStatementContext && null != ((InsertStatementContext) sqlStatementContext).getInsertSelectContext()
@@ -50,7 +53,7 @@ public final class EncryptInsertSelectProjectionTokenGenerator implements Collec
     
     @Override
     public Collection<SQLToken> generateSQLTokens(final InsertStatementContext sqlStatementContext) {
-        return new EncryptProjectionTokenGenerator(previousSQLTokens, sqlStatementContext.getSqlStatement().getDatabaseType(), rule)
+        return new EncryptProjectionTokenGenerator(previousSQLTokens, sqlStatementContext.getSqlStatement().getDatabaseType(), rule, identifierContext)
                 .generateSQLTokens(sqlStatementContext.getInsertSelectContext().getSelectStatementContext());
     }
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGenerator.java
@@ -38,6 +38,7 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.generic.SubstitutableColumnNameToken;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.SubqueryType;
@@ -82,10 +83,14 @@ public final class EncryptProjectionTokenGenerator {
     
     private final DialectDatabaseMetaData dialectDatabaseMetaData;
     
-    public EncryptProjectionTokenGenerator(final List<SQLToken> previousSQLTokens, final DatabaseType databaseType, final EncryptRule rule) {
+    private final DatabaseIdentifierContext identifierContext;
+    
+    public EncryptProjectionTokenGenerator(final List<SQLToken> previousSQLTokens, final DatabaseType databaseType, final EncryptRule rule,
+                                           final DatabaseIdentifierContext identifierContext) {
         this.previousSQLTokens = previousSQLTokens;
         this.databaseType = databaseType;
         this.rule = rule;
+        this.identifierContext = identifierContext;
         dialectDatabaseMetaData = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData();
     }
     
@@ -297,7 +302,7 @@ public final class EncryptProjectionTokenGenerator {
     private String getEncryptColumnName(final ColumnProjection columnProjection, final EncryptColumn encryptColumn) {
         IdentifierValue columnName = columnProjection.getName();
         return TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
-                ? EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName(columnName.getValue(), databaseType)
+                ? EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName(columnName.getValue(), identifierContext)
                 : encryptColumn.getCipher().getName();
     }
     
@@ -308,7 +313,7 @@ public final class EncryptProjectionTokenGenerator {
     private Collection<Projection> generateCipherProjectionsInTableSegmentSubquery(final EncryptColumn encryptColumn, final ColumnProjection columnProjection) {
         Collection<Projection> result = new LinkedList<>();
         IdentifierValue cipherColumnName = TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
-                ? new IdentifierValue(EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName(columnProjection.getName().getValue(), databaseType),
+                ? new IdentifierValue(EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName(columnProjection.getName().getValue(), identifierContext),
                         columnProjection.getName().getQuoteCharacter())
                 : new IdentifierValue(encryptColumn.getCipher().getName(), dialectDatabaseMetaData.getQuoteCharacter());
         IdentifierValue columnAlias = columnProjection.getAlias().orElse(columnProjection.getName());
@@ -325,15 +330,16 @@ public final class EncryptProjectionTokenGenerator {
     
     private IdentifierValue getEncryptColumnAliasInTableSegmentSubquery(final ColumnProjection columnProjection, final IdentifierValue columnAlias, final EncryptDerivedColumnSuffix suffix) {
         if (TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()) {
-            return columnProjection.getAlias().map(optional -> new IdentifierValue(suffix.getDerivedColumnName(optional.getValue(), databaseType), optional.getQuoteCharacter())).orElse(null);
+            return columnProjection.getAlias()
+                    .map(optional -> new IdentifierValue(suffix.getDerivedColumnName(optional.getValue(), identifierContext), optional.getQuoteCharacter())).orElse(null);
         }
-        return new IdentifierValue(suffix.getDerivedColumnName(columnAlias.getValue(), databaseType), columnAlias.getQuoteCharacter());
+        return new IdentifierValue(suffix.getDerivedColumnName(columnAlias.getValue(), identifierContext), columnAlias.getQuoteCharacter());
     }
     
     private void addAssistedQueryColumn(final ColumnProjection columnProjection, final AssistedQueryColumnItem assistedQueryColumnItem, final IdentifierValue columnAlias,
                                         final Collection<Projection> result) {
         IdentifierValue assistedQueryName = TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
-                ? new IdentifierValue(EncryptDerivedColumnSuffix.ASSISTED_QUERY.getDerivedColumnName(columnProjection.getName().getValue(), databaseType),
+                ? new IdentifierValue(EncryptDerivedColumnSuffix.ASSISTED_QUERY.getDerivedColumnName(columnProjection.getName().getValue(), identifierContext),
                         columnProjection.getName().getQuoteCharacter())
                 : new IdentifierValue(assistedQueryColumnItem.getName(), columnProjection.getName().getQuoteCharacter());
         IdentifierValue assistedQueryAlias = getEncryptColumnAliasInTableSegmentSubquery(columnProjection, columnAlias, EncryptDerivedColumnSuffix.ASSISTED_QUERY);
@@ -343,7 +349,7 @@ public final class EncryptProjectionTokenGenerator {
     
     private void addLikeQueryColumn(final ColumnProjection columnProjection, final LikeQueryColumnItem likeQueryColumnItem, final IdentifierValue columnAlias, final Collection<Projection> result) {
         IdentifierValue likeQueryName = TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
-                ? new IdentifierValue(EncryptDerivedColumnSuffix.LIKE_QUERY.getDerivedColumnName(columnProjection.getName().getValue(), databaseType),
+                ? new IdentifierValue(EncryptDerivedColumnSuffix.LIKE_QUERY.getDerivedColumnName(columnProjection.getName().getValue(), identifierContext),
                         columnProjection.getName().getQuoteCharacter())
                 : new IdentifierValue(likeQueryColumnItem.getName(), columnProjection.getName().getQuoteCharacter());
         IdentifierValue likeQueryAlias = getEncryptColumnAliasInTableSegmentSubquery(columnProjection, columnAlias, EncryptDerivedColumnSuffix.LIKE_QUERY);
@@ -368,7 +374,7 @@ public final class EncryptProjectionTokenGenerator {
     private Optional<String> getDerivedColumnName(final EncryptColumn encryptColumn, final ColumnProjection columnProjection) {
         if (TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()) {
             EncryptDerivedColumnSuffix derivedColumnSuffix = encryptColumn.getAssistedQuery().map(optional -> EncryptDerivedColumnSuffix.ASSISTED_QUERY).orElse(EncryptDerivedColumnSuffix.CIPHER);
-            return Optional.of(derivedColumnSuffix.getDerivedColumnName(columnProjection.getName().getValue(), databaseType));
+            return Optional.of(derivedColumnSuffix.getDerivedColumnName(columnProjection.getName().getValue(), identifierContext));
         }
         return Optional.empty();
     }
@@ -378,7 +384,7 @@ public final class EncryptProjectionTokenGenerator {
     }
     
     private String getDerivedColumnName(final ColumnProjection columnProjection, final EncryptDerivedColumnSuffix suffix) {
-        return null == suffix ? columnProjection.getName().getValue() : suffix.getDerivedColumnName(columnProjection.getName().getValue(), databaseType);
+        return null == suffix ? columnProjection.getName().getValue() : suffix.getDerivedColumnName(columnProjection.getName().getValue(), identifierContext);
     }
     
     private Collection<Projection> generateProjectionsInInsertSelectSubquery(final EncryptColumn encryptColumn, final ColumnProjection columnProjection) {

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptSelectProjectionTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptSelectProjectionTokenGenerator.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementCont
 import org.apache.shardingsphere.infra.binder.context.statement.type.ddl.AlterViewStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.ddl.CreateViewStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.CollectionSQLTokenGenerator;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.aware.PreviousSQLTokensAware;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
@@ -46,6 +47,8 @@ public final class EncryptSelectProjectionTokenGenerator implements CollectionSQ
     
     private List<SQLToken> previousSQLTokens;
     
+    private final DatabaseIdentifierContext identifierContext;
+    
     @Override
     public boolean isGenerateSQLToken(final SQLStatementContext sqlStatementContext) {
         return extractSelectStatementContext(sqlStatementContext).map(each -> !each.getTablesContext().getSimpleTables().isEmpty()).orElse(false);
@@ -54,7 +57,7 @@ public final class EncryptSelectProjectionTokenGenerator implements CollectionSQ
     @Override
     public Collection<SQLToken> generateSQLTokens(final SQLStatementContext sqlStatementContext) {
         return extractSelectStatementContext(sqlStatementContext)
-                .map(each -> new EncryptProjectionTokenGenerator(previousSQLTokens, each.getSqlStatement().getDatabaseType(), rule).generateSQLTokens(each))
+                .map(each -> new EncryptProjectionTokenGenerator(previousSQLTokens, each.getSqlStatement().getDatabaseType(), rule, identifierContext).generateSQLTokens(each))
                 .orElse(Collections.emptyList());
     }
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/select/EncryptGroupByItemTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/select/EncryptGroupByItemTokenGenerator.java
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.CollectionSQLTokenGenerator;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.generic.SubstitutableColumnNameToken;
@@ -55,6 +56,8 @@ import java.util.Optional;
 public final class EncryptGroupByItemTokenGenerator implements CollectionSQLTokenGenerator<SelectStatementContext> {
     
     private final EncryptRule rule;
+    
+    private final DatabaseIdentifierContext identifierContext;
     
     @Override
     public boolean isGenerateSQLToken(final SQLStatementContext sqlStatementContext) {
@@ -114,7 +117,7 @@ public final class EncryptGroupByItemTokenGenerator implements CollectionSQLToke
     private Collection<Projection> createColumnProjections(final String actualColumnName, final ColumnSegment columnSegment, final DatabaseType databaseType,
                                                            final EncryptDerivedColumnSuffix derivedColumnSuffix) {
         String columnName = TableSourceType.TEMPORARY_TABLE == columnSegment.getColumnBoundInfo().getTableSourceType()
-                ? derivedColumnSuffix.getDerivedColumnName(columnSegment.getIdentifier().getValue(), databaseType)
+                ? derivedColumnSuffix.getDerivedColumnName(columnSegment.getIdentifier().getValue(), identifierContext)
                 : actualColumnName;
         QuoteCharacter quoteCharacter = TableSourceType.TEMPORARY_TABLE == columnSegment.getColumnBoundInfo().getTableSourceType()
                 ? columnSegment.getIdentifier().getQuoteCharacter()

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/enums/EncryptDerivedColumnSuffixTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/enums/EncryptDerivedColumnSuffixTest.java
@@ -17,32 +17,18 @@
 
 package org.apache.shardingsphere.encrypt.enums;
 
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
-import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
+import org.junit.jupiter.api.Test;
 
-/**
- * Encrypt derived column suffix.
- */
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public enum EncryptDerivedColumnSuffix {
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class EncryptDerivedColumnSuffixTest {
     
-    CIPHER("_C"),
-    ASSISTED_QUERY("_A"),
-    LIKE_QUERY("_L");
-    
-    private final String suffix;
-    
-    /**
-     * Get derived column name.
-     *
-     * @param columnName column name
-     * @param identifierContext database identifier context
-     * @return derived column name
-     */
-    public String getDerivedColumnName(final String columnName, final DatabaseIdentifierContext identifierContext) {
-        return String.format("%s%s", columnName, identifierContext.normalizeStorage(IdentifierScope.COLUMN, new IdentifierValue(suffix)));
+    @Test
+    void assertGetDerivedColumnName() {
+        DatabaseIdentifierContext identifierContext = new DatabaseIdentifierContext(IdentifierCasePolicyFactory.newLowerCasePolicySet());
+        assertThat(EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName("foo_column", identifierContext), is("foo_column_c"));
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGeneratorTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.token.generator.predicate;
 
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.fixture.EncryptGeneratorFixtureBuilder;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.generic.SubstitutableColumnNameToken;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +37,8 @@ class EncryptPredicateColumnTokenGeneratorTest {
     
     @BeforeEach
     void setup() {
-        generator = new EncryptPredicateColumnTokenGenerator(EncryptGeneratorFixtureBuilder.createEncryptRule());
+        generator = new EncryptPredicateColumnTokenGenerator(
+                EncryptGeneratorFixtureBuilder.createEncryptRule(), new DatabaseIdentifierContext(IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet()));
     }
     
     @Test

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGeneratorTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.encrypt.rewrite.token.generator.projection;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.encrypt.enums.EncryptDerivedColumnSuffix;
@@ -32,7 +33,7 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
-import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.generic.SubstitutableColumnNameToken;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -70,12 +71,11 @@ class EncryptProjectionTokenGeneratorTest {
     
     private EncryptProjectionTokenGenerator generator;
     
+    private final DatabaseIdentifierContext identifierContext = new DatabaseIdentifierContext(IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet());
+    
     @BeforeEach
     void setup() {
-        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
-        when(database.getResourceMetaData().getStorageUnits()).thenReturn(Collections.emptyMap());
-        when(database.getRuleMetaData().getRules()).thenReturn(Collections.emptyList());
-        generator = new EncryptProjectionTokenGenerator(Collections.emptyList(), databaseType, mockEncryptRule());
+        generator = new EncryptProjectionTokenGenerator(Collections.emptyList(), databaseType, mockEncryptRule(), identifierContext);
     }
     
     private EncryptRule mockEncryptRule() {
@@ -167,7 +167,8 @@ class EncryptProjectionTokenGeneratorTest {
     
     @Test
     void assertGenerateSQLTokensWhenInsertSelectUsesActualColumnsForPhysicalTable() {
-        EncryptProjectionTokenGenerator actualGenerator = new EncryptProjectionTokenGenerator(Collections.emptyList(), databaseType, mockEncryptRule(createEncryptColumnWithDerivedColumns()));
+        EncryptProjectionTokenGenerator actualGenerator = new EncryptProjectionTokenGenerator(
+                Collections.emptyList(), databaseType, mockEncryptRule(createEncryptColumnWithDerivedColumns()), identifierContext);
         SelectStatementContext sqlStatementContext = mockInsertSelectStatementContext(TableSourceType.PHYSICAL_TABLE, QuoteCharacter.QUOTE);
         Collection<SQLToken> actual = actualGenerator.generateSQLTokens(sqlStatementContext);
         assertThat(actual.size(), is(1));
@@ -180,16 +181,17 @@ class EncryptProjectionTokenGeneratorTest {
     
     @Test
     void assertGenerateSQLTokensWhenInsertSelectUsesDerivedColumnsForTemporaryTable() {
-        EncryptProjectionTokenGenerator actualGenerator = new EncryptProjectionTokenGenerator(Collections.emptyList(), databaseType, mockEncryptRule(createEncryptColumnWithDerivedColumns()));
+        EncryptProjectionTokenGenerator actualGenerator = new EncryptProjectionTokenGenerator(
+                Collections.emptyList(), databaseType, mockEncryptRule(createEncryptColumnWithDerivedColumns()), identifierContext);
         SelectStatementContext sqlStatementContext = mockInsertSelectStatementContext(TableSourceType.TEMPORARY_TABLE, QuoteCharacter.BACK_QUOTE);
         Collection<SQLToken> actual = actualGenerator.generateSQLTokens(sqlStatementContext);
         assertThat(actual.size(), is(1));
         SubstitutableColumnNameToken actualToken = (SubstitutableColumnNameToken) actual.iterator().next();
         List<ColumnProjection> actualProjections = getColumnProjections(actualToken.getProjections());
         assertThat(getProjectionNames(actualProjections), is(Arrays.asList(
-                EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName("mobile", databaseType),
-                EncryptDerivedColumnSuffix.ASSISTED_QUERY.getDerivedColumnName("mobile", databaseType),
-                EncryptDerivedColumnSuffix.LIKE_QUERY.getDerivedColumnName("mobile", databaseType))));
+                EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName("mobile", identifierContext),
+                EncryptDerivedColumnSuffix.ASSISTED_QUERY.getDerivedColumnName("mobile", identifierContext),
+                EncryptDerivedColumnSuffix.LIKE_QUERY.getDerivedColumnName("mobile", identifierContext))));
         assertThat(getProjectionQuoteCharacters(actualProjections), is(Arrays.asList(QuoteCharacter.BACK_QUOTE, QuoteCharacter.BACK_QUOTE, QuoteCharacter.BACK_QUOTE)));
     }
     

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/select/EncryptGroupByItemTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/select/EncryptGroupByItemTokenGeneratorTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.encrypt.rewrite.token.generator.select;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.NullsOrderType;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
@@ -25,6 +26,7 @@ import org.apache.shardingsphere.encrypt.rule.table.EncryptTable;
 import org.apache.shardingsphere.infra.binder.context.segment.select.orderby.OrderByItem;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.OrderDirection;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
@@ -57,7 +59,8 @@ class EncryptGroupByItemTokenGeneratorTest {
     
     @BeforeEach
     void setup() {
-        generator = new EncryptGroupByItemTokenGenerator(mockEncryptRule());
+        generator = new EncryptGroupByItemTokenGenerator(
+                mockEncryptRule(), new DatabaseIdentifierContext(IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet()));
     }
     
     private EncryptRule mockEncryptRule() {


### PR DESCRIPTION

Changes proposed in this pull request:
  - Replace databaseType with identifierContext for column name derivation

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
