### PR TITLE
Fix Oracle pre-12.2 column case sensitivity

### DIFF
--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
@@ -29,7 +29,9 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.model.Tab
 import org.apache.shardingsphere.database.connector.core.metadata.database.datatype.DataTypeRegistry;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.connector.oracle.metadata.database.option.OracleDataTypeOption;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 
 import java.sql.Connection;
@@ -80,6 +82,8 @@ public final class OracleMetaDataLoader implements DialectMetaDataLoader {
     private static final int IDENTITY_COLUMN_START_MINOR_VERSION = 1;
     
     private static final int MAX_EXPRESSION_SIZE = 1000;
+    
+    private final DialectDataTypeOption dataTypeOption = new OracleDataTypeOption();
     
     @Override
     public Collection<SchemaMetaData> load(final MetaDataLoaderMaterial material) throws SQLException {
@@ -146,18 +150,24 @@ public final class OracleMetaDataLoader implements DialectMetaDataLoader {
     
     private ColumnMetaData loadColumnMetaData(final ResultSet resultSet, final Collection<String> primaryKeys, final DatabaseMetaData databaseMetaData) throws SQLException {
         String columnName = resultSet.getString("COLUMN_NAME");
-        String dataType = getOriginalDataType(resultSet.getString("DATA_TYPE"));
+        String dataTypeName = getOriginalDataType(resultSet.getString("DATA_TYPE"));
+        int dataType = DataTypeRegistry.getDataType(getDatabaseType(), dataTypeName).orElse(Types.OTHER);
         boolean primaryKey = primaryKeys.contains(columnName);
         boolean generated = versionContainsIdentityColumn(databaseMetaData) && "YES".equals(resultSet.getString("IDENTITY_COLUMN"));
-        String collation = versionContainsCollation(databaseMetaData) ? resultSet.getString("COLLATION") : null;
-        boolean caseSensitive = null != collation && isCaseSensitive(collation);
+        boolean collationSupported = versionContainsCollation(databaseMetaData);
+        String collation = collationSupported ? resultSet.getString("COLLATION") : null;
+        boolean caseSensitive = isResolveCaseSensitive(dataType, collation, collationSupported);
         boolean isVisible = "NO".equals(resultSet.getString("HIDDEN_COLUMN"));
         boolean nullable = "Y".equals(resultSet.getString("NULLABLE"));
-        return new ColumnMetaData(columnName, DataTypeRegistry.getDataType(getDatabaseType(), dataType).orElse(Types.OTHER), primaryKey, generated, caseSensitive, isVisible, false, nullable);
+        return new ColumnMetaData(columnName, dataType, primaryKey, generated, caseSensitive, isVisible, false, nullable);
+    }
+    
+    private boolean isResolveCaseSensitive(final int dataType, final String collation, final boolean collationSupported) {
+        // TODO Resolve case sensitivity from session parameters for Oracle versions earlier than 12.2 and session-dependent collations.
+        return collationSupported ? null != collation && isCaseSensitive(collation) : dataTypeOption.isStringDataType(dataType);
     }
     
     private boolean isCaseSensitive(final String collation) {
-        // TODO Support case sensitivity resolved from session parameters for Oracle versions earlier than 12.2 and session-dependent collations.
         if ("USING_NLS_COMP".equals(collation) || "USING_NLS_SORT".equals(collation)) {
             return false;
         }

--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
@@ -156,13 +156,13 @@ public final class OracleMetaDataLoader implements DialectMetaDataLoader {
         boolean generated = versionContainsIdentityColumn(databaseMetaData) && "YES".equals(resultSet.getString("IDENTITY_COLUMN"));
         boolean collationSupported = versionContainsCollation(databaseMetaData);
         String collation = collationSupported ? resultSet.getString("COLLATION") : null;
-        boolean caseSensitive = isResolveCaseSensitive(dataType, collation, collationSupported);
+        boolean caseSensitive = isCaseSensitive(dataType, collation, collationSupported);
         boolean isVisible = "NO".equals(resultSet.getString("HIDDEN_COLUMN"));
         boolean nullable = "Y".equals(resultSet.getString("NULLABLE"));
         return new ColumnMetaData(columnName, dataType, primaryKey, generated, caseSensitive, isVisible, false, nullable);
     }
     
-    private boolean isResolveCaseSensitive(final int dataType, final String collation, final boolean collationSupported) {
+    private boolean isCaseSensitive(final int dataType, final String collation, final boolean collationSupported) {
         // TODO Resolve case sensitivity from session parameters for Oracle versions earlier than 12.2 and session-dependent collations.
         return collationSupported ? null != collation && isCaseSensitive(collation) : dataTypeOption.isStringDataType(dataType);
     }

--- a/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoaderTest.java
+++ b/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoaderTest.java
@@ -257,12 +257,12 @@ class OracleMetaDataLoaderTest {
     private static Stream<Arguments> assertLoadArguments() {
         return Stream.of(
                 Arguments.of("major12Minor2WithoutPrimaryKey", 12, 2, false, "BINARY", true),
-                Arguments.of("major12Minor1WithoutPrimaryKey", 12, 1, false, NO_COLLATION, false),
-                Arguments.of("major11Minor2WithoutPrimaryKey", 11, 2, false, NO_COLLATION, false),
-                Arguments.of("major12Minor0WithoutPrimaryKey", 12, 0, false, NO_COLLATION, false),
+                Arguments.of("major12Minor1WithoutPrimaryKey", 12, 1, false, NO_COLLATION, true),
+                Arguments.of("major11Minor2WithoutPrimaryKey", 11, 2, false, NO_COLLATION, true),
+                Arguments.of("major12Minor0WithoutPrimaryKey", 12, 0, false, NO_COLLATION, true),
                 Arguments.of("major12Minor2WithPrimaryKey", 12, 2, true, "BINARY", true),
-                Arguments.of("major12Minor1WithPrimaryKey", 12, 1, true, NO_COLLATION, false),
-                Arguments.of("major11Minor2WithPrimaryKey", 11, 2, true, NO_COLLATION, false),
+                Arguments.of("major12Minor1WithPrimaryKey", 12, 1, true, NO_COLLATION, true),
+                Arguments.of("major11Minor2WithPrimaryKey", 11, 2, true, NO_COLLATION, true),
                 Arguments.of("major19Minor0WithPrimaryKey", 19, 0, true, "BINARY", true),
                 Arguments.of("major12Minor2WithNullCollation", 12, 2, true, NO_COLLATION, false),
                 Arguments.of("major12Minor2WithNamedCollation", 12, 2, true, "FRENCH", true),


### PR DESCRIPTION
Use Oracle's default case-sensitive behavior for character columns when COLLATION metadata is unavailable before version 12.2.

Reuse the Oracle data type classification for non-character columns and preserve the existing 12.2+ collation handling.
