### PR TITLE
Support function table alias column parsing for PostgreSQL and openGauss

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -73,6 +73,7 @@
 1. SQL Parser: Add Hive CTAS and window function parsing - [#39188](https://github.com/apache/shardingsphere/pull/39188)
 1. SQL Parser: Support SQLServer table variable declaration parse - [#38904](https://github.com/apache/shardingsphere/pull/38904)
 1. SQL Parser: Support Oracle procedure parser and binder - [#39231](https://github.com/apache/shardingsphere/pull/39231)
+1. SQL Parser: Support function table alias column parsing for PostgreSQL and openGauss - [#39268](https://github.com/apache/shardingsphere/pull/39268)
 1. SQL Binder: Support select order by index bind metadata - [#38386](https://github.com/apache/shardingsphere/pull/38386)
 1. SQL Binder: Support SQL bind when with temp table name is same with physical table - [#38411](https://github.com/apache/shardingsphere/pull/38411)
 1. Metadata: Support Oracle dictionary views by adding SYS default system schema and YAML definitions - [#38388](https://github.com/apache/shardingsphere/pull/38388)

--- a/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -1358,7 +1358,15 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementParser
     
     private FunctionTableSegment getFunctionTableSegment(final TableReferenceContext ctx) {
         FunctionSegment functionSegment = (FunctionSegment) visit(ctx.functionTable().functionExprWindowless().funcApplication());
-        return new FunctionTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), functionSegment);
+        FunctionTableSegment result = new FunctionTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), functionSegment);
+        if (null != ctx.funcAliasClause() && null != ctx.funcAliasClause().aliasClause()) {
+            AliasClauseContext aliasClause = ctx.funcAliasClause().aliasClause();
+            result.setAlias(new AliasSegment(aliasClause.colId().start.getStartIndex(), aliasClause.colId().stop.getStopIndex(), new IdentifierValue(aliasClause.colId().getText())));
+            if (null != aliasClause.nameList()) {
+                result.getColumns().addAll(generateUsingColumn(aliasClause.nameList()));
+            }
+        }
+        return result;
     }
     
     @Override

--- a/parser/sql/engine/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitorTest.java
+++ b/parser/sql/engine/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitorTest.java
@@ -24,10 +24,15 @@ import org.apache.shardingsphere.sql.parser.engine.core.ParseASTNode;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.FunctionTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,6 +51,18 @@ class OpenGaussStatementVisitorTest {
         assertTrue(aggregationProjection.getWindow().isPresent());
         WindowItemSegment windowItem = aggregationProjection.getWindow().get();
         assertThat(windowItem.getOrderBySegment().getOrderByItems().size(), is(1));
+    }
+    
+    @Test
+    void assertVisitFunctionTableColumnAliases() {
+        SelectStatement statement = parseSelectStatement("SELECT s.r FROM generate_series(1, 3) AS s(r)");
+        assertTrue(statement.getFrom().isPresent());
+        assertThat(statement.getFrom().get(), isA(FunctionTableSegment.class));
+        FunctionTableSegment functionTableSegment = (FunctionTableSegment) statement.getFrom().get();
+        assertTrue(functionTableSegment.getAliasSegment().isPresent());
+        assertThat(functionTableSegment.getAliasSegment().get().getIdentifier().getValue(), is("s"));
+        Collection<String> actualColumns = functionTableSegment.getColumns().stream().map(each -> each.getIdentifier().getValue()).collect(Collectors.toList());
+        assertThat(actualColumns, contains("r"));
     }
     
     private SelectStatement parseSelectStatement(final String sql) {

--- a/parser/sql/engine/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
+++ b/parser/sql/engine/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
@@ -1343,7 +1343,15 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
     
     private FunctionTableSegment getFunctionTableSegment(final TableReferenceContext ctx) {
         FunctionSegment functionSegment = (FunctionSegment) visit(ctx.functionTable().functionExprWindowless().funcApplication());
-        return new FunctionTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), functionSegment);
+        FunctionTableSegment result = new FunctionTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), functionSegment);
+        if (null != ctx.funcAliasClause() && null != ctx.funcAliasClause().aliasClause()) {
+            AliasClauseContext aliasClause = ctx.funcAliasClause().aliasClause();
+            result.setAlias((AliasSegment) visit(aliasClause));
+            if (null != aliasClause.nameList()) {
+                result.getColumns().addAll(generateUsingColumn(aliasClause.nameList()));
+            }
+        }
+        return result;
     }
     
     @Override

