### PR TITLE
Enforce complete review-pr finding convergence

### DIFF
--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -3,8 +3,9 @@ name: review-pr
 description: >-
   Review Apache ShardingSphere pull requests and PR discussions from public evidence.
   Use for code-correctness or mergeability decisions, CI-focused review, root-cause and
-  regression analysis, copy-ready committer feedback, challenged findings, multi-round
-  review, and the repository completion loop's Local Candidate Preflight Mode.
+  regression analysis, complete consolidated findings, copy-ready committer feedback,
+  challenged findings, multi-round review, and the repository completion loop's Local
+  Candidate Preflight Mode.
 ---
 
 # Review PR
@@ -58,9 +59,11 @@ fact—not CI—as the incomplete reason.
 5. Treat every concern as a candidate until it passes the Finding Proof Gate.
 6. Do not turn uncertainty, inaccessible evidence, tool failure, skipped
    verification, or uninspected counter-evidence into a blocker.
-7. Consolidate findings by independent fix boundary. Do not publish draft
-   findings or drip-feed issues unless the user asks for status or early
-   high-risk blockers.
+7. In Formal Review and Local Candidate Preflight, do not select a verdict,
+   stop at the first blocker, or publish findings before the Completion Gate.
+   Consolidate findings by independent fix boundary and return the complete
+   current-head set once. Only an explicit request for status, narrow review, or
+   early high-risk blockers authorizes a partial result.
 8. Follow `AGENTS.md` for repository authority, command execution, local
    verification, sensitive data, and completion-loop rules.
 
@@ -104,32 +107,17 @@ Classify failed candidates as an incomplete-evidence gap, non-blocking
 observation, clarification question, pre-existing issue, or no issue. Do not
 publish non-blocking observations unless they materially help the user.
 
-## Decision Contract
+## Behavior Clusters and Risk Triage
 
-Choose the result in this order:
+Before deep review, group the scope into the smallest independently meaningful
+behavior changes. A behavior cluster may cross several files, and one file may
+belong to several clusters. Map every substantive changed file to at least one
+cluster; treat churn-only files explicitly rather than silently dropping them.
 
-1. If public evidence disproves the problem model, expected behavior, ownership,
-   protocol or SQL semantics, compatibility assumption, or solution direction,
-   use `Not Mergeable` with `Feedback Mode: Needs Discussion`.
-2. If at least one candidate passes the Finding Proof Gate, use `Not Mergeable`
-   with `Feedback Mode: Change Request`.
-3. If no blocker is confirmed but a public fact required by the selected focus
-   is unavailable, stale, inaccessible, or unattributable, use
-   `Review Incomplete`.
-4. Otherwise use `Mergeable` for the selected focus.
-
-`Mergeable` in Code Correctness Review means code-scope readiness only. Required
-pending CI prevents Mergeable in Mergeability Review. A relevant CI failure is
-a blocker when attributable to the PR and an incomplete gap when attribution is
-unclear.
-
-When a confirmed blocker and an additional evidence gap coexist, keep
-`Not Mergeable` and disclose the unreviewed scope under `Coverage and Limits`.
-`Review Incomplete` is not a substitute for a proven blocker.
-
-## Review Criteria
-
-Apply only criteria triggered by the changed behavior:
+For every cluster, identify its root cause, behavior owner, entry paths,
+callers or consumers, contracts, changed conditions or state transitions, and
+validation points. Then consider every risk axis and deepen only the triggered
+ones:
 
 - Root cause and linked-issue completeness.
 - Functional behavior, important boundaries, disabled paths, adjacent features,
@@ -144,7 +132,8 @@ Apply only criteria triggered by the changed behavior:
 - Dependencies, licenses, packaging, native metadata, generated resources, and
   distribution impact.
 
-Read only the triggered sections in
+This triage is mandatory even when no risk is ultimately found. Read only the
+triggered sections in
 [high-risk-review.md](references/high-risk-review.md). For SQL grammar,
 visitors, parser tests, syntax documentation, dialect behavior, or parser
 baselines, also read
@@ -154,35 +143,74 @@ baselines, also read
 
 1. Select output mode and review focus.
 2. Establish the authoritative latest-head scope and linked requirements.
