### PR TITLE
Fix MySQL TIME fractional seconds in proxy results

### DIFF
--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/text/MySQLTextResultSetRowPacket.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/text/MySQLTextResultSetRowPacket.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Clob;
 import java.sql.SQLException;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -79,6 +80,8 @@ public final class MySQLTextResultSetRowPacket extends MySQLPacket {
             payload.writeStringLenenc(formatLocalDateTime((LocalDateTime) data));
         } else if (data instanceof LocalTime) {
             payload.writeStringLenenc(formatLocalTime((LocalTime) data));
+        } else if (data instanceof Time) {
+            payload.writeStringLenenc(formatTime((Time) data));
         } else if (data instanceof Clob) {
             try {
                 // TODO Verify the correct approach for this in MySQL.
@@ -125,5 +128,19 @@ public final class MySQLTextResultSetRowPacket extends MySQLPacket {
         }
         result.append(microsecondsText, 0, endIndex);
         return result.toString();
+    }
+    
+    private String formatTime(final Time value) {
+        int milliseconds = (int) Math.floorMod(value.getTime(), 1000L);
+        if (0 == milliseconds) {
+            return value.toString();
+        }
+        StringBuilder result = new StringBuilder(value.toString()).append('.');
+        String millisecondsText = String.format("%03d", milliseconds);
+        int endIndex = millisecondsText.length();
+        while (endIndex > 0 && '0' == millisecondsText.charAt(endIndex - 1)) {
+            endIndex--;
+        }
+        return result.append(millisecondsText, 0, endIndex).toString();
     }
 }

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/text/MySQLTextResultSetRowPacketTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/text/MySQLTextResultSetRowPacketTest.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.sql.Clob;
 import java.sql.SQLException;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -144,12 +145,19 @@ class MySQLTextResultSetRowPacketTest {
     
     private static Stream<Arguments> writeBasicValueArguments() {
         byte[] binary = new byte[]{1, 2, 3};
+        Time withMilliseconds = Time.valueOf("11:22:33");
+        withMilliseconds.setTime(withMilliseconds.getTime() + 123L);
+        Time withTrailingMillisecondZero = Time.valueOf("11:22:33");
+        withTrailingMillisecondZero.setTime(withTrailingMillisecondZero.getTime() + 120L);
         return Stream.of(
                 Arguments.of("Null", null, true, null, null),
                 Arguments.of("ByteArray", binary, false, null, binary),
                 Arguments.of("BigDecimal", new BigDecimal("123.4500"), false, "123.4500", null),
                 Arguments.of("BooleanTrue", Boolean.TRUE, false, null, new byte[]{1}),
                 Arguments.of("BooleanFalse", Boolean.FALSE, false, null, new byte[]{0}),
+                Arguments.of("TimeWithoutMilliseconds", Time.valueOf("11:22:33"), false, "11:22:33", null),
+                Arguments.of("TimeWithoutTrailingMillisecondZero", withMilliseconds, false, "11:22:33.123", null),
+                Arguments.of("TimeWithTrailingMillisecondZero", withTrailingMillisecondZero, false, "11:22:33.12", null),
                 Arguments.of("DefaultToString", "value_a", false, "value_a", null));
     }
     


### PR DESCRIPTION
Fixes #39327 .

Changes proposed in this pull request:
  - Fix MySQL TIME fractional seconds in proxy results

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