--- a/parser/sql/engine/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/PostgreSQLStatementVisitorTest.java
+++ b/parser/sql/engine/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/PostgreSQLStatementVisitorTest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.Aggr
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.FunctionTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.UpdateStatement;
@@ -74,6 +75,18 @@ class PostgreSQLStatementVisitorTest {
         Collection<ProjectionSegment> actualProjections = subqueryTableSegment.getSubquery().getSelect().getProjections().getProjections();
         assertThat(actualProjections.size(), is(3));
         actualProjections.forEach(each -> assertThat(each, isA(ExpressionProjectionSegment.class)));
+    }
+    
+    @Test
+    void assertVisitFunctionTableColumnAliases() {
+        SelectStatement statement = parseSelectStatement("SELECT s.r FROM generate_series(1, 3) AS s(r)");
+        assertTrue(statement.getFrom().isPresent());
+        assertThat(statement.getFrom().get(), isA(FunctionTableSegment.class));
+        FunctionTableSegment functionTableSegment = (FunctionTableSegment) statement.getFrom().get();
+        assertTrue(functionTableSegment.getAliasSegment().isPresent());
+        assertThat(functionTableSegment.getAliasSegment().get().getIdentifier().getValue(), is("s"));
+        Collection<String> actualColumns = functionTableSegment.getColumns().stream().map(each -> each.getIdentifier().getValue()).collect(Collectors.toList());
+        assertThat(actualColumns, contains("r"));
     }
     
     @Test

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/table/TableAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/table/TableAssert.java
@@ -116,6 +116,9 @@ public final class TableAssert {
     private static void assertIs(final SQLCaseAssertContext assertContext, final FunctionTableSegment actual, final ExpectedFunctionTable expected) {
         assertTableFunction(assertContext, actual.getTableFunction(), expected.getTableFunction());
         actual.getAliasName().ifPresent(optional -> assertThat(assertContext.getText("Table function alias assertion error"), optional, is(expected.getTableAlias())));
+        if (!expected.getColumns().isEmpty()) {
+            ColumnAssert.assertIs(assertContext, actual.getColumns(), expected.getColumns());
+        }
     }
     
     /**

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/table/ExpectedFunctionTable.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/table/ExpectedFunctionTable.java
@@ -20,10 +20,13 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedDelimiterSQLSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.column.ExpectedColumn;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.expr.ExpectedTableFunction;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Expected function table.
@@ -40,4 +43,7 @@ public final class ExpectedFunctionTable extends AbstractExpectedDelimiterSQLSeg
     
     @XmlElement(name = "table-function")
     private ExpectedTableFunction tableFunction;
+    
+    @XmlElement(name = "column")
+    private final List<ExpectedColumn> columns = new LinkedList<>();
 }

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -5010,6 +5010,28 @@
             </function-table>
         </from>
     </select>
+
+    <select sql-case-id="select_from_table_function_with_alias_columns">
+        <projections start-index="7" stop-index="9">
+            <column-projection name="r" start-index="7" stop-index="9">
+                <owner name="s" start-index="7" stop-index="7" />
+            </column-projection>
+        </projections>
+        <from start-index="16" stop-index="44">
+            <function-table start-index="16" stop-index="44" table-alias="s">
+                <table-function function-name="generate_series" text="generate_series(1, 3)" start-index="16" stop-index="36">
+                    <parameter>
+                        <literal-expression value="1" start-index="32" stop-index="32" />
+                    </parameter>
+                    <parameter>
+                        <literal-expression value="3" start-index="35" stop-index="35" />
+                    </parameter>
+                </table-function>
+                <column name="r" start-index="43" stop-index="43" />
+            </function-table>
+        </from>
+    </select>
+
     <select sql-case-id="select_bitxor" db-types="Doris">
         <projections start-index="7" stop-index="17">
             <expression-projection text="BITXOR(3,5)" start-index="7" stop-index="17">

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -236,6 +236,7 @@
     <sql-case id="select_ps_thread_id" value="SELECT PS_THREAD_ID(5)" db-types="MySQL" />
     <sql-case id="select_quote" value="SELECT QUOTE('Don\'t!')" db-types="MySQL" />
     <sql-case id="select_from_table_function" value="SELECT * FROM GENERATE_SERIES(1, name)" db-types="PostgreSQL,openGauss" />
+    <sql-case id="select_from_table_function_with_alias_columns" value="SELECT s.r FROM generate_series(1, 3) AS s(r)" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_json_objectagg" value="SELECT JSON_OBJECTAGG(attribute, value) FROM t GROUP BY id" db-types="MySQL" />
     <sql-case id="select_json_overlaps" value="SELECT JSON_OVERLAPS(&quot;[1,3,5,7]&quot;, &quot;[2,5,7]&quot;)" db-types="MySQL" />
     <sql-case id="select_json_pretty" value="SELECT JSON_PRETTY('123')" db-types="MySQL" />


### PR DESCRIPTION
Fixes #39255.

Changes proposed in this pull request:
  - Preserve function table aliases and alias columns for PostgreSQL function table segments.
  - Preserve function table alias columns for openGauss and keep the table alias value independent from the column alias list.
  - Add parser IT assertions for function table alias columns and cover `generate_series(...) AS s(r)`.

Tests performed:
  - `./mvnw -nsu -B -pl parser/sql/engine/dialect/postgresql,parser/sql/engine/dialect/opengauss -Dtest=PostgreSQLStatementVisitorTest,OpenGaussStatementVisitorTest -Dsurefire.failIfNoSpecifiedTests=false test -Dspotless.apply.skip=true`
  - `./mvnw -nsu -B -pl test/it/parser -Dtest=org.apache.shardingsphere.test.it.sql.parser.postgresql.InternalPostgreSQLParserIT,org.apache.shardingsphere.test.it.sql.parser.opengauss.InternalOpenGaussParserIT -Dsurefire.failIfNoSpecifiedTests=false test -Dspotless.apply.skip=true`
  - `./mvnw -nsu -B install -f test/e2e/sql/pom.xml -Dspotless.apply.skip=true -De2e.run.type=DOCKER -De2e.artifact.modes=Cluster -De2e.artifact.adapters=proxy -De2e.run.additional.cases=false -De2e.scenarios=passthrough -De2e.artifact.databases=PostgreSQL -Dit.test=GeneralDQLE2EIT`
  - `./mvnw -nsu -B install -f test/e2e/sql/pom.xml -Dspotless.apply.skip=true -De2e.run.type=DOCKER -De2e.artifact.modes=Cluster -De2e.artifact.adapters=proxy -De2e.run.additional.cases=false -De2e.scenarios=passthrough -De2e.artifact.databases=openGauss -Dit.test=GeneralDQLE2EIT`
  - `./mvnw spotless:apply -Pcheck -T1C`
  - `./mvnw checkstyle:check -Pcheck -T1C`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