-3. Model the root cause and map every required behavior to changed code and a
-   validation point.
-4. Build the applicable risk inventory and search for counterexamples,
-   adjacent paths, compatibility changes, and unrelated substantive changes.
-5. Trace tests and verification through real entry paths; apply the Finding
-   Proof Gate to every candidate.
-6. Deduplicate findings, review the latest delta, and run one adversarial pass.
-   Stop only after a full pass finds no new independent actionable finding.
+3. Build behavior clusters and complete the mandatory risk triage.
+4. Discover candidates across the complete scope before choosing a verdict.
+   Use three distinct lenses:
+   - `Root Cause and Behavior`: intended fix, changed decisions, boundaries,
+     disabled paths, adjacent cases, and old-scenario regression.
+   - `Blast Radius and Contracts`: callers, consumers, shared state, public
+     contracts, compatibility, dependencies, packaging, and generated outputs.
+   - `Tests, Runtime, and Operations`: realistic regressions that can still
+     pass, error and lifecycle paths, runtime verification, diagnostics,
+     documentation, rollout, and rollback.
+5. Apply the Finding Proof Gate to every candidate. Keep discovery notes
+   private and classify every candidate before publication.
+6. Consolidate confirmed findings by independent fix boundary and identify any
+   evidence or coverage gap that could still change the blocker set.
+7. Review the latest delta and run a full-scope convergence pass after the most
+   recent candidate change. If it finds a new independent candidate, return to
+   step 5 and repeat. Select the verdict only after the Completion Gate passes.
 
 If the scope cannot be reviewed honestly, return the mode-appropriate incomplete
 result or request a split. Do not produce a complete verdict from a partial
 review.
 
-## Coverage Audit and Scripts
+## Completion Gate and Scripts
 
-Use Coverage Audit when the user requests complete or non-drip review, or when
-the triggered high-risk criteria make omission materially likely.
+Apply the Completion Gate to every Formal Review and Local Candidate Preflight.
+Apply it to a discussion reply only when the reply makes or changes an overall
+readiness conclusion.
 
-- Use `scripts/build_review_inventory.py` with local refs to establish a bounded
-  deterministic scope inventory.
-- Use `scripts/review_ledger.py` only to account for authoritative files,
-  finding classifications, and final audit passes.
+- Complete the behavior-cluster mapping and risk triage for every authoritative
+  file; classify churn-only files explicitly.
+- Finish all three discovery lenses and classify every candidate.
+- Leave no unresolved evidence or coverage gap that could change the blocker
+  set.
+- Require a full-scope convergence pass after the latest candidate change with
+  zero new independent candidates.
+- Use `scripts/build_review_inventory.py --format json` when local refs are
+  available. Its Markdown output is a bounded human summary, not the
+  authoritative file list.
+- Use `scripts/review_ledger.py` for multi-file, high-risk, or otherwise
+  omission-prone review. It mechanically accounts for files, clusters, risk
+  axes, finding classifications, proof fields, and review passes; it does not
+  judge semantic correctness.
 - Mutate one ledger sequentially; do not run ledger commands concurrently.
-- Treat script output as mechanical evidence, not semantic proof.
-- Before a complete result, require every authoritative file to have a final
-  coverage state, every finding to have a final classification, and the latest
-  audit pass to report zero new independent findings.
 - Keep temporary ledger data private and remove only the exact ledger created
   for the current review.
+
+If the gate cannot pass, return the mode-appropriate incomplete result. In
+Formal Review, when confirmed blockers coexist with a gap that could hide more
+blockers, list them as confirmed partial facts but do not present them as the
+complete change-request set.
+
+## Formal Decision Contract
+
+Apply this order to Formal Review only after the Completion Gate evaluation:
+
+1. If the gate fails, use `Review Incomplete`, even when some blockers are
+   already confirmed.
+2. If public evidence disproves the problem model, expected behavior, ownership,
+   protocol or SQL semantics, compatibility assumption, or solution direction,
+   use `Not Mergeable` with `Feedback Mode: Needs Discussion`.
+3. If at least one candidate passes the Finding Proof Gate, use `Not Mergeable`
+   with `Feedback Mode: Change Request`.
+4. Otherwise use `Mergeable` for the selected focus.
+
+`Mergeable` in Code Correctness Review means code-scope readiness only. Required
+pending CI prevents Mergeable in Mergeability Review. A relevant CI failure is
+a blocker when attributable to the PR and an incomplete gap when attribution is
+unclear.
 
 ## Local Candidate Preflight Mode
 
