### PR TITLE
Respect storage identifier policy for physical schemas

### DIFF
--- a/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCasePolicyProvider.java
@@ -17,15 +17,10 @@
 
 package org.apache.shardingsphere.database.connector.opengauss.metadata.identifier;
 
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProviderContext;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
-
-import java.util.EnumMap;
-import java.util.Map;
 
 /**
  * openGauss provider of identifier case rules.
@@ -34,10 +29,7 @@ public final class OpenGaussIdentifierCasePolicyProvider implements IdentifierCa
     
     @Override
     public IdentifierCasePolicySet provide(final IdentifierCasePolicyProviderContext context) {
-        IdentifierCasePolicySet lowerCasePolicySet = IdentifierCasePolicyFactory.newLowerCasePolicySet();
-        Map<IdentifierScope, IdentifierCasePolicy> scopedRules = new EnumMap<>(IdentifierScope.class);
-        scopedRules.put(IdentifierScope.SCHEMA, IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.SCHEMA));
-        return new IdentifierCasePolicySet(lowerCasePolicySet.getPolicy(IdentifierScope.TABLE), scopedRules);
+        return IdentifierCasePolicyFactory.newLowerCasePolicySet();
     }
     
     @Override

--- a/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCasePolicyProviderTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.enums
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProviderContext;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -49,13 +50,17 @@ class OpenGaussIdentifierCasePolicyProviderTest {
     @Test
     void assertProvide() {
         IdentifierCasePolicyProviderContext context = new IdentifierCasePolicyProviderContext(databaseType, null);
-        IdentifierCasePolicy tableRule = provider.provide(context).getPolicy(IdentifierScope.TABLE);
+        IdentifierCasePolicySet actual = provider.provide(context);
+        IdentifierCasePolicy tableRule = actual.getPolicy(IdentifierScope.TABLE);
         assertThat(tableRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
         assertTrue(tableRule.matches("foo", "FOO", QuoteCharacter.NONE));
         assertFalse(tableRule.matches("Foo", "foo", QuoteCharacter.NONE));
-        IdentifierCasePolicy schemaRule = provider.provide(context).getPolicy(IdentifierScope.SCHEMA);
+        IdentifierCasePolicy schemaRule = actual.getPolicy(IdentifierScope.SCHEMA);
         assertThat(schemaRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
-        assertTrue(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.NONE));
+        assertThat(schemaRule.normalizeForDefinition("FooSchema", QuoteCharacter.NONE), is("fooschema"));
+        assertThat(schemaRule.normalizeForDefinition("FooSchema", QuoteCharacter.QUOTE), is("FooSchema"));
+        assertTrue(schemaRule.matches("lower_schema", "LOWER_SCHEMA", QuoteCharacter.NONE));
+        assertFalse(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.NONE));
         assertFalse(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.QUOTE));
     }
 }

--- a/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCasePolicyProvider.java
+++ b/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCasePolicyProvider.java
@@ -17,14 +17,10 @@
 
 package org.apache.shardingsphere.database.connector.postgresql.metadata.identifier;
 
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProviderContext;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
-import java.util.EnumMap;
-import java.util.Map;
 
 /**
  * PostgreSQL provider of identifier case rules.
@@ -33,10 +29,7 @@ public final class PostgreSQLIdentifierCasePolicyProvider implements IdentifierC
     
     @Override
     public IdentifierCasePolicySet provide(final IdentifierCasePolicyProviderContext context) {
-        IdentifierCasePolicySet lowerCasePolicySet = IdentifierCasePolicyFactory.newLowerCasePolicySet();
-        Map<IdentifierScope, IdentifierCasePolicy> scopedRules = new EnumMap<>(IdentifierScope.class);
-        scopedRules.put(IdentifierScope.SCHEMA, IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.SCHEMA));
-        return new IdentifierCasePolicySet(lowerCasePolicySet.getPolicy(IdentifierScope.TABLE), scopedRules);
+        return IdentifierCasePolicyFactory.newLowerCasePolicySet();
     }
     
     @Override

--- a/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCasePolicyProviderTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.enums
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProviderContext;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -49,13 +50,17 @@ class PostgreSQLIdentifierCasePolicyProviderTest {
     @Test
     void assertProvide() {
         IdentifierCasePolicyProviderContext context = new IdentifierCasePolicyProviderContext(databaseType, null);
-        IdentifierCasePolicy tableRule = provider.provide(context).getPolicy(IdentifierScope.TABLE);
+        IdentifierCasePolicySet actual = provider.provide(context);
+        IdentifierCasePolicy tableRule = actual.getPolicy(IdentifierScope.TABLE);
         assertThat(tableRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
         assertTrue(tableRule.matches("foo", "FOO", QuoteCharacter.NONE));
         assertFalse(tableRule.matches("Foo", "foo", QuoteCharacter.NONE));
-        IdentifierCasePolicy schemaRule = provider.provide(context).getPolicy(IdentifierScope.SCHEMA);
+        IdentifierCasePolicy schemaRule = actual.getPolicy(IdentifierScope.SCHEMA);
         assertThat(schemaRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
-        assertTrue(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.NONE));
+        assertThat(schemaRule.normalizeForDefinition("FooSchema", QuoteCharacter.NONE), is("fooschema"));
+        assertThat(schemaRule.normalizeForDefinition("FooSchema", QuoteCharacter.QUOTE), is("FooSchema"));
+        assertTrue(schemaRule.matches("lower_schema", "LOWER_SCHEMA", QuoteCharacter.NONE));
+        assertFalse(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.NONE));
         assertFalse(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.QUOTE));
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
@@ -20,10 +20,12 @@ package org.apache.shardingsphere.infra.metadata.identifier;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
+import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.MetadataIdentifierCaseSensitivity;
@@ -64,7 +66,8 @@ public final class DatabaseIdentifierContextFactory {
     public static DatabaseIdentifierContext create(final DatabaseType databaseType, final DataSource dataSource) {
         IdentifierCasePolicySet protocolPolicySet = IdentifierCasePolicyResolver.resolveProtocol(databaseType);
         IdentifierCasePolicySet storagePolicySet = IdentifierCasePolicyResolver.resolveStorage(databaseType, dataSource);
-        IdentifierCasePolicySet metaDataPolicySet = createMetaDataPolicySet(protocolPolicySet, storagePolicySet, new ConfigurationProperties(new Properties()));
+        IdentifierCasePolicySet metaDataPolicySet = createMetaDataPolicySet(
+                protocolPolicySet, storagePolicySet, new ConfigurationProperties(new Properties()), protocolPolicySet.getPolicy(IdentifierScope.SCHEMA));
         return new DatabaseIdentifierContext(protocolPolicySet, storagePolicySet, metaDataPolicySet, false);
     }
     
@@ -116,19 +119,22 @@ public final class DatabaseIdentifierContextFactory {
         IdentifierCasePolicySet storagePolicySet = null == storageUnit
                 ? protocolPolicySet
                 : IdentifierCasePolicyResolver.resolveStorage(storageUnit.getStorageType(), storageUnit.getDataSource());
+        IdentifierCasePolicy schemaPolicy = (null != storageUnit && isSchemaAvailable(protocolType) && isSchemaAvailable(storageUnit.getStorageType())
+                ? storagePolicySet
+                : protocolPolicySet).getPolicy(IdentifierScope.SCHEMA);
         return new ResolvedIdentifierContext(protocolPolicySet, storagePolicySet,
-                createMetaDataPolicySet(protocolPolicySet, storagePolicySet, props), isHeterogeneous(protocolType, storageUnits));
+                createMetaDataPolicySet(protocolPolicySet, storagePolicySet, props, schemaPolicy), isHeterogeneous(protocolType, storageUnits));
     }
     
     private static IdentifierCasePolicySet createMetaDataPolicySet(final IdentifierCasePolicySet protocolPolicySet, final IdentifierCasePolicySet storagePolicySet,
-                                                                   final ConfigurationProperties props) {
+                                                                   final ConfigurationProperties props, final IdentifierCasePolicy schemaPolicy) {
         MetadataIdentifierCaseSensitivity configuredCaseSensitivity = new TemporaryConfigurationProperties(props.getProps())
                 .getValue(TemporaryConfigurationPropertyKey.METADATA_IDENTIFIER_CASE_SENSITIVITY);
         if (MetadataIdentifierCaseSensitivity.INSENSITIVE != configuredCaseSensitivity) {
-            return createScopeAwarePolicySet(protocolPolicySet, storagePolicySet);
+            return createScopeAwarePolicySet(protocolPolicySet, storagePolicySet, schemaPolicy);
         }
         IdentifierCasePolicySet insensitivePolicySet = IdentifierCasePolicyFactory.newInsensitivePolicySet();
-        return createScopeAwarePolicySet(insensitivePolicySet, insensitivePolicySet);
+        return createScopeAwarePolicySet(insensitivePolicySet, insensitivePolicySet, insensitivePolicySet.getPolicy(IdentifierScope.SCHEMA));
     }
     
     private static Collection<StorageUnit> getStorageUnits(final ResourceMetaData resourceMetaData) {
@@ -138,16 +144,22 @@ public final class DatabaseIdentifierContextFactory {
         return resourceMetaData.getStorageUnits().values();
     }
     
-    private static IdentifierCasePolicySet createScopeAwarePolicySet(final IdentifierCasePolicySet protocolPolicySet, final IdentifierCasePolicySet storagePolicySet) {
+    private static IdentifierCasePolicySet createScopeAwarePolicySet(final IdentifierCasePolicySet protocolPolicySet, final IdentifierCasePolicySet storagePolicySet,
+                                                                     final IdentifierCasePolicy schemaPolicy) {
         Map<IdentifierScope, IdentifierCasePolicy> scopedPolicies = new EnumMap<>(IdentifierScope.class);
         for (IdentifierScope each : IdentifierScope.values()) {
             scopedPolicies.put(each, storagePolicySet.getPolicy(each));
         }
         IdentifierCasePolicy databasePolicy = IdentifierCasePolicyFactory.newInsensitivePolicySet().getPolicy(IdentifierScope.DATABASE);
         scopedPolicies.put(IdentifierScope.DATABASE, databasePolicy);
-        scopedPolicies.put(IdentifierScope.SCHEMA, protocolPolicySet.getPolicy(IdentifierScope.SCHEMA));
+        scopedPolicies.put(IdentifierScope.SCHEMA, schemaPolicy);
         scopedPolicies.put(IdentifierScope.LOGICAL_TABLE, protocolPolicySet.getPolicy(IdentifierScope.LOGICAL_TABLE));
         return new IdentifierCasePolicySet(storagePolicySet.getPolicy(IdentifierScope.TABLE), scopedPolicies);
+    }
+    
+    private static boolean isSchemaAvailable(final DatabaseType databaseType) {
+        return DatabaseTypedSPILoader.findService(DialectDatabaseMetaData.class, databaseType)
+                .map(each -> each.getSchemaOption().isSchemaAvailable()).orElse(false);
     }
     
     private static boolean isHeterogeneous(final DatabaseType protocolType, final Collection<StorageUnit> storageUnits) {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
@@ -397,10 +397,10 @@ class ShardingSphereDatabaseTest {
     }
     
     @Test
-    void assertDefaultPropsUseInsensitiveLookup() {
+    void assertDefaultPropsUsePostgreSQLSchemaLookup() {
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", postgreSQLDatabaseType, createResourceMetaData(),
-                new RuleMetaData(Collections.emptyList()), Collections.singleton(createSchema("foo_schema", postgreSQLDatabaseType)), new ConfigurationProperties(new Properties()));
-        assertTrue(database.containsSchema("FOO_SCHEMA"));
+                new RuleMetaData(Collections.emptyList()), Collections.singleton(createSchema("FOO_SCHEMA", postgreSQLDatabaseType)), new ConfigurationProperties(new Properties()));
+        assertFalse(database.containsSchema("foo_schema"));
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -137,6 +137,7 @@ class DatabaseIdentifierContextFactoryTest {
         assertThat(actual.normalizeProtocol(IdentifierScope.TABLE, new IdentifierValue("Foo")), is("FOO"));
         assertThat(actual.normalizeStorage(IdentifierScope.TABLE, new IdentifierValue("Foo")), is("foo"));
         assertThat(actual.getMetaDataPolicy(IdentifierScope.TABLE).normalizeForLookup("Foo"), is("foo"));
+        assertTrue(actual.matchesMetaData(IdentifierScope.SCHEMA, "Foo", new IdentifierValue("foo")));
     }
     
     @Test
@@ -147,6 +148,7 @@ class DatabaseIdentifierContextFactoryTest {
         assertThat(actual.normalizeProtocol(IdentifierScope.TABLE, new IdentifierValue("Foo")), is("FOO"));
         assertThat(actual.normalizeStorage(IdentifierScope.TABLE, new IdentifierValue("Foo")), is("foo"));
         assertThat(actual.getMetaDataPolicy(IdentifierScope.TABLE).normalizeForLookup("Foo"), is("foo"));
+        assertTrue(actual.matchesMetaData(IdentifierScope.SCHEMA, "Foo", new IdentifierValue("foo")));
     }
     
     @ParameterizedTest(name = "{0}")
@@ -178,6 +180,34 @@ class DatabaseIdentifierContextFactoryTest {
         IdentifierCasePolicy actualTableRule = actual.getMetaDataPolicy(IdentifierScope.TABLE);
         assertTrue(actualSchemaRule.matches("test_db", "TEST_DB", QuoteCharacter.NONE));
         assertTrue(actualTableRule.matches("T_ORDER", "t_order", QuoteCharacter.NONE));
+    }
+    
+    @Test
+    void assertCreateUsesProtocolRuleForSchemaWhenProtocolSchemaUnavailable() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(
+                MYSQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        assertTrue(actual.getMetaDataPolicy(IdentifierScope.SCHEMA).matches("FOO_SCHEMA", "foo_schema", QuoteCharacter.NONE));
+    }
+    
+    @Test
+    void assertRefreshUsesProtocolRuleForSchemaWhenProtocolSchemaUnavailable() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
+        DatabaseIdentifierContextFactory.refresh(actual, MYSQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        assertTrue(actual.getMetaDataPolicy(IdentifierScope.SCHEMA).matches("FOO_SCHEMA", "foo_schema", QuoteCharacter.NONE));
+    }
+    
+    @Test
+    void assertCreateUsesProtocolRuleForSchemaWhenStorageSchemaUnavailable() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(
+                POSTGRESQL_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        assertTrue(actual.getMetaDataPolicy(IdentifierScope.SCHEMA).matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE));
+    }
+    
+    @Test
+    void assertRefreshUsesProtocolRuleForSchemaWhenStorageSchemaUnavailable() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
+        DatabaseIdentifierContextFactory.refresh(actual, POSTGRESQL_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        assertTrue(actual.getMetaDataPolicy(IdentifierScope.SCHEMA).matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE));
     }
     
     @Test
@@ -439,8 +469,10 @@ class DatabaseIdentifierContextFactoryTest {
     private static Stream<Arguments> createWithSupportedDatabaseSchemaLookupArguments() {
         return Stream.of(
                 createNormalizedLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
-                createInsensitiveQuotedExactLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
-                createInsensitiveQuotedExactLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
+                createLowerCaseLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
+                createLowerCaseLookupArguments("postgresql protocol openGauss storage schema", POSTGRESQL_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
+                createLowerCaseLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
+                createLowerCaseLookupArguments("openGauss protocol postgresql storage schema", OPEN_GAUSS_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
                 createUpperCaseLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))
                 .flatMap(each -> each);
     }
@@ -489,8 +521,10 @@ class DatabaseIdentifierContextFactoryTest {
     private static Stream<Arguments> createWithMixedStoredCaseSchemaLookupArguments() {
         return Stream.of(
                 createNormalizedMixedLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
-                createInsensitiveQuotedExactMixedLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
-                createInsensitiveQuotedExactMixedLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
+                createLowerCaseMixedLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
+                createLowerCaseMixedLookupArguments("postgresql protocol openGauss storage schema", POSTGRESQL_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
+                createLowerCaseMixedLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
+                createLowerCaseMixedLookupArguments("openGauss protocol postgresql storage schema", OPEN_GAUSS_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
                 createUpperCaseMixedLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))
                 .flatMap(each -> each);
     }
@@ -553,29 +587,6 @@ class DatabaseIdentifierContextFactoryTest {
     
     private static Optional<String> getExpectedResult(final String expectedName) {
         return null == expectedName ? Optional.empty() : Optional.of(expectedName);
-    }
-    
-    private static Stream<Arguments> createInsensitiveQuotedExactLookupArguments(final String databaseName, final DatabaseType protocolType,
-                                                                                 final ResourceMetaData resourceMetaData, final String lowerActualName,
-                                                                                 final String quoteCharacter) {
-        String upperActualName = lowerActualName.toUpperCase(Locale.ENGLISH);
-        return Stream.of(
-                createLookupArgument(databaseName + " finds lower actual by unquoted lower lookup",
-                        protocolType, resourceMetaData, lowerActualName, lowerActualName, false, quoteCharacter, lowerActualName),
-                createLookupArgument(databaseName + " finds lower actual by unquoted upper lookup",
-                        protocolType, resourceMetaData, lowerActualName, upperActualName, false, quoteCharacter, lowerActualName),
-                createLookupArgument(databaseName + " finds lower actual by quoted lower lookup",
-                        protocolType, resourceMetaData, lowerActualName, lowerActualName, true, quoteCharacter, lowerActualName),
-                createLookupArgument(databaseName + " does not find lower actual by quoted upper lookup",
-                        protocolType, resourceMetaData, lowerActualName, upperActualName, true, quoteCharacter, null),
-                createLookupArgument(databaseName + " finds upper actual by unquoted lower lookup",
-                        protocolType, resourceMetaData, upperActualName, lowerActualName, false, quoteCharacter, upperActualName),
-                createLookupArgument(databaseName + " finds upper actual by unquoted upper lookup",
-                        protocolType, resourceMetaData, upperActualName, upperActualName, false, quoteCharacter, upperActualName),
-                createLookupArgument(databaseName + " does not find upper actual by quoted lower lookup",
-                        protocolType, resourceMetaData, upperActualName, lowerActualName, true, quoteCharacter, null),
-                createLookupArgument(databaseName + " finds upper actual by quoted upper lookup",
-                        protocolType, resourceMetaData, upperActualName, upperActualName, true, quoteCharacter, upperActualName));
     }
     
     private static Stream<Arguments> createNormalizedLookupArguments(final String databaseName, final DatabaseType protocolType, final ResourceMetaData resourceMetaData,
@@ -642,17 +653,6 @@ class DatabaseIdentifierContextFactoryTest {
                         protocolType, resourceMetaData, upperActualName, lowerActualName, true, quoteCharacter, null),
                 createLookupArgument(databaseName + " finds upper actual by quoted upper lookup",
                         protocolType, resourceMetaData, upperActualName, upperActualName, true, quoteCharacter, upperActualName));
-    }
-    
-    private static Stream<Arguments> createInsensitiveQuotedExactMixedLookupArguments(final String databaseName, final DatabaseType protocolType,
-                                                                                      final ResourceMetaData resourceMetaData, final String lowerActualName,
-                                                                                      final String quoteCharacter) {
-        String upperActualName = lowerActualName.toUpperCase(Locale.ENGLISH);
-        return Stream.of(
-                createMixedLookupArgument(databaseName + " finds lower actual by quoted lower lookup", protocolType, resourceMetaData, lowerActualName, true, quoteCharacter, lowerActualName),
-                createMixedLookupArgument(databaseName + " finds upper actual by quoted upper lookup", protocolType, resourceMetaData, upperActualName, true, quoteCharacter, upperActualName),
-                createMixedLookupArgument(databaseName + " finds lower actual by unquoted lower lookup", protocolType, resourceMetaData, lowerActualName, false, quoteCharacter, lowerActualName),
-                createMixedLookupArgument(databaseName + " finds upper actual by unquoted upper lookup", protocolType, resourceMetaData, upperActualName, false, quoteCharacter, upperActualName));
     }
     
     private static Stream<Arguments> createNormalizedMixedLookupArguments(final String databaseName, final DatabaseType protocolType, final ResourceMetaData resourceMetaData,


### PR DESCRIPTION

Changes proposed in this pull request:
  - Respect storage identifier policy for physical schemas

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
