### PR TITLE
Align MCP LLM invalid resource recovery scenario

### DIFF
--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/LLMHttpE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/LLMHttpE2ETest.java
@@ -146,8 +146,8 @@ class LLMHttpE2ETest extends AbstractConfigBackedRuntimeE2ETest {
     void assertInvalidResourceRecovery() throws IOException {
         runScenario(new Scenario(
                 "invalid-resource-recovery",
-                "A user pasted stale resource `" + STALE_TABLE_RESOURCE_URI + "`. Inspect that resource, recover using live MCP context without assuming the correct URI, "
-                        + "and report how many rows are currently in the orders table.",
+                "A user pasted stale resource `" + STALE_TABLE_RESOURCE_URI + "`. Inspect that resource, then follow the first safe read-only action in its top-level "
+                        + "`next_actions` by reading its `resource_uri` exactly. Do not guess another URI. Then report how many rows are currently in the orders table.",
                 false,
                 this::evaluateInvalidResourceRecovery));
     }


### PR DESCRIPTION
Require the model to follow the first safe top-level next_action resource URI instead of guessing a recovery path.