@@ -193,8 +221,8 @@ the triggered high-risk criteria make omission materially likely.
 - Review from the public PR merge-base through the working tree. Scope is the
   union of GitHub files and the authorized local delta; exclude unrelated local
   changes.
-- Apply Code Correctness Review, the same proof gate, triggered high-risk
-  criteria, and final adversarial pass.
+- Apply Code Correctness Review, the same proof and completion gates, triggered
+  high-risk criteria, and convergence loop.
 - Return exactly one status: `Local Preflight Result: Pass`, `Local Preflight
   Result: Changes Required`, or `Local Preflight Result: Incomplete`.
 - Keep this Skill review-only. The active implementation loop fixes safe
@@ -209,7 +237,9 @@ challenged.
 
 Always re-evaluate the latest head. Treat a prior finding as a hypothesis to
 disprove, inspect challenger-provided public evidence first, and withdraw or
-downgrade any unsupported blocker rather than defending it.
+downgrade any unsupported blocker rather than defending it. Classify every
+finding first reported after an earlier formal review as introduced by the
+latest commits, exposed by the previous fix, or missed in the previous review.
 
 ## Output Contract
 
@@ -226,14 +256,17 @@ logs, or emojis.
 
 ### Formal Review
 
-- `Mergeable`: `### Summary` with exactly one bold `Review Result: Mergeable`
-  line and a concise reason; `### Evidence`; `### Coverage and Limits`.
-- `Not Mergeable`: `### Summary` with exactly one bold
-  `Review Result: Not Mergeable` line, one `Feedback Mode`, and a concise
-  reason; `### Blocking Issues`; `### Coverage and Limits`.
-- `Review Incomplete`: `### Summary` with exactly one bold
+- `Mergeable`: `### Result` with exactly one bold
+  `Review Result: Mergeable` line and a concise reason; `### Evidence`;
+  `### Coverage`.
+- `Not Mergeable`: `### Result` with exactly one bold
+  `Review Result: Not Mergeable` line, one `Feedback Mode`, a bold
+  `Blocking Issues: N` line, and a concise reason; `### Blocking Issues`;
+  `### Coverage`.
+- `Review Incomplete`: `### Result` with exactly one bold
   `Review Result: Review Incomplete` line and a concise reason;
-  `### Verified Facts`; `### Required Evidence`; `### Coverage and Limits`.
+  `### Confirmed Issues` when any are already proven; `### Verified Facts`;
+  `### Required Evidence`; `### Coverage`.
 
 For each blocking issue include:
 
@@ -243,8 +276,10 @@ For each blocking issue include:
   Discussion.
 
 Do not add patch-level changes after selecting Needs Discussion. Do not include
-placeholder or optional headings. In Code Correctness Review, state that the
-result is code-scope only and CI was not reviewed.
+placeholder headings. In `### Coverage`, report the reviewed head, authoritative
+files accounted for, behavior clusters, completed discovery lenses, unresolved
+gaps, and CI scope. In Code Correctness Review, state that the result is
+code-scope only and CI was not reviewed.
 
 ### PR Discussion Reply
 
@@ -255,7 +290,7 @@ evidence and minimum next action. Do not force a formal verdict.
 ### Local Candidate Preflight
 
 Return `### Local Preflight`, exactly one bold Local Preflight Result line,
-confirmed required findings when present, and `### Coverage and Limits`.
+confirmed required findings when present, and `### Coverage`.
 
 ### Correction
 

--- a/.codex/skills/review-pr/agents/openai.yaml
+++ b/.codex/skills/review-pr/agents/openai.yaml
@@ -17,7 +17,8 @@
 
 interface:
   display_name: "Review PR"
-  short_description: "Evidence-backed PR review and reply drafting"
+  short_description: "Complete evidence-backed PR review"
   default_prompt: >-
