### PR TITLE
Fix ArrayIndexOutOfBoundsException in RoundRobinLoadBalanceAlgorithm when its counter overflows

### DIFF
--- a/infra/algorithm/type/load-balancer/type/round-robin/src/main/java/org/apache/shardingsphere/infra/algorithm/loadbalancer/round/robin/RoundRobinLoadBalanceAlgorithm.java
+++ b/infra/algorithm/type/load-balancer/type/round-robin/src/main/java/org/apache/shardingsphere/infra/algorithm/loadbalancer/round/robin/RoundRobinLoadBalanceAlgorithm.java
@@ -33,7 +33,7 @@ public final class RoundRobinLoadBalanceAlgorithm implements LoadBalanceAlgorith
     @HighFrequencyInvocation
     @Override
     public String getTargetName(final String groupName, final List<String> availableTargetNames) {
-        return availableTargetNames.get(Math.abs(count.getAndIncrement()) % availableTargetNames.size());
+        return availableTargetNames.get(Math.floorMod(count.getAndIncrement(), availableTargetNames.size()));
     }
     
     @Override

--- a/infra/algorithm/type/load-balancer/type/round-robin/src/test/java/org/apache/shardingsphere/infra/algorithm/loadbalancer/round/robin/RoundRobinLoadBalanceAlgorithmTest.java
+++ b/infra/algorithm/type/load-balancer/type/round-robin/src/test/java/org/apache/shardingsphere/infra/algorithm/loadbalancer/round/robin/RoundRobinLoadBalanceAlgorithmTest.java
@@ -20,10 +20,12 @@ package org.apache.shardingsphere.infra.algorithm.loadbalancer.round.robin;
 import org.apache.shardingsphere.infra.algorithm.loadbalancer.spi.LoadBalanceAlgorithm;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,6 +39,17 @@ class RoundRobinLoadBalanceAlgorithmTest {
         String availableTargetName2 = "test_read_ds_2";
         List<String> availableTargetNames = Arrays.asList(availableTargetName1, availableTargetName2);
         assertRoundRobinLoadBalance(availableTargetName1, availableTargetName2, loadBalanceAlgorithm, availableTargetNames);
+    }
+    
+    @Test
+    void assertGetAvailableTargetNameWhenCounterOverflows() throws ReflectiveOperationException {
+        LoadBalanceAlgorithm loadBalanceAlgorithm = TypedSPILoader.getService(LoadBalanceAlgorithm.class, "ROUND_ROBIN", new Properties());
+        Plugins.getMemberAccessor().set(
+                RoundRobinLoadBalanceAlgorithm.class.getDeclaredField("count"), loadBalanceAlgorithm, new AtomicInteger(Integer.MAX_VALUE));
+        List<String> availableTargetNames = Arrays.asList("test_read_ds_1", "test_read_ds_2", "test_read_ds_3");
+        assertThat(loadBalanceAlgorithm.getTargetName("ds", availableTargetNames), is("test_read_ds_2"));
+        assertThat(loadBalanceAlgorithm.getTargetName("ds", availableTargetNames), is("test_read_ds_2"));
+        assertThat(loadBalanceAlgorithm.getTargetName("ds", availableTargetNames), is("test_read_ds_3"));
     }
     
     private void assertRoundRobinLoadBalance(final String availableTargetName1, final String availableTargetName2, final LoadBalanceAlgorithm loadBalanceAlgorithm,


### PR DESCRIPTION
## Changes

`RoundRobinLoadBalanceAlgorithm.getTargetName` indexes with `Math.abs(count.getAndIncrement()) % availableTargetNames.size()`. `Math.abs(Integer.MIN_VALUE)` is `Integer.MIN_VALUE` — `abs` cannot represent `2^31` in an `int` — so once the counter wraps, the remainder is negative and `List.get` throws.

```
java.lang.ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 3
    at RoundRobinLoadBalanceAlgorithm.getTargetName(RoundRobinLoadBalanceAlgorithm.java:36)
```

Replaced with `Math.floorMod(count.getAndIncrement(), availableTargetNames.size())`.

Only replica groups whose size is not a power of two are affected — for 2, 4 or 8 the negative remainder happens to be 0:

| group size | `Math.abs(Integer.MIN_VALUE) % size` | |
| --- | --- | --- |
| 2 | 0 | survives |
| 3 | **-2** | throws |
| 4 | 0 | survives |
| 5 | **-3** | throws |
| 8 | 0 | survives |

The existing test uses a two-element list, which is why this was never caught.

## Why `floorMod` is safe below the wrap

`Math.floorMod(i, size)` and `Math.abs(i) % size` are identical for every non-negative `i`, so nothing changes until the counter overflows. I checked that exhaustively rather than assuming it — all counters in `[0, 5_000_000]` against group sizes 1..16, 80,000,016 pairs, zero differences. The only behavioural change is at the wrap itself, where one target is selected twice in a row instead of an exception being thrown.

## Prior art

#1265 reported this same `ArrayIndexOutOfBoundsException` in 2018 and was closed as completed; the fix then was a `count.compareAndSet(readDataSourceNames.size(), 0)` line that kept the counter bounded. #17422 removed that line in 2022 while changing the counter from a static map to an instance field, and kept the `Math.abs(...)` expression.

To be accurate about it: that old line was itself racy — several threads could step past `size` before any of them observed it — so the point is not that a correct guard was lost, but that the counter has had no bound at all since then, and `getTargetName` is annotated `@HighFrequencyInvocation`.

## Testing

Added `assertGetAvailableTargetNameWhenCounterOverflows`, which seeds `count` with `Integer.MAX_VALUE` using the repo's `Plugins.getMemberAccessor()` idiom and calls the algorithm three times against a three-element list. It reproduces the exception on `master` and passes with this change.

- `RoundRobinLoadBalanceAlgorithmTest` — fails before, 2/2 after
- `infra/algorithm/type/load-balancer/type/round-robin` + `features/readwrite-splitting/core` with `-am` — 3404 tests, 0 failures, 0 errors
- `checkstyle:check` with `src/resources/checkstyle.xml` — clean

Fixes #39319

## Type
- [x] Bugfix
