### PR TITLE
Preserve whitespace in DistSQL properties

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/enums/QuoteCharacter.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/enums/QuoteCharacter.java
@@ -106,16 +106,4 @@ public enum QuoteCharacter {
     public static String unwrapText(final String text) {
         return getQuoteCharacter(text).unwrap(text);
     }
-    
-    /**
-     * Unwrap and trim text.
-     *
-     * @param text text to be unwrapped and trimmed
-     * @return unwrapped and trimmed test
-     */
-    // TODO Should use unwrap instead of this method after new rules defined in G4's property key and property key, which should include string but cannot permit blank on first and last of the value
-    // TODO @longtao
-    public static String unwrapAndTrimText(final String text) {
-        return unwrapText(text).trim();
-    }
 }

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/database/enums/QuoteCharacterTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/database/enums/QuoteCharacterTest.java
@@ -58,11 +58,6 @@ class QuoteCharacterTest {
         assertThat(QuoteCharacter.unwrapText(text), is(expectedText));
     }
     
-    @Test
-    void assertUnwrapAndTrimText() {
-        assertThat(QuoteCharacter.unwrapAndTrimText("` test `"), is("test"));
-    }
-    
     private static Stream<Arguments> getQuoteCharacterArguments() {
         return Stream.of(
                 Arguments.of("null value", null, QuoteCharacter.NONE),
@@ -98,6 +93,7 @@ class QuoteCharacterTest {
                 Arguments.of("double quote text", "\"test\"", "test"),
                 Arguments.of("brackets text", "[test]", "test"),
                 Arguments.of("parentheses text", "(test)", "test"),
+                Arguments.of("single quote text with boundary whitespace", "' test '", " test "),
                 Arguments.of("unrecognized wrapper text", "{test}", "{test}"),
                 Arguments.of("unmatched back quote text", "`test'", "`test'"));
     }

--- a/features/encrypt/distsql/parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLStatementVisitor.java
+++ b/features/encrypt/distsql/parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLStatementVisitor.java
@@ -119,7 +119,7 @@ public final class EncryptDistSQLStatementVisitor extends EncryptDistSQLStatemen
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/features/mask/distsql/parser/src/main/java/org/apache/shardingsphere/mask/distsql/parser/core/MaskDistSQLStatementVisitor.java
+++ b/features/mask/distsql/parser/src/main/java/org/apache/shardingsphere/mask/distsql/parser/core/MaskDistSQLStatementVisitor.java
@@ -102,7 +102,7 @@ public final class MaskDistSQLStatementVisitor extends MaskDistSQLStatementBaseV
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/features/readwrite-splitting/distsql/parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLStatementVisitor.java
+++ b/features/readwrite-splitting/distsql/parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLStatementVisitor.java
@@ -122,7 +122,7 @@ public final class ReadwriteSplittingDistSQLStatementVisitor extends ReadwriteSp
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/features/shadow/distsql/parser/src/main/java/org/apache/shardingsphere/shadow/distsql/parser/core/ShadowDistSQLStatementVisitor.java
+++ b/features/shadow/distsql/parser/src/main/java/org/apache/shardingsphere/shadow/distsql/parser/core/ShadowDistSQLStatementVisitor.java
@@ -125,7 +125,7 @@ public final class ShadowDistSQLStatementVisitor extends ShadowDistSQLStatementB
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -391,7 +391,7 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/features/sharding/distsql/parser/src/test/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitorTest.java
+++ b/features/sharding/distsql/parser/src/test/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitorTest.java
@@ -66,10 +66,11 @@ class ShardingDistSQLStatementVisitorTest {
     @Test
     void assertCreateKeyGenerator() {
         CreateShardingKeyGeneratorStatement actual = (CreateShardingKeyGeneratorStatement) parse(
-                "CREATE SHARDING KEY GENERATOR snowflake_generator (TYPE(NAME='SNOWFLAKE', PROPERTIES('worker-id'=1)))");
+                "CREATE SHARDING KEY GENERATOR snowflake_generator (TYPE(NAME='SNOWFLAKE', PROPERTIES('worker-id'=1, ' foo_key '=' bar_value ')))");
         assertThat(actual.getName(), is("snowflake_generator"));
         assertThat(actual.getAlgorithmSegment().getName(), is("SNOWFLAKE"));
         assertThat(actual.getAlgorithmSegment().getProps().getProperty("worker-id"), is("1"));
+        assertThat(actual.getAlgorithmSegment().getProps().getProperty(" foo_key "), is(" bar_value "));
     }
     
     @Test

--- a/kernel/data-pipeline/scenario/cdc/distsql/parser/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/distsql/parser/core/CDCDistSQLStatementVisitor.java
+++ b/kernel/data-pipeline/scenario/cdc/distsql/parser/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/distsql/parser/core/CDCDistSQLStatementVisitor.java
@@ -141,7 +141,7 @@ public final class CDCDistSQLStatementVisitor extends CDCDistSQLStatementBaseVis
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/kernel/data-pipeline/scenario/migration/distsql/parser/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/distsql/parser/core/MigrationDistSQLStatementVisitor.java
+++ b/kernel/data-pipeline/scenario/migration/distsql/parser/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/distsql/parser/core/MigrationDistSQLStatementVisitor.java
@@ -253,7 +253,7 @@ public final class MigrationDistSQLStatementVisitor extends MigrationDistSQLStat
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/kernel/global-clock/distsql/parser/src/main/java/org/apache/shardingsphere/globalclock/distsql/parser/core/GlobalClockDistSQLStatementVisitor.java
+++ b/kernel/global-clock/distsql/parser/src/main/java/org/apache/shardingsphere/globalclock/distsql/parser/core/GlobalClockDistSQLStatementVisitor.java
@@ -56,7 +56,7 @@ public final class GlobalClockDistSQLStatementVisitor extends GlobalClockDistSQL
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/kernel/sql-translator/distsql/parser/src/main/java/org/apache/shardingsphere/sqltranslator/distsql/parser/core/SQLTranslatorDistSQLStatementVisitor.java
+++ b/kernel/sql-translator/distsql/parser/src/main/java/org/apache/shardingsphere/sqltranslator/distsql/parser/core/SQLTranslatorDistSQLStatementVisitor.java
@@ -61,7 +61,7 @@ public final class SQLTranslatorDistSQLStatementVisitor extends SQLTranslatorDis
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/kernel/transaction/distsql/parser/src/main/java/org/apache/shardingsphere/transaction/distsql/parser/core/TransactionDistSQLStatementVisitor.java
+++ b/kernel/transaction/distsql/parser/src/main/java/org/apache/shardingsphere/transaction/distsql/parser/core/TransactionDistSQLStatementVisitor.java
@@ -66,7 +66,7 @@ public final class TransactionDistSQLStatementVisitor extends TransactionDistSQL
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }

--- a/parser/distsql/engine/src/main/java/org/apache/shardingsphere/distsql/parser/core/kernel/KernelDistSQLStatementVisitor.java
+++ b/parser/distsql/engine/src/main/java/org/apache/shardingsphere/distsql/parser/core/kernel/KernelDistSQLStatementVisitor.java
@@ -189,7 +189,7 @@ public final class KernelDistSQLStatementVisitor extends KernelDistSQLStatementB
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }
@@ -306,7 +306,7 @@ public final class KernelDistSQLStatementVisitor extends KernelDistSQLStatementB
             return result;
         }
         for (PropertyContext each : ctx.properties().property()) {
-            result.setProperty(QuoteCharacter.unwrapAndTrimText(each.key.getText()), QuoteCharacter.unwrapAndTrimText(each.value.getText()));
+            result.setProperty(QuoteCharacter.unwrapText(each.key.getText()), QuoteCharacter.unwrapText(each.value.getText()));
         }
         return result;
     }


### PR DESCRIPTION
Replace trim-based property unwrapping with QuoteCharacter.unwrapText across DistSQL visitors. Remove the obsolete unwrapAndTrimText method and cover quoted boundary whitespace.