-    Use $review-pr to review a ShardingSphere PR or PR discussion from current
-    public evidence and return one concise, copy-ready Markdown result.
+    Use $review-pr to complete a consolidated current-head review of a
+    ShardingSphere PR or PR discussion from public evidence and return one
+    concise, copy-ready Markdown result.

--- a/.codex/skills/review-pr/references/high-risk-review.md
+++ b/.codex/skills/review-pr/references/high-risk-review.md
@@ -17,9 +17,10 @@
 
 # High-Risk Review
 
-Read only the sections triggered by the changed behavior. Use Coverage Audit
-when the user requests complete, non-drip review or when the PR crosses several
-of these boundaries.
+Read the sections selected by the main Skill's mandatory risk triage. More than
+one section may apply to a behavior cluster; do not stop after the first
+recognized risk. Complete the main Skill's Completion Gate after applying the
+triggered guidance.
 
 ## Shared Ownership and Implicit State
 

--- a/.codex/skills/review-pr/references/review-corrections.md
+++ b/.codex/skills/review-pr/references/review-corrections.md
@@ -24,7 +24,7 @@ finding.
 ## Multi-Round Review
 
 Use public previous-round feedback only. Do not expose private review notes,
-local chat iterations, raw inventory, or internal accountability.
+local chat iterations, raw inventory, or internal scratch state.
 
 For every prior public finding, classify the latest head as:
 
@@ -42,6 +42,21 @@ the minimum remaining work.
 If the latest evidence shows that the direction itself must be reconsidered,
 switch to `Needs Discussion` and stop presenting previous patch-level requests
 as the main path.
+
+## Findings First Reported Later
+
+Classify every finding first reported after an earlier formal review:
+
+- `Introduced by latest commits`: the reviewed delta created the problem.
+- `Exposed by the previous fix`: the earlier fix made a different path newly
+  reachable or materially changed the evidence.
+- `Missed in the previous review`: the problem was already present in the
+  previously reviewed head.
+
+Prove the classification from the previous and current heads. Do not describe
+an earlier-head problem as newly introduced. For a previous-review miss,
+acknowledge it directly, rerun the full Completion Gate, and return the complete
+remaining blocker set rather than publishing only the late finding.
 
 ## Challenged Findings
 

--- a/.codex/skills/review-pr/references/sql-parser-review.md
+++ b/.codex/skills/review-pr/references/sql-parser-review.md
@@ -45,5 +45,5 @@ Read this reference before reviewing PRs that touch SQL grammar, SQL visitor cla
 
 ## Output Requirements
 
-- In `Coverage and Limits`, name the target dialect, related trunk or branch dialects checked, official documentation pages used, and repo docs or examples checked.
+- In `Coverage`, name the target dialect, related trunk or branch dialects checked, official documentation pages used, and repo docs or examples checked.
 - If syntax evidence is missing or contradicted, classify the result using the main skill's evidence sufficiency rules instead of guessing.

--- a/.codex/skills/review-pr/scripts/review_ledger.py
+++ b/.codex/skills/review-pr/scripts/review_ledger.py
@@ -36,11 +36,14 @@ from review_common import categorize, compare_github_files, final_paths, get_rep
 
 
 LEDGER_KIND = "review-pr-coverage-ledger"
-LEDGER_VERSION = 2
+LEDGER_VERSION = 3
 LEDGER_FILE_NAME = "ledger.json"
 FILE_STATUSES = frozenset({"pending", "reviewed", "churn-only", "test-only-reviewed", "not-applicable", "blocked"})
 FINAL_FILE_STATUSES = FILE_STATUSES - {"pending"}
+SUBSTANTIVE_FILE_STATUSES = frozenset({"reviewed", "test-only-reviewed"})
+EXPLAINED_FILE_STATUSES = frozenset({"churn-only", "not-applicable"})
 FINDING_STATUSES = frozenset({"candidate", "confirmed", "withdrawn", "review-incomplete-gap", "non-blocking", "out-of-scope"})
+PASS_FOCUSES = ("root-cause", "blast-radius", "tests-runtime", "convergence")
 
 
 def ledger_root() -> Path:
@@ -135,6 +138,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         "version": LEDGER_VERSION,
         "created_at": now,
         "updated_at": now,
