### PR TITLE
Avoid reusing active Firebird BLOB handles

### DIFF
--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdCancelBlobCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdCancelBlobCommandExecutor.java
@@ -50,6 +50,7 @@ public final class FirebirdCancelBlobCommandExecutor implements CommandExecutor 
             FirebirdBlobWriteCache.getInstance().removeWrite(connectionSession.getConnectionId(), blobId.getAsLong());
         }
         FirebirdBlobReadCache.getInstance().removeBlob(connectionSession.getConnectionId(), blobHandle);
+        FirebirdBlobHandleGenerator.getInstance().releaseBlobHandle(connectionSession.getConnectionId(), blobHandle);
         return Collections.singleton(new FirebirdGenericResponsePacket());
     }
 }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdCloseBlobCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdCloseBlobCommandExecutor.java
@@ -47,6 +47,7 @@ public final class FirebirdCloseBlobCommandExecutor implements CommandExecutor {
         OptionalLong blobId = FirebirdBlobWriteCache.getInstance().getBlobId(connectionSession.getConnectionId(), blobHandle);
         FirebirdBlobWriteCache.getInstance().closeWrite(connectionSession.getConnectionId(), blobHandle);
         FirebirdBlobReadCache.getInstance().removeBlob(connectionSession.getConnectionId(), blobHandle);
+        FirebirdBlobHandleGenerator.getInstance().releaseBlobHandle(connectionSession.getConnectionId(), blobHandle);
         long responseBlobId = blobId.isPresent() ? blobId.getAsLong() : 0L;
         FirebirdGenericResponsePacket response = new FirebirdGenericResponsePacket().setWriteZeroStatementId(true).setId(responseBlobId);
         return Collections.singleton(response);

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/cache/FirebirdBlobWriteCache.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/cache/FirebirdBlobWriteCache.java
@@ -107,11 +107,13 @@ public final class FirebirdBlobWriteCache {
      * @return optional current size of buffered data
      */
     public OptionalInt closeWrite(final int connectionId, final int blobHandle) {
-        FirebirdBlobWrite write = getHandleMap(connectionId).get(blobHandle);
+        Map<Integer, FirebirdBlobWrite> handleMap = getHandleMap(connectionId);
+        FirebirdBlobWrite write = handleMap.get(blobHandle);
         if (null == write) {
             return OptionalInt.empty();
         }
         write.markClosed();
+        handleMap.remove(blobHandle, write);
         return OptionalInt.of(write.getSize());
     }
     
@@ -178,7 +180,7 @@ public final class FirebirdBlobWriteCache {
     public void removeWrite(final int connectionId, final long blobId) {
         FirebirdBlobWrite write = getIdMap(connectionId).remove(blobId);
         if (null != write) {
-            getHandleMap(connectionId).remove(write.getBlobHandle());
+            getHandleMap(connectionId).remove(write.getBlobHandle(), write);
         }
     }
     

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGenerator.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGenerator.java
@@ -19,13 +19,22 @@ package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.gen
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.database.protocol.firebird.exception.FirebirdProtocolException;
+import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 
+import java.util.BitSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * BLOB handle (p_resp_object) generator for Firebird.
+ *
+ * <p>Firebird carries object handles as 16 bit values and reserves {@code 0xFFFF} as the invalid object handle,
+ * so handles are issued within the range 1 to {@code 0xFFFE}. BLOB operations sent immediately after
+ * {@code op_create_blob2} or {@code op_open_blob2}, without waiting for its response, can use the invalid object
+ * handle instead of the not yet received BLOB handle, which refers to the latest object created.</p>
+ *
+ * @see <a href="https://firebirdsql.org/file/documentation/html/en/firebirddocs/wireprotocol/firebird-wire-protocol.html#wireprotocol-blobs-create-v11">Firebird wire protocol - blobs</a>
  */
 @NoArgsConstructor(access = AccessLevel.NONE)
 public final class FirebirdBlobHandleGenerator {
@@ -36,7 +45,7 @@ public final class FirebirdBlobHandleGenerator {
     
     private static final int MAX_OBJECT_HANDLE = INVALID_OBJECT_HANDLE - 1;
     
-    private final Map<Integer, AtomicInteger> connectionRegistry = new ConcurrentHashMap<>();
+    private final Map<Integer, ConnectionBlobHandles> connectionRegistry = new ConcurrentHashMap<>();
     
     public static FirebirdBlobHandleGenerator getInstance() {
         return INSTANCE;
@@ -48,31 +57,37 @@ public final class FirebirdBlobHandleGenerator {
      * @param connectionId connection ID
      */
     public void registerConnection(final int connectionId) {
-        connectionRegistry.put(connectionId, new AtomicInteger());
+        connectionRegistry.put(connectionId, new ConnectionBlobHandles());
     }
     
     /**
      * Generate next BLOB handle for connection.
      *
-     * <p>Firebird carries object handles as 16 bit values, and {@code 0xFFFF} is reserved as the deferred
-     * placeholder handle, so generated handles wrap within the range 1 to {@code 0xFFFE}. Handle 0 is never
-     * issued because it marks a connection that has not generated a handle yet.</p>
-     *
      * @param connectionId connection ID
-     * @return generated BLOB handle
+     * @return generated BLOB handle within the range 1 to {@code 0xFFFE}
+     * @throws FirebirdProtocolException when connection is not registered or no free BLOB handle is available
      */
     public int nextBlobHandle(final int connectionId) {
-        return connectionRegistry.get(connectionId).updateAndGet(current -> MAX_OBJECT_HANDLE <= current ? 1 : current + 1);
+        ConnectionBlobHandles connectionBlobHandles = connectionRegistry.get(connectionId);
+        ShardingSpherePreconditions.checkState(null != connectionBlobHandles,
+                () -> new FirebirdProtocolException("Connection %d is not registered.", connectionId));
+        synchronized (connectionBlobHandles) {
+            int handleIndex = connectionBlobHandles.handles.nextClearBit(connectionBlobHandles.searchPosition);
+            if (handleIndex >= MAX_OBJECT_HANDLE) {
+                handleIndex = connectionBlobHandles.handles.nextClearBit(0);
+            }
+            if (handleIndex < MAX_OBJECT_HANDLE) {
+                connectionBlobHandles.handles.set(handleIndex);
+                connectionBlobHandles.lastBlobHandle = handleIndex + 1;
+                connectionBlobHandles.searchPosition = connectionBlobHandles.lastBlobHandle;
+                return connectionBlobHandles.lastBlobHandle;
+            }
+            throw new FirebirdProtocolException("No free BLOB handles are available for connection %d.", connectionId);
+        }
     }
     
     /**
      * Resolve a BLOB handle, mapping the deferred placeholder handle to the most recently generated one.
-     *
-     * <p>In the Firebird lazy (deferred) protocol a pipelined operation such as {@code op_put_segment},
-     * {@code op_get_segment} or {@code op_info_blob} that is flushed together with its preceding
-     * {@code op_create_blob2} or {@code op_open_blob2} carries the placeholder handle {@code 0xFFFF}
-     * (INVALID_OBJECT), which the server resolves to the most recently created object. Handles are generated
-     * here for both created and opened BLOBs, so the last generated handle mirrors that resolution.</p>
      *
      * @param connectionId connection ID
      * @param blobHandle blob handle received from the client
@@ -82,8 +97,37 @@ public final class FirebirdBlobHandleGenerator {
         if (INVALID_OBJECT_HANDLE != blobHandle) {
             return blobHandle;
         }
-        AtomicInteger lastGenerated = connectionRegistry.get(connectionId);
-        return null == lastGenerated || 0 == lastGenerated.get() ? blobHandle : lastGenerated.get();
+        ConnectionBlobHandles connectionBlobHandles = connectionRegistry.get(connectionId);
+        if (null == connectionBlobHandles) {
+            return blobHandle;
+        }
+        synchronized (connectionBlobHandles) {
+            return 0 == connectionBlobHandles.lastBlobHandle ? blobHandle : connectionBlobHandles.lastBlobHandle;
+        }
+    }
+    
+    /**
+     * Release BLOB handle for connection.
+     *
+     * @param connectionId connection ID
+     * @param blobHandle BLOB handle
+     * @throws FirebirdProtocolException when BLOB handle is invalid
+     */
+    public void releaseBlobHandle(final int connectionId, final int blobHandle) {
+        ConnectionBlobHandles connectionBlobHandles = connectionRegistry.get(connectionId);
+        if (null == connectionBlobHandles) {
+            return;
+        }
+        ShardingSpherePreconditions.checkState(0 < blobHandle && MAX_OBJECT_HANDLE >= blobHandle,
+                () -> new FirebirdProtocolException("Invalid BLOB handle %d.", blobHandle));
+        synchronized (connectionBlobHandles) {
+            ShardingSpherePreconditions.checkState(connectionBlobHandles.handles.get(blobHandle - 1),
+                    () -> new FirebirdProtocolException("Invalid BLOB handle %d.", blobHandle));
+            connectionBlobHandles.handles.clear(blobHandle - 1);
+            if (blobHandle == connectionBlobHandles.lastBlobHandle) {
+                connectionBlobHandles.lastBlobHandle = 0;
+            }
+        }
     }
     
     /**
@@ -94,4 +138,14 @@ public final class FirebirdBlobHandleGenerator {
     public void unregisterConnection(final int connectionId) {
         connectionRegistry.remove(connectionId);
     }
+    
+    private static final class ConnectionBlobHandles {
+        
+        private final BitSet handles = new BitSet();
+        
+        private int searchPosition;
+        
+        private int lastBlobHandle;
+    }
+    
 }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGenerator.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGenerator.java
@@ -63,6 +63,8 @@ public final class FirebirdBlobHandleGenerator {
     /**
      * Generate next BLOB handle for connection.
      *
+     * <p>The search starts at the lowest free handle, so a handle released by close or cancel is reused at once.</p>
+     *
      * @param connectionId connection ID
      * @return generated BLOB handle within the range 1 to {@code 0xFFFE}
      * @throws FirebirdProtocolException when connection is not registered or no free BLOB handle is available
@@ -73,16 +75,12 @@ public final class FirebirdBlobHandleGenerator {
                 () -> new FirebirdProtocolException("Connection %d is not registered.", connectionId));
         synchronized (connectionBlobHandles) {
             int handleIndex = connectionBlobHandles.handles.nextClearBit(connectionBlobHandles.searchPosition);
-            if (handleIndex >= MAX_OBJECT_HANDLE) {
-                handleIndex = connectionBlobHandles.handles.nextClearBit(0);
-            }
-            if (handleIndex < MAX_OBJECT_HANDLE) {
-                connectionBlobHandles.handles.set(handleIndex);
-                connectionBlobHandles.lastBlobHandle = handleIndex + 1;
-                connectionBlobHandles.searchPosition = connectionBlobHandles.lastBlobHandle;
-                return connectionBlobHandles.lastBlobHandle;
-            }
-            throw new FirebirdProtocolException("No free BLOB handles are available for connection %d.", connectionId);
+            ShardingSpherePreconditions.checkState(MAX_OBJECT_HANDLE > handleIndex,
+                    () -> new FirebirdProtocolException("No free BLOB handles are available for connection %d.", connectionId));
+            connectionBlobHandles.handles.set(handleIndex);
+            connectionBlobHandles.lastBlobHandle = handleIndex + 1;
+            connectionBlobHandles.searchPosition = connectionBlobHandles.lastBlobHandle;
+            return connectionBlobHandles.lastBlobHandle;
         }
     }
     
@@ -123,7 +121,9 @@ public final class FirebirdBlobHandleGenerator {
         synchronized (connectionBlobHandles) {
             ShardingSpherePreconditions.checkState(connectionBlobHandles.handles.get(blobHandle - 1),
                     () -> new FirebirdProtocolException("Invalid BLOB handle %d.", blobHandle));
-            connectionBlobHandles.handles.clear(blobHandle - 1);
+            int position = blobHandle - 1;
+            connectionBlobHandles.handles.clear(position);
+            connectionBlobHandles.searchPosition = Math.min(connectionBlobHandles.searchPosition, position);
             if (blobHandle == connectionBlobHandles.lastBlobHandle) {
                 connectionBlobHandles.lastBlobHandle = 0;
             }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdCancelBlobCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdCancelBlobCommandExecutorTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
+import org.apache.shardingsphere.database.protocol.firebird.exception.FirebirdProtocolException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdCancelBlobCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobWriteCache;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.generator.FirebirdBlobHandleGenerator;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementIdGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,6 +56,7 @@ class FirebirdCancelBlobCommandExecutorTest {
     @BeforeEach
     void setup() {
         FirebirdStatementIdGenerator.getInstance().registerConnection(CONNECTION_ID);
+        FirebirdBlobHandleGenerator.getInstance().registerConnection(CONNECTION_ID);
         FirebirdBlobWriteCache.getInstance().registerConnection(CONNECTION_ID);
         when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
     }
@@ -60,12 +64,13 @@ class FirebirdCancelBlobCommandExecutorTest {
     @AfterEach
     void tearDown() {
         FirebirdStatementIdGenerator.getInstance().unregisterConnection(CONNECTION_ID);
+        FirebirdBlobHandleGenerator.getInstance().unregisterConnection(CONNECTION_ID);
         FirebirdBlobWriteCache.getInstance().unregisterConnection(CONNECTION_ID);
     }
     
     @Test
     void assertExecute() {
-        int blobHandle = 5;
+        int blobHandle = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(CONNECTION_ID);
         long blobId = 9L;
         FirebirdBlobWriteCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, blobId);
         when(packet.getBlobHandle()).thenReturn(blobHandle);
@@ -76,5 +81,15 @@ class FirebirdCancelBlobCommandExecutorTest {
         assertThat(response, isA(FirebirdGenericResponsePacket.class));
         assertThat(((FirebirdGenericResponsePacket) response).getHandle(), is(0));
         assertFalse(FirebirdBlobWriteCache.getInstance().getBlobId(CONNECTION_ID, blobHandle).isPresent());
+        assertThrows(FirebirdProtocolException.class, () -> FirebirdBlobHandleGenerator.getInstance().releaseBlobHandle(CONNECTION_ID, blobHandle));
+    }
+    
+    @Test
+    void assertExecuteWithoutBlobWrite() {
+        int blobHandle = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(CONNECTION_ID);
+        when(packet.getBlobHandle()).thenReturn(blobHandle);
+        Collection<DatabasePacket> actual = new FirebirdCancelBlobCommandExecutor(packet, connectionSession).execute();
+        assertThat(actual.size(), is(1));
+        assertThrows(FirebirdProtocolException.class, () -> FirebirdBlobHandleGenerator.getInstance().releaseBlobHandle(CONNECTION_ID, blobHandle));
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdCloseBlobCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdCloseBlobCommandExecutorTest.java
@@ -17,10 +17,12 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
+import org.apache.shardingsphere.database.protocol.firebird.exception.FirebirdProtocolException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdCloseBlobCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.generator.FirebirdBlobHandleGenerator;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.generator.FirebirdBlobIdGenerator;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobWriteCache;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementIdGenerator;
@@ -37,6 +39,7 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,6 +56,7 @@ class FirebirdCloseBlobCommandExecutorTest {
     @BeforeEach
     void setup() {
         FirebirdStatementIdGenerator.getInstance().registerConnection(CONNECTION_ID);
+        FirebirdBlobHandleGenerator.getInstance().registerConnection(CONNECTION_ID);
         FirebirdBlobIdGenerator.getInstance().registerConnection(CONNECTION_ID);
         FirebirdBlobWriteCache.getInstance().registerConnection(CONNECTION_ID);
         when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
@@ -61,13 +65,14 @@ class FirebirdCloseBlobCommandExecutorTest {
     @AfterEach
     void tearDown() {
         FirebirdStatementIdGenerator.getInstance().unregisterConnection(CONNECTION_ID);
+        FirebirdBlobHandleGenerator.getInstance().unregisterConnection(CONNECTION_ID);
         FirebirdBlobIdGenerator.getInstance().unregisterConnection(CONNECTION_ID);
         FirebirdBlobWriteCache.getInstance().unregisterConnection(CONNECTION_ID);
     }
     
     @Test
     void assertExecute() {
-        int blobHandle = 9;
+        int blobHandle = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(CONNECTION_ID);
         long blobId = 5L;
         FirebirdBlobWriteCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, blobId);
         when(packet.getBlobHandle()).thenReturn(blobHandle);
@@ -78,5 +83,15 @@ class FirebirdCloseBlobCommandExecutorTest {
         assertThat(response, isA(FirebirdGenericResponsePacket.class));
         assertThat(((FirebirdGenericResponsePacket) response).getHandle(), is(0));
         assertThat(((FirebirdGenericResponsePacket) response).getId(), is(blobId));
+        assertThrows(FirebirdProtocolException.class, () -> FirebirdBlobHandleGenerator.getInstance().releaseBlobHandle(CONNECTION_ID, blobHandle));
+    }
+    
+    @Test
+    void assertExecuteWithoutBlobWrite() {
+        int blobHandle = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(CONNECTION_ID);
+        when(packet.getBlobHandle()).thenReturn(blobHandle);
+        Collection<DatabasePacket> actual = new FirebirdCloseBlobCommandExecutor(packet, connectionSession).execute();
+        assertThat(((FirebirdGenericResponsePacket) actual.iterator().next()).getId(), is(0L));
+        assertThrows(FirebirdProtocolException.class, () -> FirebirdBlobHandleGenerator.getInstance().releaseBlobHandle(CONNECTION_ID, blobHandle));
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/cache/FirebirdBlobWriteCacheTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/cache/FirebirdBlobWriteCacheTest.java
@@ -90,6 +90,7 @@ class FirebirdBlobWriteCacheTest {
         OptionalInt actualSizeAfterClose = CACHE.closeWrite(connectionId, blobHandle);
         assertTrue(actualSizeAfterClose.isPresent());
         assertThat(actualSizeAfterClose.getAsInt(), is(3));
+        assertFalse(CACHE.getBlobId(connectionId, blobHandle).isPresent());
         assertTrue(CACHE.isClosed(connectionId, blobId));
         Optional<byte[]> actualBlobData = CACHE.getBlobData(connectionId, blobId);
         assertTrue(actualBlobData.isPresent());
@@ -97,6 +98,22 @@ class FirebirdBlobWriteCacheTest {
         CACHE.removeWrite(connectionId, blobId);
         assertFalse(getHandleCache().get(connectionId).containsKey(blobHandle));
         assertFalse(getIdCache().get(connectionId).containsKey(blobId));
+    }
+    
+    @Test
+    void assertRemoveWriteDoesNotRemoveReusedHandle() {
+        int connectionId = 12;
+        int blobHandle = 8;
+        long oldBlobId = 9L;
+        long expectedBlobId = 10L;
+        CACHE.registerConnection(connectionId);
+        CACHE.registerBlob(connectionId, blobHandle, oldBlobId);
+        CACHE.closeWrite(connectionId, blobHandle);
+        CACHE.registerBlob(connectionId, blobHandle, expectedBlobId);
+        CACHE.removeWrite(connectionId, oldBlobId);
+        OptionalLong actualBlobId = CACHE.getBlobId(connectionId, blobHandle);
+        assertTrue(actualBlobId.isPresent());
+        assertThat(actualBlobId.getAsLong(), is(expectedBlobId));
     }
     
     @Test

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
@@ -83,7 +83,7 @@ class FirebirdBlobHandleGeneratorTest {
         assertThat(generator.nextBlobHandle(CONNECTION_ID), is(releasedHandle));
         assertThat(generator.nextBlobHandle(CONNECTION_ID), is(lastHandle + 1));
     }
-
+    
     @Test
     void assertNextBlobHandleReusesLowestReleasedHandle() {
         FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
@@ -21,9 +21,15 @@ import org.apache.shardingsphere.database.protocol.firebird.exception.FirebirdPr
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FirebirdBlobHandleGeneratorTest {
@@ -31,6 +37,8 @@ class FirebirdBlobHandleGeneratorTest {
     private static final int CONNECTION_ID = 91;
     
     private static final int INVALID_OBJECT_HANDLE = 0xFFFF;
+    
+    private static final int MAX_OBJECT_HANDLE = INVALID_OBJECT_HANDLE - 1;
     
     @BeforeEach
     void setUp() {
@@ -53,9 +61,27 @@ class FirebirdBlobHandleGeneratorTest {
         FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();
         int firstHandle = generator.nextBlobHandle(CONNECTION_ID);
         assertThat(firstHandle, is(1));
-        for (int i = 1; i < 0xFFFE; i++) {
+        for (int i = 1; i < MAX_OBJECT_HANDLE; i++) {
             generator.nextBlobHandle(CONNECTION_ID);
         }
+        assertThrows(FirebirdProtocolException.class, () -> generator.nextBlobHandle(CONNECTION_ID));
+    }
+    
+    @Test
+    void assertNextBlobHandleWhenConnectionIsNotRegistered() {
+        FirebirdBlobHandleGenerator.getInstance().unregisterConnection(CONNECTION_ID);
+        assertThrows(FirebirdProtocolException.class, () -> FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(CONNECTION_ID));
+    }
+    
+    @Test
+    void assertNextBlobHandleReusesReleasedHandleAfterWrap() {
+        FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();
+        int releasedHandle = generator.nextBlobHandle(CONNECTION_ID);
+        generator.releaseBlobHandle(CONNECTION_ID, releasedHandle);
+        for (int i = 1; i < MAX_OBJECT_HANDLE; i++) {
+            generator.nextBlobHandle(CONNECTION_ID);
+        }
+        assertThat(generator.nextBlobHandle(CONNECTION_ID), is(releasedHandle));
         assertThrows(FirebirdProtocolException.class, () -> generator.nextBlobHandle(CONNECTION_ID));
     }
     
@@ -79,5 +105,47 @@ class FirebirdBlobHandleGeneratorTest {
     @Test
     void assertResolveBlobHandleWithPlaceholderAndUnknownConnectionExpectsPlaceholder() {
         assertThat(FirebirdBlobHandleGenerator.getInstance().resolveBlobHandle(92, INVALID_OBJECT_HANDLE), is(INVALID_OBJECT_HANDLE));
+    }
+    
+    @Test
+    void assertReleaseBlobHandleClearsLastBlobHandle() {
+        FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();
+        int blobHandle = generator.nextBlobHandle(CONNECTION_ID);
+        generator.releaseBlobHandle(CONNECTION_ID, blobHandle);
+        assertThat(generator.resolveBlobHandle(CONNECTION_ID, INVALID_OBJECT_HANDLE), is(INVALID_OBJECT_HANDLE));
+        assertThat(generator.nextBlobHandle(CONNECTION_ID), is(2));
+    }
+    
+    @Test
+    void assertReleaseBlobHandleKeepsLastActiveBlobHandle() {
+        FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();
+        int blobHandle = generator.nextBlobHandle(CONNECTION_ID);
+        int expected = generator.nextBlobHandle(CONNECTION_ID);
+        generator.releaseBlobHandle(CONNECTION_ID, blobHandle);
+        assertThat(generator.resolveBlobHandle(CONNECTION_ID, INVALID_OBJECT_HANDLE), is(expected));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidBlobHandleProvider")
+    void assertReleaseBlobHandleWhenHandleIsOutsideValidRange(final String name, final int blobHandle) {
+        assertThrows(FirebirdProtocolException.class, () -> FirebirdBlobHandleGenerator.getInstance().releaseBlobHandle(CONNECTION_ID, blobHandle));
+    }
+    
+    @Test
+    void assertReleaseBlobHandleWhenHandleIsNotActive() {
+        assertThrows(FirebirdProtocolException.class, () -> FirebirdBlobHandleGenerator.getInstance().releaseBlobHandle(CONNECTION_ID, 1));
+    }
+    
+    @Test
+    void assertReleaseBlobHandleWhenConnectionIsNotRegistered() {
+        FirebirdBlobHandleGenerator.getInstance().unregisterConnection(CONNECTION_ID);
+        assertDoesNotThrow(() -> FirebirdBlobHandleGenerator.getInstance().releaseBlobHandle(CONNECTION_ID, 1));
+    }
+    
+    private static Stream<Arguments> invalidBlobHandleProvider() {
+        return Stream.of(
+                Arguments.of("negative handle", -1),
+                Arguments.of("zero handle", 0),
+                Arguments.of("deferred handle", INVALID_OBJECT_HANDLE));
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
@@ -17,13 +17,14 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.generator;
 
+import org.apache.shardingsphere.database.protocol.firebird.exception.FirebirdProtocolException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FirebirdBlobHandleGeneratorTest {
     
@@ -48,14 +49,14 @@ class FirebirdBlobHandleGeneratorTest {
     }
     
     @Test
-    void assertNextBlobHandleSkipsPlaceholderAndWraps() {
-        int lastBeforePlaceholder = 0;
-        for (int i = 0; i < INVALID_OBJECT_HANDLE; i++) {
-            lastBeforePlaceholder = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(CONNECTION_ID);
-            assertThat(lastBeforePlaceholder, not(0));
-            assertThat(lastBeforePlaceholder, not(INVALID_OBJECT_HANDLE));
+    void assertNextBlobHandleWhenAllHandlesAreActive() {
+        FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();
+        int firstHandle = generator.nextBlobHandle(CONNECTION_ID);
+        assertThat(firstHandle, is(1));
+        for (int i = 1; i < 0xFFFE; i++) {
+            generator.nextBlobHandle(CONNECTION_ID);
         }
-        assertThat(lastBeforePlaceholder, is(1));
+        assertThrows(FirebirdProtocolException.class, () -> generator.nextBlobHandle(CONNECTION_ID));
     }
     
     @Test

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
@@ -74,15 +74,26 @@ class FirebirdBlobHandleGeneratorTest {
     }
     
     @Test
-    void assertNextBlobHandleReusesReleasedHandleAfterWrap() {
+    void assertNextBlobHandleReusesReleasedHandle() {
         FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();
+        generator.nextBlobHandle(CONNECTION_ID);
         int releasedHandle = generator.nextBlobHandle(CONNECTION_ID);
+        int lastHandle = generator.nextBlobHandle(CONNECTION_ID);
         generator.releaseBlobHandle(CONNECTION_ID, releasedHandle);
-        for (int i = 1; i < MAX_OBJECT_HANDLE; i++) {
-            generator.nextBlobHandle(CONNECTION_ID);
-        }
         assertThat(generator.nextBlobHandle(CONNECTION_ID), is(releasedHandle));
-        assertThrows(FirebirdProtocolException.class, () -> generator.nextBlobHandle(CONNECTION_ID));
+        assertThat(generator.nextBlobHandle(CONNECTION_ID), is(lastHandle + 1));
+    }
+
+    @Test
+    void assertNextBlobHandleReusesLowestReleasedHandle() {
+        FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();
+        int lowestHandle = generator.nextBlobHandle(CONNECTION_ID);
+        generator.nextBlobHandle(CONNECTION_ID);
+        int highestHandle = generator.nextBlobHandle(CONNECTION_ID);
+        generator.releaseBlobHandle(CONNECTION_ID, lowestHandle);
+        generator.releaseBlobHandle(CONNECTION_ID, highestHandle);
+        assertThat(generator.nextBlobHandle(CONNECTION_ID), is(lowestHandle));
+        assertThat(generator.nextBlobHandle(CONNECTION_ID), is(highestHandle));
     }
     
     @Test
@@ -113,7 +124,7 @@ class FirebirdBlobHandleGeneratorTest {
         int blobHandle = generator.nextBlobHandle(CONNECTION_ID);
         generator.releaseBlobHandle(CONNECTION_ID, blobHandle);
         assertThat(generator.resolveBlobHandle(CONNECTION_ID, INVALID_OBJECT_HANDLE), is(INVALID_OBJECT_HANDLE));
-        assertThat(generator.nextBlobHandle(CONNECTION_ID), is(2));
+        assertThat(generator.nextBlobHandle(CONNECTION_ID), is(blobHandle));
     }
     
     @Test


### PR DESCRIPTION
Fixes #39251

Changes proposed in this pull request:
  - A new BLOB handle allocation logic is implemented: a BitSet is used, created lazily - only on the first BLOB request. A free handle is searched for with nextClearBit, starting from the position of the last issued handle (searchPosition). If there are no free positions in the range from searchPosition to 0xFFFE, the search continues from the beginning up to searchPoint. If nothing is found there either, an error is thrown.

---

  Before committing this PR, I'm sure that I have checked the following options:                                                                                                                                                    
  - [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.                                                                                               
  - [x] I have self-reviewed the commit code.                                                                                                                                                                                       
  - [ ] I have (or in comment I request) added corresponding labels for the pull request.                                                                                                                                           
  - [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.                                                                                                             
  - [ ] I have made corresponding changes to the documentation.                                                                                                                                                                     
  - [x] I have added corresponding unit tests for my changes.  
