### PR TITLE
Refine MCP LLM E2E discovery and recovery coverage

### DIFF
--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -269,7 +269,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 20
       matrix:
         include:
           - id: http-read-only-query

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/functionality/MySQLMetadataE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/functionality/MySQLMetadataE2ETest.java
@@ -64,6 +64,21 @@ class MySQLMetadataE2ETest extends AbstractMySQLRuntimeE2ETest {
     }
     
     @ParameterizedTest(name = "{0}")
+    @MethodSource("httpTransportCase")
+    void assertReadUnknownDatabaseRecovery(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.readResource("shardingsphere://databases/missing_db");
+            assertTrue(getPayloadItems(actual).isEmpty());
+            assertThat(getObjectOrEmpty(actual.get("empty_state")).get("category"), is("unknown_database"));
+            assertThat(getObjectOrEmpty(actual.get("recovery")).get("category"), is("unknown_database"));
+            Map<String, Object> nextAction = getRequiredObjectList(actual.get("next_actions")).getFirst();
+            assertThat(nextAction.get("type"), is("resource_read"));
+            assertThat(nextAction.get("resource_uri"), is("shardingsphere://databases"));
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
     @MethodSource("singleMetadataResourceCases")
     void assertReadSingleMetadataResource(final String name, final RuntimeTransport transport,
                                           final String resourceUri, final String key, final String expectedValue) throws IOException, InterruptedException {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/LLMHttpE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/LLMHttpE2ETest.java
@@ -185,10 +185,11 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
         if (0 > unscopedSearchIndex) {
             return LLME2EAssertionReport.failure("missing_unscoped_discovery", "The model did not discover metadata without database and schema scope.");
         }
+        int discoveryTurn = trace.get(unscopedSearchIndex).getModelTurn();
         Set<String> actualMetadataNames = new LinkedHashSet<>();
         for (int index = unscopedSearchIndex; index < trace.size(); index++) {
             MCPInteractionTraceRecord each = trace.get(index);
-            if (isValidModelAction(each, "database_gateway_search_metadata")) {
+            if (isValidModelAction(each, "database_gateway_search_metadata") && (unscopedSearchIndex == index || each.getModelTurn() > discoveryTurn)) {
                 actualMetadataNames.addAll(getMetadataNames(each.getStructuredContent()));
             }
         }
@@ -245,7 +246,7 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
         if (0 > recoveryResourceIndex) {
             return LLME2EAssertionReport.failure("missing_resource_recovery", "The model did not follow the stale response recovery action to a live resource containing orders.");
         }
-        Optional<Integer> actualCount = findQueryCount(trace, recoveryResourceIndex + 1);
+        Optional<Integer> actualCount = findQueryCount(trace, trace.get(recoveryResourceIndex).getModelTurn());
         if (actualCount.isEmpty() || getRequiredRuntimeFixture().totalOrders() != actualCount.get()) {
             return LLME2EAssertionReport.failure("query_evidence_mismatch", "The recovered conversation did not obtain the fixture row count from MCP.");
         }
@@ -267,20 +268,25 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
     }
     
     private int findGuidedRecoveryResourceIndex(final List<MCPInteractionTraceRecord> trace, final int staleResourceIndex) {
-        List<Map<String, Object>> nextActions = getObjectList(trace.get(staleResourceIndex).getStructuredContent().get("next_actions"));
-        int recoveryResourceIndex = staleResourceIndex + 1;
-        if (nextActions.isEmpty() || recoveryResourceIndex >= trace.size()) {
+        MCPInteractionTraceRecord staleResource = trace.get(staleResourceIndex);
+        List<Map<String, Object>> nextActions = getObjectList(staleResource.getStructuredContent().get("next_actions"));
+        if (nextActions.isEmpty()) {
             return -1;
         }
         Map<String, Object> recoveryAction = nextActions.getFirst();
-        MCPInteractionTraceRecord recoveryResource = trace.get(recoveryResourceIndex);
-        if (!"resource_read".equals(recoveryAction.get("type"))
-                || !isValidModelAction(recoveryResource, "mcp_read_resource")
-                || !Objects.equals(recoveryAction.get("resource_uri"), recoveryResource.getArguments().get("uri"))
-                || !containsOrdersTable(recoveryResource.getStructuredContent())) {
+        if (!"resource_read".equals(recoveryAction.get("type"))) {
             return -1;
         }
-        return recoveryResourceIndex;
+        for (int index = staleResourceIndex + 1; index < trace.size(); index++) {
+            MCPInteractionTraceRecord each = trace.get(index);
+            if (each.getModelTurn() > staleResource.getModelTurn()
+                    && isValidModelAction(each, "mcp_read_resource")
+                    && Objects.equals(recoveryAction.get("resource_uri"), each.getArguments().get("uri"))
+                    && containsOrdersTable(each.getStructuredContent())) {
+                return index;
+            }
+        }
+        return -1;
     }
     
     private boolean containsOrdersTable(final Map<String, Object> structuredContent) {
@@ -294,10 +300,9 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
                 || expectedCategory.equals(recovery.get("category")) || expectedCategory.equals(recovery.get("recovery_category"));
     }
     
-    private Optional<Integer> findQueryCount(final List<MCPInteractionTraceRecord> trace, final int startIndex) {
-        for (int index = startIndex; index < trace.size(); index++) {
-            MCPInteractionTraceRecord each = trace.get(index);
-            if (!isValidModelAction(each, "database_gateway_execute_query") || !isOrdersCountQuery(each.getArguments())) {
+    private Optional<Integer> findQueryCount(final List<MCPInteractionTraceRecord> trace, final int previousModelTurn) {
+        for (MCPInteractionTraceRecord each : trace) {
+            if (each.getModelTurn() <= previousModelTurn || !isValidModelAction(each, "database_gateway_execute_query") || !isOrdersCountQuery(each.getArguments())) {
                 continue;
             }
             for (Map<String, Object> row : getObjectList(each.getStructuredContent().get("row_objects"))) {
@@ -375,6 +380,7 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
     private void assertTrace(final String scenarioId, final Collection<MCPInteractionTraceRecord> trace) {
         for (MCPInteractionTraceRecord each : trace) {
             assertTrue(0 < each.getSequence(), () -> "Trace sequence must be positive in " + scenarioId);
+            assertTrue(0 < each.getModelTurn(), () -> "Trace model turn must be positive in " + scenarioId);
             assertFalse(each.getActionKind().isBlank(), () -> "Trace action kind is blank in " + scenarioId);
             assertTrue(MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN.equals(each.getActionOrigin()), () -> "Non-model trace action origin in " + scenarioId);
             assertFalse(each.getTargetName().isBlank(), () -> "Trace target name is blank in " + scenarioId);

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/LLMHttpE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/LLMHttpE2ETest.java
@@ -72,7 +72,7 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
     
     private static final String TABLE_NAME = "orders";
     
-    private static final String STALE_TABLE_RESOURCE_URI = "shardingsphere://databases/unknown/schemas/unknown/tables/orders";
+    private static final String STALE_TABLE_RESOURCE_URI = "shardingsphere://databases/logic_db/schemas/logic_db/tables/missing_orders";
     
     private static final Set<String> EXPECTED_METADATA_NAMES = Set.of("active_orders", "order_items", "orders");
     
@@ -181,25 +181,24 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
     }
     
     private LLME2EAssertionReport evaluateMetadataDiscovery(final String answer, final List<MCPInteractionTraceRecord> trace) {
-        boolean unscopedSearchObserved = trace.stream()
-                .filter(each -> isValidModelAction(each, "database_gateway_search_metadata"))
-                .map(MCPInteractionTraceRecord::getArguments)
-                .anyMatch(each -> !each.containsKey("database") && !each.containsKey("schema"));
-        if (!unscopedSearchObserved) {
-            return LLME2EAssertionReport.failure("missing_unscoped_discovery", "The model did not start metadata discovery without database and schema scope.");
+        int unscopedSearchIndex = findUnscopedMetadataSearchIndex(trace);
+        if (0 > unscopedSearchIndex) {
+            return LLME2EAssertionReport.failure("missing_unscoped_discovery", "The model did not discover metadata without database and schema scope.");
         }
-        boolean matchingEvidenceObserved = trace.stream()
-                .filter(each -> isValidModelAction(each, "database_gateway_search_metadata"))
-                .map(MCPInteractionTraceRecord::getStructuredContent)
-                .map(this::getMetadataNames)
-                .anyMatch(EXPECTED_METADATA_NAMES::equals);
-        if (!matchingEvidenceObserved) {
-            return LLME2EAssertionReport.failure("metadata_evidence_mismatch", "No MCP metadata response contained the expected table and view set.");
+        Set<String> actualMetadataNames = new LinkedHashSet<>();
+        for (int index = unscopedSearchIndex; index < trace.size(); index++) {
+            MCPInteractionTraceRecord each = trace.get(index);
+            if (isValidModelAction(each, "database_gateway_search_metadata")) {
+                actualMetadataNames.addAll(getMetadataNames(each.getStructuredContent()));
+            }
+        }
+        if (!EXPECTED_METADATA_NAMES.equals(actualMetadataNames)) {
+            return LLME2EAssertionReport.failure("metadata_evidence_mismatch", "MCP metadata responses did not contain the expected table and view set.");
         }
         String normalizedAnswer = answer.toLowerCase(Locale.ENGLISH);
         return EXPECTED_METADATA_NAMES.stream().allMatch(each -> containsIdentifier(normalizedAnswer, each))
-                ? LLME2EAssertionReport.success("The answer named every object returned by the live MCP metadata search.")
-                : LLME2EAssertionReport.failure("answer_mismatch", "The answer omitted an object returned by the live MCP metadata search.");
+                ? LLME2EAssertionReport.success("The answer named every object returned by the live MCP metadata searches.")
+                : LLME2EAssertionReport.failure("answer_mismatch", "The answer omitted an object returned by the live MCP metadata searches.");
     }
     
     private LLME2EAssertionReport evaluateSideEffectPreview(final String answer, final List<MCPInteractionTraceRecord> trace, final String statusBefore) {
@@ -242,11 +241,11 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
         if (0 > staleResourceIndex) {
             return LLME2EAssertionReport.failure("missing_stale_resource_error", "The model did not observe the stale resource error.");
         }
-        int liveResourceIndex = findLiveTableResourceIndex(trace, staleResourceIndex + 1);
-        if (0 > liveResourceIndex) {
-            return LLME2EAssertionReport.failure("missing_resource_recovery", "The model did not discover and read the live orders resource after the stale error.");
+        int recoveryResourceIndex = findGuidedRecoveryResourceIndex(trace, staleResourceIndex);
+        if (0 > recoveryResourceIndex) {
+            return LLME2EAssertionReport.failure("missing_resource_recovery", "The model did not follow the stale response recovery action to a live resource containing orders.");
         }
-        Optional<Integer> actualCount = findQueryCount(trace, liveResourceIndex + 1);
+        Optional<Integer> actualCount = findQueryCount(trace, recoveryResourceIndex + 1);
         if (actualCount.isEmpty() || getRequiredRuntimeFixture().totalOrders() != actualCount.get()) {
             return LLME2EAssertionReport.failure("query_evidence_mismatch", "The recovered conversation did not obtain the fixture row count from MCP.");
         }
@@ -260,23 +259,28 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
             MCPInteractionTraceRecord each = trace.get(index);
             if (isValidModelAction(each, "mcp_read_resource")
                     && STALE_TABLE_RESOURCE_URI.equals(each.getArguments().get("uri"))
-                    && hasRecoveryCategory(each.getStructuredContent(), "unknown_database")) {
+                    && hasRecoveryCategory(each.getStructuredContent(), "object_not_visible")) {
                 return index;
             }
         }
         return -1;
     }
     
-    private int findLiveTableResourceIndex(final List<MCPInteractionTraceRecord> trace, final int startIndex) {
-        for (int index = startIndex; index < trace.size(); index++) {
-            MCPInteractionTraceRecord each = trace.get(index);
-            if (isValidModelAction(each, "mcp_read_resource")
-                    && !STALE_TABLE_RESOURCE_URI.equals(each.getArguments().get("uri"))
-                    && containsOrdersTable(each.getStructuredContent())) {
-                return index;
-            }
+    private int findGuidedRecoveryResourceIndex(final List<MCPInteractionTraceRecord> trace, final int staleResourceIndex) {
+        List<Map<String, Object>> nextActions = getObjectList(trace.get(staleResourceIndex).getStructuredContent().get("next_actions"));
+        int recoveryResourceIndex = staleResourceIndex + 1;
+        if (nextActions.isEmpty() || recoveryResourceIndex >= trace.size()) {
+            return -1;
         }
-        return -1;
+        Map<String, Object> recoveryAction = nextActions.getFirst();
+        MCPInteractionTraceRecord recoveryResource = trace.get(recoveryResourceIndex);
+        if (!"resource_read".equals(recoveryAction.get("type"))
+                || !isValidModelAction(recoveryResource, "mcp_read_resource")
+                || !Objects.equals(recoveryAction.get("resource_uri"), recoveryResource.getArguments().get("uri"))
+                || !containsOrdersTable(recoveryResource.getStructuredContent())) {
+            return -1;
+        }
+        return recoveryResourceIndex;
     }
     
     private boolean containsOrdersTable(final Map<String, Object> structuredContent) {
@@ -327,6 +331,18 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
             }
         }
         return result;
+    }
+    
+    private int findUnscopedMetadataSearchIndex(final List<MCPInteractionTraceRecord> trace) {
+        for (int index = 0; index < trace.size(); index++) {
+            MCPInteractionTraceRecord each = trace.get(index);
+            if (isValidModelAction(each, "database_gateway_search_metadata")
+                    && !each.getArguments().containsKey("database") && !each.getArguments().containsKey("schema")
+                    && getObjectList(each.getStructuredContent().get("items")).stream().anyMatch(item -> DATABASE_NAME.equals(item.get("database")))) {
+                return index;
+            }
+        }
+        return -1;
     }
     
     private boolean isValidModelAction(final MCPInteractionTraceRecord traceRecord, final String actionName) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMConversationRunner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMConversationRunner.java
@@ -125,7 +125,7 @@ public final class LLMConversationRunner {
                 .map(each -> LLMMCPJsonValues.castToMap(each.get("function")))
                 .map(each -> String.valueOf(each.get("name")))
                 .collect(Collectors.toSet());
-        for (int i = 0; i < maxTurns; i++) {
+        for (int turnIndex = 0; turnIndex < maxTurns; turnIndex++) {
             LLMChatCompletion completion;
             try {
                 completion = llmChatClient.complete(messages, toolDefinitions, "auto", false);
@@ -138,7 +138,7 @@ public final class LLMConversationRunner {
                 return createFinalResult(scenario, completion.getContent(), artifacts);
             }
             messages.add(LLMChatMessage.assistant(completion.getContent(), completion.getToolCalls()));
-            Optional<Result> failure = executeToolCalls(scenario, completion.getToolCalls(), messages, artifacts, availableToolNames);
+            Optional<Result> failure = executeToolCalls(scenario, turnIndex + 1, completion.getToolCalls(), messages, artifacts, availableToolNames);
             if (failure.isPresent()) {
                 return failure.get();
             }
@@ -147,11 +147,11 @@ public final class LLMConversationRunner {
                 LLME2EAssertionReport.failure("turn_limit_exhausted", "Model did not produce a final answer within the configured turn limit."));
     }
     
-    private Optional<Result> executeToolCalls(final Scenario scenario, final List<LLMToolCall> toolCalls, final List<LLMChatMessage> messages,
+    private Optional<Result> executeToolCalls(final Scenario scenario, final int modelTurn, final List<LLMToolCall> toolCalls, final List<LLMChatMessage> messages,
                                               final ConversationArtifacts artifacts, final Set<String> availableToolNames) throws InterruptedException {
         for (LLMToolCall each : toolCalls) {
             if (!availableToolNames.contains(each.getName())) {
-                artifacts.addTrace(MCPInteractionTraceRecord.createInvalidAction(artifacts.nextSequence(), TOOL_CALL_KIND, each.getName(),
+                artifacts.addTrace(MCPInteractionTraceRecord.createInvalidAction(artifacts.nextSequence(), modelTurn, TOOL_CALL_KIND, each.getName(),
                         Map.of("rawArgumentsJson", each.getArgumentsJson()), "unexpected_tool_requested"));
                 return Optional.of(artifacts.createResult(scenario, modelName,
                         LLME2EAssertionReport.failure("unexpected_tool_requested", "Model requested a tool that was not advertised for this scenario.")));
@@ -160,7 +160,7 @@ public final class LLMConversationRunner {
             try {
                 arguments = LLMMCPJsonValues.parseToolArguments(each.getArgumentsJson());
             } catch (final IllegalArgumentException ex) {
-                artifacts.addTrace(MCPInteractionTraceRecord.createInvalidAction(artifacts.nextSequence(), TOOL_CALL_KIND, each.getName(),
+                artifacts.addTrace(MCPInteractionTraceRecord.createInvalidAction(artifacts.nextSequence(), modelTurn, TOOL_CALL_KIND, each.getName(),
                         Map.of("rawArgumentsJson", each.getArgumentsJson()), "invalid_tool_arguments"));
                 return Optional.of(artifacts.createResult(scenario, modelName,
                         LLME2EAssertionReport.failure("invalid_tool_arguments", "Model returned invalid tool arguments JSON.")));
@@ -169,7 +169,7 @@ public final class LLMConversationRunner {
             if (validationFailure.isPresent()) {
                 LLMMCPToolCallValidationFailure failure = validationFailure.get();
                 artifacts.addTrace(MCPInteractionTraceRecord.createInvalidAction(
-                        artifacts.nextSequence(), getActionKind(each.getName()), each.getName(), arguments, failure.getFailureType()));
+                        artifacts.nextSequence(), modelTurn, getActionKind(each.getName()), each.getName(), arguments, failure.getFailureType()));
                 return Optional.of(artifacts.createResult(scenario, modelName,
                         LLME2EAssertionReport.failure(failure.getFailureType(), failure.getMessage())));
             }
@@ -178,7 +178,8 @@ public final class LLMConversationRunner {
             try {
                 response = actionExecutor.executeSafely(each.getName(), arguments);
             } catch (final IllegalArgumentException ex) {
-                artifacts.addTrace(MCPInteractionTraceRecord.createInvalidAction(artifacts.nextSequence(), TOOL_CALL_KIND, each.getName(), arguments, "invalid_tool_arguments"));
+                artifacts.addTrace(MCPInteractionTraceRecord.createInvalidAction(
+                        artifacts.nextSequence(), modelTurn, TOOL_CALL_KIND, each.getName(), arguments, "invalid_tool_arguments"));
                 return Optional.of(artifacts.createResult(scenario, modelName,
                         LLME2EAssertionReport.failure("invalid_tool_arguments", ex.getMessage())));
             } catch (final IllegalStateException ex) {
@@ -187,7 +188,7 @@ public final class LLMConversationRunner {
             }
             long latencyMillis = System.currentTimeMillis() - startTime;
             artifacts.addTrace(new MCPInteractionTraceRecord(
-                    artifacts.nextSequence(), getActionKind(each.getName()), MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN,
+                    artifacts.nextSequence(), modelTurn, getActionKind(each.getName()), MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN,
                     each.getName(), getTraceArguments(each.getName(), arguments), response, true, latencyMillis));
             artifacts.addRuntimeLogLine("action=" + each.getName() + " args=" + JsonUtils.toJsonString(arguments));
             artifacts.addRuntimeLogLine("response=" + JsonUtils.toJsonString(response));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/MCPInteractionTraceRecord.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/MCPInteractionTraceRecord.java
@@ -33,6 +33,8 @@ public final class MCPInteractionTraceRecord {
     
     private final int sequence;
     
+    private final int modelTurn;
+    
     private final String actionKind;
     
     private final String actionOrigin;
@@ -51,14 +53,15 @@ public final class MCPInteractionTraceRecord {
      * Create invalid action.
      *
      * @param sequence sequence
+     * @param modelTurn model turn
      * @param actionKind action kind
      * @param targetName target name
      * @param arguments arguments
      * @param failureType failure type
      * @return interaction trace record
      */
-    public static MCPInteractionTraceRecord createInvalidAction(final int sequence, final String actionKind, final String targetName,
+    public static MCPInteractionTraceRecord createInvalidAction(final int sequence, final int modelTurn, final String actionKind, final String targetName,
                                                                 final Map<String, Object> arguments, final String failureType) {
-        return new MCPInteractionTraceRecord(sequence, actionKind, MODEL_TOOL_CALL_ORIGIN, targetName, arguments, Map.of("error_code", failureType), false, 0L);
+        return new MCPInteractionTraceRecord(sequence, modelTurn, actionKind, MODEL_TOOL_CALL_ORIGIN, targetName, arguments, Map.of("error_code", failureType), false, 0L);
     }
 }


### PR DESCRIPTION
- aggregate metadata evidence after unscoped discovery
- validate guided invalid-resource recovery while preserving unknown database coverage
- run all MCP LLM E2E scenarios in parallel