+        "review_revision": 0,
         "scope": {
             "repo": repo_root.name,
             "pr": args.pr,
@@ -152,8 +156,10 @@ def cmd_init(args: argparse.Namespace) -> int:
             "old_path": each.old_path,
             "category": categorize(each.path),
             "status": "pending",
+            "clusters": [],
             "risk_axes": [],
             "findings": [],
+            "reason": "",
         } for each in changed_files],
         "findings": [],
         "passes": [],
@@ -169,7 +175,10 @@ def cmd_mark_file(args: argparse.Namespace) -> int:
     ledger = read_ledger(ledger_file)
     entry = find_file_entry(ledger, args.path)
     entry["status"] = args.status
+    unique_extend(entry["clusters"], args.cluster or [])
     unique_extend(entry["risk_axes"], args.risk_axis or [])
+    entry["reason"] = args.reason or ""
+    ledger["review_revision"] += 1
     write_ledger(ledger_file, ledger)
     print(f"marked={args.path} status={args.status}")
     return 0
@@ -197,6 +206,7 @@ def cmd_add_finding(args: argparse.Namespace) -> int:
     else:
         ledger["findings"].append(finding)
     sync_file_findings(ledger)
+    ledger["review_revision"] += 1
     write_ledger(ledger_file, ledger)
     print(f"finding={args.id} status={args.status}")
     return 0
@@ -205,9 +215,13 @@ def cmd_add_finding(args: argparse.Namespace) -> int:
 def cmd_add_pass(args: argparse.Namespace) -> int:
     ledger_file = resolve_ledger_file(args.ledger)
     ledger = read_ledger(ledger_file)
+    if 0 > args.new_findings:
+        raise RuntimeError("New finding count must not be negative")
     ledger["passes"].append({
         "focus": args.focus,
         "new_findings": args.new_findings,
+        "review_revision": ledger["review_revision"],
+        "finding_count": len(ledger["findings"]),
         "created_at": int(time.time()),
     })
     write_ledger(ledger_file, ledger)
@@ -233,10 +247,29 @@ def validate_ledger(ledger: dict[str, Any]) -> list[str]:
     blocked_files = [each["path"] for each in ledger["files"] if "blocked" == each["status"]]
     if blocked_files:
         result.append(f"Blocked files require more evidence or an incomplete result: {len(blocked_files)}")
+    missing_clusters = [each["path"] for each in ledger["files"]
+                        if each["status"] in SUBSTANTIVE_FILE_STATUSES
+                        and (not each.get("clusters") or not all(each["clusters"]))]
+    if missing_clusters:
+        result.append(f"Substantive files missing behavior clusters: {len(missing_clusters)}")
+    missing_risk_axes = [each["path"] for each in ledger["files"]
+                         if each["status"] in SUBSTANTIVE_FILE_STATUSES
+                         and (not each.get("risk_axes") or not all(each["risk_axes"]))]
+    if missing_risk_axes:
+        result.append(f"Substantive files missing reviewed risk axes: {len(missing_risk_axes)}")
+    unexplained_files = [each["path"] for each in ledger["files"]
+                         if each["status"] in EXPLAINED_FILE_STATUSES and not each.get("reason")]
+    if unexplained_files:
+        result.append(f"Non-substantive file classifications missing reasons: {len(unexplained_files)}")
     finding_counts = Counter(each["id"] for each in ledger["findings"])
     duplicate_findings = [finding_id for finding_id, count in finding_counts.items() if 1 < count]
     if duplicate_findings:
         result.append(f"Duplicate finding ids remain: {len(duplicate_findings)}")
+    fix_boundary_counts = Counter(each["fix_boundary"] for each in ledger["findings"]
+                                  if "confirmed" == each["status"] and each["fix_boundary"])
+    duplicate_fix_boundaries = [fix_boundary for fix_boundary, count in fix_boundary_counts.items() if 1 < count]
+    if duplicate_fix_boundaries:
+        result.append(f"Confirmed findings share fix boundaries: {len(duplicate_fix_boundaries)}")
     finding_ids = set(finding_counts)
     scope_files = set(file_counts)
     for each in ledger["files"]:
