### PR TITLE
Simplify MCP validation and verify runtime limits

### DIFF
--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -311,6 +311,8 @@ jobs:
           restore-maven-repository: 'false'
           docker-image-archives: mcp-llm-runtime-image.tar
       - name: Run MCP LLM E2E
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: 'true'
         run: ./mvnw -pl test/e2e/mcp test -Pe2e.mcp.llm -DskipITs -Dspotless.skip=true -Dtest='${{ matrix.test }}' -Dmcp.llm.artifact-root="${{ github.workspace }}/test/e2e/mcp/target/llm-e2e" -Dmcp.llm.run-id=gha-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.id }} -B -ntp
       - name: Upload MCP LLM E2E Artifacts
         if: always()

--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
@@ -29,7 +29,9 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.model.Tab
 import org.apache.shardingsphere.database.connector.core.metadata.database.datatype.DataTypeRegistry;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.connector.oracle.metadata.database.option.OracleDataTypeOption;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 
 import java.sql.Connection;
@@ -80,6 +82,8 @@ public final class OracleMetaDataLoader implements DialectMetaDataLoader {
     private static final int IDENTITY_COLUMN_START_MINOR_VERSION = 1;
     
     private static final int MAX_EXPRESSION_SIZE = 1000;
+    
+    private final DialectDataTypeOption dataTypeOption = new OracleDataTypeOption();
     
     @Override
     public Collection<SchemaMetaData> load(final MetaDataLoaderMaterial material) throws SQLException {
@@ -146,18 +150,24 @@ public final class OracleMetaDataLoader implements DialectMetaDataLoader {
     
     private ColumnMetaData loadColumnMetaData(final ResultSet resultSet, final Collection<String> primaryKeys, final DatabaseMetaData databaseMetaData) throws SQLException {
         String columnName = resultSet.getString("COLUMN_NAME");
-        String dataType = getOriginalDataType(resultSet.getString("DATA_TYPE"));
+        String dataTypeName = getOriginalDataType(resultSet.getString("DATA_TYPE"));
+        int dataType = DataTypeRegistry.getDataType(getDatabaseType(), dataTypeName).orElse(Types.OTHER);
         boolean primaryKey = primaryKeys.contains(columnName);
         boolean generated = versionContainsIdentityColumn(databaseMetaData) && "YES".equals(resultSet.getString("IDENTITY_COLUMN"));
-        String collation = versionContainsCollation(databaseMetaData) ? resultSet.getString("COLLATION") : null;
-        boolean caseSensitive = null != collation && isCaseSensitive(collation);
+        boolean collationSupported = versionContainsCollation(databaseMetaData);
+        String collation = collationSupported ? resultSet.getString("COLLATION") : null;
+        boolean caseSensitive = isResolveCaseSensitive(dataType, collation, collationSupported);
         boolean isVisible = "NO".equals(resultSet.getString("HIDDEN_COLUMN"));
         boolean nullable = "Y".equals(resultSet.getString("NULLABLE"));
-        return new ColumnMetaData(columnName, DataTypeRegistry.getDataType(getDatabaseType(), dataType).orElse(Types.OTHER), primaryKey, generated, caseSensitive, isVisible, false, nullable);
+        return new ColumnMetaData(columnName, dataType, primaryKey, generated, caseSensitive, isVisible, false, nullable);
+    }
+    
+    private boolean isResolveCaseSensitive(final int dataType, final String collation, final boolean collationSupported) {
+        // TODO Resolve case sensitivity from session parameters for Oracle versions earlier than 12.2 and session-dependent collations.
+        return collationSupported ? null != collation && isCaseSensitive(collation) : dataTypeOption.isStringDataType(dataType);
     }
     
     private boolean isCaseSensitive(final String collation) {
-        // TODO Support case sensitivity resolved from session parameters for Oracle versions earlier than 12.2 and session-dependent collations.
         if ("USING_NLS_COMP".equals(collation) || "USING_NLS_SORT".equals(collation)) {
             return false;
         }

--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoader.java
@@ -156,13 +156,13 @@ public final class OracleMetaDataLoader implements DialectMetaDataLoader {
         boolean generated = versionContainsIdentityColumn(databaseMetaData) && "YES".equals(resultSet.getString("IDENTITY_COLUMN"));
         boolean collationSupported = versionContainsCollation(databaseMetaData);
         String collation = collationSupported ? resultSet.getString("COLLATION") : null;
-        boolean caseSensitive = isResolveCaseSensitive(dataType, collation, collationSupported);
+        boolean caseSensitive = isCaseSensitive(dataType, collation, collationSupported);
         boolean isVisible = "NO".equals(resultSet.getString("HIDDEN_COLUMN"));
         boolean nullable = "Y".equals(resultSet.getString("NULLABLE"));
         return new ColumnMetaData(columnName, dataType, primaryKey, generated, caseSensitive, isVisible, false, nullable);
     }
     
-    private boolean isResolveCaseSensitive(final int dataType, final String collation, final boolean collationSupported) {
+    private boolean isCaseSensitive(final int dataType, final String collation, final boolean collationSupported) {
         // TODO Resolve case sensitivity from session parameters for Oracle versions earlier than 12.2 and session-dependent collations.
         return collationSupported ? null != collation && isCaseSensitive(collation) : dataTypeOption.isStringDataType(dataType);
     }

--- a/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoaderTest.java
+++ b/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/data/loader/OracleMetaDataLoaderTest.java
@@ -257,12 +257,12 @@ class OracleMetaDataLoaderTest {
     private static Stream<Arguments> assertLoadArguments() {
         return Stream.of(
                 Arguments.of("major12Minor2WithoutPrimaryKey", 12, 2, false, "BINARY", true),
-                Arguments.of("major12Minor1WithoutPrimaryKey", 12, 1, false, NO_COLLATION, false),
-                Arguments.of("major11Minor2WithoutPrimaryKey", 11, 2, false, NO_COLLATION, false),
-                Arguments.of("major12Minor0WithoutPrimaryKey", 12, 0, false, NO_COLLATION, false),
+                Arguments.of("major12Minor1WithoutPrimaryKey", 12, 1, false, NO_COLLATION, true),
+                Arguments.of("major11Minor2WithoutPrimaryKey", 11, 2, false, NO_COLLATION, true),
+                Arguments.of("major12Minor0WithoutPrimaryKey", 12, 0, false, NO_COLLATION, true),
                 Arguments.of("major12Minor2WithPrimaryKey", 12, 2, true, "BINARY", true),
-                Arguments.of("major12Minor1WithPrimaryKey", 12, 1, true, NO_COLLATION, false),
-                Arguments.of("major11Minor2WithPrimaryKey", 11, 2, true, NO_COLLATION, false),
+                Arguments.of("major12Minor1WithPrimaryKey", 12, 1, true, NO_COLLATION, true),
+                Arguments.of("major11Minor2WithPrimaryKey", 11, 2, true, NO_COLLATION, true),
                 Arguments.of("major19Minor0WithPrimaryKey", 19, 0, true, "BINARY", true),
                 Arguments.of("major12Minor2WithNullCollation", 12, 2, true, NO_COLLATION, false),
                 Arguments.of("major12Minor2WithNamedCollation", 12, 2, true, "FRENCH", true),

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/ToolDefinitionRegistryTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/ToolDefinitionRegistryTest.java
@@ -35,6 +35,7 @@ import org.apache.shardingsphere.mcp.core.protocol.exception.MCPToolArgumentCont
 import org.apache.shardingsphere.mcp.core.protocol.exception.UnsupportedToolException;
 import org.apache.shardingsphere.mcp.core.resource.ResourceTestDataFactory;
 import org.apache.shardingsphere.mcp.core.resource.ResourceTestDataFactory.RequestContextFixture;
+import org.apache.shardingsphere.mcp.support.security.MCPRuntimeProtectionPolicy;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.internal.configuration.plugins.Plugins;
@@ -79,6 +80,20 @@ class ToolDefinitionRegistryTest {
         assertRequiredFields(actual.get(5), List.of("plan_id", "execution_mode"));
         assertField(actual.get(5), "execution_mode", "string", List.of("preview", "review-then-execute", "manual-only"), true);
         assertField(actual.get(5), "approved_steps", "array", List.of(), false);
+    }
+    
+    @Test
+    void assertGetSupportedToolDescriptorsWithRuntimeProtectionLimits() {
+        List<MCPToolDescriptor> descriptors = ToolDefinitionRegistry.getSupportedToolDescriptors();
+        for (String each : List.of("database_gateway_execute_query", "database_gateway_execute_explain_query", "database_gateway_execute_update")) {
+            MCPToolDescriptor descriptor = descriptors.stream().filter(tool -> each.equals(tool.getName())).findFirst().orElseThrow();
+            Map<?, ?> actualMaxRows = findField(descriptor, "max_rows");
+            assertThat(actualMaxRows.get("default"), is(MCPRuntimeProtectionPolicy.DEFAULT_MAX_ROWS));
+            assertThat(actualMaxRows.get("maximum"), is(MCPRuntimeProtectionPolicy.MAX_ROWS_LIMIT));
+            Map<?, ?> actualTimeout = findField(descriptor, "timeout_ms");
+            assertThat(actualTimeout.get("default"), is(MCPRuntimeProtectionPolicy.DEFAULT_TIMEOUT_MILLISECONDS));
+            assertThat(actualTimeout.get("maximum"), is(MCPRuntimeProtectionPolicy.MAX_TIMEOUT_MILLISECONDS));
+        }
     }
     
     @Test

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowValidationService.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowValidationService.java
@@ -75,10 +75,11 @@ public final class BroadcastWorkflowValidationService implements MCPWorkflowRunt
                                             final ValidationReport validationReport, final MCPFeatureQueryFacade queryFacade) {
         BroadcastWorkflowRequest request = (BroadcastWorkflowRequest) snapshot.getRequest();
         boolean dropWorkflow = WorkflowLifecycleUtils.isDropWorkflow(snapshot);
+        boolean expectedRuleExists = !dropWorkflow;
         for (String each : request.getTargetTables()) {
             boolean ruleExists = broadcastRules.stream().anyMatch(rule -> queryFacade.isSameIdentifier(
                     request.getDatabase(), IdentifierScope.TABLE, each, WorkflowRuleValueUtils.getRuleValue(rule, "broadcast_table")));
-            if (dropWorkflow && ruleExists || !dropWorkflow && !ruleExists) {
+            if (expectedRuleExists != ruleExists) {
                 addRuleMismatch(validationReport, dropWorkflow, each);
                 return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, broadcastRules, "Broadcast rule state does not match the planned DistSQL artifact.");
             }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingRuleWorkflowValidationService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingRuleWorkflowValidationService.java
@@ -81,10 +81,9 @@ public final class ReadwriteSplittingRuleWorkflowValidationService implements MC
     }
     
     private void addRuleDistSQLIssues(final List<Map<String, Object>> issues, final WorkflowContextSnapshot snapshot, final String sql, final String displaySql) {
-        if (!isReadwriteSplittingRuleDistSQL(sql) || !(snapshot.getRequest() instanceof ReadwriteSplittingRuleWorkflowRequest)) {
+        if (!isReadwriteSplittingRuleDistSQL(sql) || !(snapshot.getRequest() instanceof final ReadwriteSplittingRuleWorkflowRequest request)) {
             return;
         }
-        ReadwriteSplittingRuleWorkflowRequest request = (ReadwriteSplittingRuleWorkflowRequest) snapshot.getRequest();
         addLoadBalancerIssue(issues, request, displaySql);
         addWeightIssues(issues, request, displaySql);
     }
@@ -142,11 +141,13 @@ public final class ReadwriteSplittingRuleWorkflowValidationService implements MC
                                             final ValidationReport validationReport, final MCPFeatureQueryFacade queryFacade) {
         ReadwriteSplittingRuleWorkflowRequest request = (ReadwriteSplittingRuleWorkflowRequest) snapshot.getRequest();
         boolean ruleExists = containsRule(rules, queryFacade, request.getDatabase(), request.getRuleName());
-        if (WorkflowLifecycleUtils.isDropWorkflow(snapshot) && ruleExists || !WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !ruleExists) {
-            addRuleMismatch(validationReport, request.getRuleName(), WorkflowLifecycleUtils.isDropWorkflow(snapshot));
+        boolean dropWorkflow = WorkflowLifecycleUtils.isDropWorkflow(snapshot);
+        boolean expectedRuleExists = !dropWorkflow;
+        if (expectedRuleExists != ruleExists) {
+            addRuleMismatch(validationReport, request.getRuleName(), dropWorkflow);
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, rules, "Readwrite-splitting rule state does not match the planned DistSQL artifact.");
         }
-        if (!WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !matchesRuleShape(rules, queryFacade, request)) {
+        if (!dropWorkflow && !matchesRuleShape(rules, queryFacade, request)) {
             addRuleShapeMismatch(validationReport, request.getRuleName());
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, rules, "Readwrite-splitting rule fields do not match the planned DistSQL artifact.");
         }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationService.java
@@ -110,12 +110,14 @@ public final class ShardingWorkflowValidationService implements MCPWorkflowRunti
     private ValidationSection validateNamedState(final WorkflowContextSnapshot snapshot, final ValidationReport validationReport,
                                                  final List<Map<String, Object>> rows, final MCPFeatureQueryFacade queryFacade, final String databaseName,
                                                  final String fieldName, final String expected, final boolean shapeMatches) {
-        boolean exists = containsNamedRow(rows, queryFacade, databaseName, fieldName, expected);
-        if (WorkflowLifecycleUtils.isDropWorkflow(snapshot) && exists || !WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !exists) {
+        boolean ruleExists = containsNamedRow(rows, queryFacade, databaseName, fieldName, expected);
+        boolean dropWorkflow = WorkflowLifecycleUtils.isDropWorkflow(snapshot);
+        boolean expectedRuleExists = !dropWorkflow;
+        if (expectedRuleExists != ruleExists) {
             addMismatch(validationReport, fieldName, expected);
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, rows, "Sharding rule state does not match the planned DistSQL artifact.");
         }
-        if (!WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !shapeMatches) {
+        if (!dropWorkflow && !shapeMatches) {
             addMismatch(validationReport, fieldName, expected);
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, rows, "Sharding rule fields do not match the planned DistSQL artifact.");
         }
@@ -216,13 +218,15 @@ public final class ShardingWorkflowValidationService implements MCPWorkflowRunti
     
     private ValidationSection validateDefaultStrategy(final WorkflowContextSnapshot snapshot, final ValidationReport validationReport,
                                                       final List<Map<String, Object>> rows, final MCPFeatureQueryFacade queryFacade, final ShardingWorkflowRequest request) {
-        boolean exists = rows.stream().anyMatch(each -> queryFacade.isSameIdentifier(request.getDatabase(), IdentifierScope.TABLE, request.getDefaultStrategyType(),
+        boolean strategyExists = rows.stream().anyMatch(each -> queryFacade.isSameIdentifier(request.getDatabase(), IdentifierScope.TABLE, request.getDefaultStrategyType(),
                 WorkflowRuleValueUtils.getRuleValue(each, "name")) && !WorkflowRuleValueUtils.getRuleValue(each, "type").isEmpty());
-        if (WorkflowLifecycleUtils.isDropWorkflow(snapshot) && exists || !WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !exists) {
+        boolean dropWorkflow = WorkflowLifecycleUtils.isDropWorkflow(snapshot);
+        boolean expectedStrategyExists = !dropWorkflow;
+        if (expectedStrategyExists != strategyExists) {
             addMismatch(validationReport, "name", request.getDefaultStrategyType());
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, rows, "Default sharding strategy state does not match the planned DistSQL artifact.");
         }
-        if (!WorkflowLifecycleUtils.isDropWorkflow(snapshot) && !matchesDefaultStrategy(rows, queryFacade, request)) {
+        if (!dropWorkflow && !matchesDefaultStrategy(rows, queryFacade, request)) {
             addMismatch(validationReport, "name", request.getDefaultStrategyType());
             return new ValidationSection(WorkflowLifecycle.STATUS_FAILED, rows, "Default sharding strategy fields do not match the planned DistSQL artifact.");
         }


### PR DESCRIPTION
Simplify create and drop workflow state checks by comparing the
expected and actual rule state directly.

Verify that SQL execution tool descriptors remain aligned with MCP
runtime row and timeout limits.