### PR TITLE
Remove obsolete TODO from Oracle metadata loader

### DIFF
--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
@@ -236,7 +236,6 @@ public final class OracleMetaDataLoader implements DialectMetaDataLoader {
     }
     
     private String getIndexMetaDataSQL(final Collection<String> tableNames) {
-        // TODO The table name needs to be in uppercase, otherwise the index cannot be found.
         return String.format(INDEX_META_DATA_SQL, tableNames.stream().map(each -> String.format("'%s'", each)).collect(Collectors.joining(",")));
     }
     


### PR DESCRIPTION
Oracle table names are normalized with the storage identifier policy before metadata loading.