@@ -268,12 +301,22 @@ def validate_ledger(ledger: dict[str, Any]) -> list[str]:
                 result.append(f"{each['id']} confirmed finding is missing scope proof")
             if not each["files"]:
                 result.append(f"{each['id']} confirmed finding is missing scope files")
-        if "review-incomplete-gap" == each["status"] and not each["reason"]:
-            result.append(f"{each['id']} incomplete gap is missing a reason")
-    if not ledger["passes"]:
-        result.append("No final adversarial pass was recorded")
-    elif 0 != ledger["passes"][-1].get("new_findings"):
-        result.append("Latest adversarial pass did not finish with zero new findings")
+        if "review-incomplete-gap" == each["status"]:
+            if not each["reason"]:
+                result.append(f"{each['id']} incomplete gap is missing a reason")
+            result.append(f"{each['id']} requires a Review Incomplete result")
+    pass_foci = {each.get("focus") for each in ledger["passes"]}
+    missing_passes = [each for each in PASS_FOCUSES if each not in pass_foci]
+    if missing_passes:
+        result.append(f"Required review passes missing: {', '.join(missing_passes)}")
+    if ledger["passes"]:
+        final_pass = ledger["passes"][-1]
+        if "convergence" != final_pass.get("focus"):
+            result.append("Latest review pass is not the convergence pass")
+        if 0 != final_pass.get("new_findings"):
+            result.append("Latest convergence pass did not finish with zero new findings")
+        if ledger["review_revision"] != final_pass.get("review_revision"):
+            result.append("Latest convergence pass predates a file or finding change")
     return result
 
 
@@ -292,9 +335,11 @@ def cmd_status(args: argparse.Namespace) -> int:
     ledger = read_ledger(args.ledger)
     file_counts = Counter(each["status"] for each in ledger["files"])
     finding_counts = Counter(each["status"] for each in ledger["findings"])
+    pass_counts = Counter(each["focus"] for each in ledger["passes"])
     print(f"files={dict(sorted(file_counts.items()))}")
     print(f"findings={dict(sorted(finding_counts.items()))}")
-    print(f"passes={len(ledger['passes'])}")
+    print(f"passes={dict(sorted(pass_counts.items()))}")
+    print(f"review_revision={ledger['review_revision']}")
     return 0
 
 
@@ -322,7 +367,9 @@ def build_parser() -> argparse.ArgumentParser:
     mark_file.add_argument("--ledger", required=True, help="Ledger file or directory")
     mark_file.add_argument("--path", required=True, help="Repository-relative changed file path")
     mark_file.add_argument("--status", required=True, choices=sorted(FILE_STATUSES), help="Coverage state")
+    mark_file.add_argument("--cluster", action="append", help="Behavior cluster containing this file")
     mark_file.add_argument("--risk-axis", action="append", help="Risk axis covered for this file")
+    mark_file.add_argument("--reason", help="Reason for a non-substantive file classification")
     mark_file.set_defaults(func=cmd_mark_file)
     finding = subparsers.add_parser("add-finding", help="Add or update one finding classification")
     finding.add_argument("--ledger", required=True, help="Ledger file or directory")
@@ -338,9 +385,9 @@ def build_parser() -> argparse.ArgumentParser:
     finding.add_argument("--file", action="append", help="Repository-relative scope file")
     finding.add_argument("--reason", help="Reason for an incomplete or non-blocking classification")
     finding.set_defaults(func=cmd_add_finding)
-    review_pass = subparsers.add_parser("add-pass", help="Record an adversarial review pass")
+    review_pass = subparsers.add_parser("add-pass", help="Record a required review pass")
     review_pass.add_argument("--ledger", required=True, help="Ledger file or directory")
-    review_pass.add_argument("--focus", required=True, help="Pass focus")
+    review_pass.add_argument("--focus", required=True, choices=PASS_FOCUSES, help="Pass focus")
     review_pass.add_argument("--new-findings", required=True, type=int, help="New independent findings")
     review_pass.set_defaults(func=cmd_add_pass)
     validate = subparsers.add_parser("validate", help="Validate mechanical coverage completion")


### PR DESCRIPTION
- delay formal verdicts until multi-lens review reaches convergence
- classify late findings and expose completion coverage
- strengthen the review ledger for clusters, risk axes, and stale passes
