### PR TITLE
Refine design audit reporting and effort estimation

### DIFF
--- a/.codex/skills/audit-shardingsphere-design/SKILL.md
+++ b/.codex/skills/audit-shardingsphere-design/SKILL.md
@@ -33,8 +33,8 @@ description: >-
 Find current, material design problems that an experienced ShardingSphere engineer can
 verify and act on. Review a named Maven module or the complete repository. Include production
 and test code by default. When the invocation provides no scope, review the complete repository
-without asking for one. Explain the minimum correction direction, but never modify code or produce
-a patch.
+without asking for one. Report the minimum correction, required change scope, and development-effort
+range for each confirmed problem, but never modify code or produce a patch.
 
 ## Boundaries
 
@@ -52,8 +52,8 @@ a patch.
 
 Read these files directly from this Skill before classifying findings:
 
-- Always read [finding-model.md](references/finding-model.md) for proof, priority,
-  confidence, and output rules.
+- Always read [finding-model.md](references/finding-model.md) for internal diagnosis, proof,
+  priority, remediation assessment, and publication rules.
 - Always read [design-smells.md](references/design-smells.md) for responsibility,
   coupling, complexity, duplication, and style criteria.
 - Read [spi-plugin-design.md](references/spi-plugin-design.md) whenever the scope contains
@@ -85,12 +85,14 @@ Read these files directly from this Skill before classifying findings:
 5. Apply the proof gate in `finding-model.md`. Inspect the strongest counter-evidence. Reject
    checklist matches that do not demonstrate a real consequence in this codebase.
 6. Consolidate findings that share one root cause and correction boundary. Rank findings by
-   impact, scope, and confidence; do not rank by how easy they are to describe.
-7. Return the report defined below. If no candidate passes the proof gate, say that no confirmed
-   design problem was found and list any material evidence limitation without inventing findings.
-   If an aggregate scope cannot be completed, return `Review incomplete`, preserve confirmed
-   findings as partial facts, and identify the unreviewed modules; never present partial coverage
-   as a complete repository or module conclusion.
+   impact, scope, and confidence; do not rank by implementation effort. Derive the minimum change
+   scope and development-effort range for each consolidated finding as defined in
+   `finding-model.md`.
+7. Return only the conclusions defined below. Do not expose candidate analysis, evidence chains,
+   path walkthroughs, counter-evidence checks, or confidence. If no candidate passes the proof
+   gate, say that no confirmed design problem was found. If an aggregate scope cannot be completed,
+   return `Review incomplete`, preserve confirmed findings as partial facts, and identify the
+   unreviewed modules and decisive missing facts; never present partial coverage as complete.
 
 ## Judgment Rules
 
@@ -119,40 +121,44 @@ available. Translate headings and field labels as well as the finding text; keep
 and repository paths unchanged.
 
 Start with the reviewed scope and a one-sentence conclusion. Then list confirmed findings in
-priority order. Apply the self-contained finding rules in `finding-model.md` and use this shape for
-every finding:
+priority order. Publish only final diagnoses and remediation conclusions. Do not publish the
+internal reasoning fields from `finding-model.md` or category references. Use this report shape and
+repeat only the finding section for additional findings:
 
 ```markdown
-### [P1|P2|P3] Concise problem title
+Reviewed scope: the complete repository or exact modules examined
+Conclusion: the count and highest-priority confirmed design result
 
-- Location: repository-relative file and line, or the smallest responsible module
-- Capability: one capability group from the workflow
-- Evidence: applicable exact code, dependency, registration, rule, or maintained precedent
-- Path: the relevant owner, caller, dependency, loading, registration, and packaging path
-- Problem: the violated responsibility, contract, or project principle
-- Impact: current maintenance, extension, correctness, packaging, or test consequence
-- Direction: the smallest correction boundary, naming what stays, moves, or changes and how to
-  verify the preserved behavior, without patch content
-- Counter-evidence: the strongest alternative explanation checked and why it does not reverse the
-  finding
-- Confidence: High or Medium, with the reason
+### [P1|P2|P3] Root problem and current consequence
+
+One concise paragraph states the final diagnosis: what is wrong in current ShardingSphere code and
+which concrete consequence it causes. It must not narrate how the analysis reached the conclusion.
+
+- Key locations: the minimum repository-relative files, classes, resources, POMs, and tight lines
+  needed to verify the conclusion
+- Minimum correction: the final responsibility boundary, naming what stays, moves, or changes,
+  without patch content
+- Change scope: the minimum required production owners and callers, dependencies, SPI contracts or
+  registrations, configuration, resources, packaging, compatibility work, and tests
+- Development effort: a numeric person-day range for one engineer familiar with ShardingSphere,
+  followed by the assumption that materially controls the range
 ```
 
 Use `P1` for a confirmed wrong ownership or contract that creates broad or immediate risk, `P2`
 for a material extension or maintenance cost, and `P3` for a localized but non-trivial clarity,
-consistency, or test-design problem. Do not publish low-confidence candidates as findings.
+consistency, or test-design problem. Priority is independent from development effort. Do not
+publish low-confidence candidates as findings.
 
-End with:
-
-- `Coverage`: capability groups and modules actually examined.
-- `Not findings`: important candidates rejected by counter-evidence, only when this helps prevent
-  the same false positive from recurring.
-- `Evidence limits`: facts that could materially change the conclusion.
+If there are no confirmed findings, output only the reviewed scope and the conclusion. If the
+review is incomplete, state `Review incomplete`, the unreviewed modules or partitions, and the
+decisive missing facts; include already confirmed findings using the same conclusion shape. Do not
+output `Coverage`, `Not findings`, `Evidence limits`, candidate logs, or rejected findings as
+separate analysis sections.
 
 Keep the report concise. Do not add a generic checklist, praise unaffected code, or recommend a
-large redesign when a smaller ownership correction addresses the evidence. A finding must explain
-the concrete project problem and correction without requiring the reader to infer the meaning of a
-smell label or ask a follow-up question.
+large redesign when a smaller ownership correction addresses the evidence. The title and diagnosis
+paragraph must explain the concrete project problem without requiring the reader to decode a smell
+label or reconstruct the analysis.
 
 ## Completion Gate
 
@@ -160,12 +166,18 @@ Before returning the report, verify that:
 
 - every finding traces a complete relevant path and cites current repository evidence;
 - every finding identifies a concrete consequence and minimum correction boundary;
-- every finding is self-contained and explains project-specific terms that are necessary to
-  understand the problem;
+- every finding is consolidated by root cause before change scope and development effort are
+  estimated;
+- every published finding contains only the final diagnosis, key locations, minimum correction,
+  minimum change scope, and numeric person-day range with its controlling assumption;
+- no published finding exposes capability tags, evidence chains, path walkthroughs,
+  counter-evidence checks, confidence, candidates, or rejected items;
 - every leaf module in an aggregate scope is accounted for, or the result is explicitly incomplete;
 - SPI findings apply the correct category profile rather than a universal placement rule, and SPI
-  placement findings satisfy the reporting contract in `spi-plugin-design.md`;
+  placement findings satisfy the internal proof gate in `spi-plugin-design.md`;
 - style findings distinguish written rules from engineering judgment;
 - test findings protect production-owned behavior rather than coverage appearance;
 - no finding depends on another Skill, a single regex match, or an unverified deletion premise;
-- the report covers every applicable capability group and contains no patch or source edit.
+- effort does not affect priority or whether a finding passes the proof gate;
+- the report covers every applicable capability group internally and contains no patch or source
+  edit.

--- a/.codex/skills/audit-shardingsphere-design/references/finding-model.md
+++ b/.codex/skills/audit-shardingsphere-design/references/finding-model.md
@@ -17,51 +17,40 @@
 
 # Finding Model
 
-## Candidate and Finding
+## Candidate Diagnosis and Proof Gate
 
 Treat a naming pattern, directory placement, dependency, abstraction, duplicate block, or rule
-match as a candidate. Publish it as a finding only when all of these conditions hold:
+match as a candidate. Complete the diagnosis below internally before confirming it. Do not turn
+these reasoning steps into report fields or expose the candidate analysis in the final report.
 
-1. **Observation:** Identify the exact current code, registration, dependency, contract, test,
-   or written project rule.
-2. **Path:** Trace the relevant caller-to-owner or contract-to-loader-to-implementation path far
-   enough to establish responsibility and consequence.
-3. **Principle:** Name the concrete module responsibility, SPI contract, dependency direction,
-   repository rule, or design principle that the code violates.
-4. **Consequence:** Demonstrate current correctness risk, knowledge leakage, packaging risk,
+1. **Current owner:** Identify the concrete class, resource, POM, registration, module, or test that
+   owns the observed behavior.
+2. **Owned responsibility:** Identify the decision, knowledge, state, rule, variation, or production
+   behavior that changes independently.
+3. **Boundary failure:** Prove why the current owner should not own that responsibility, or why an
+   abstraction, duplicate owner, style choice, or test design violates its concrete responsibility,
+   contract, dependency direction, written rule, or maintained project principle.
+4. **Change propagation:** Trace the caller, dependency, loading, registration, packaging, or test
+   path far enough to demonstrate current correctness risk, knowledge leakage, packaging risk,
    extension cost, duplicated change points, navigation cost, or misleading test protection.
-5. **Counter-evidence:** Inspect the strongest fact that could make the design intentional, such
-   as framework requirements, public contracts, another variation, packaging, or nearby owners.
-6. **Correction boundary:** Identify the smallest responsibility or dependency that must change.
+5. **Correct boundary:** Determine what stays, what moves or changes, and which owner should carry
+   the responsibility. Prove current ownership wrong independently from whether the correct owner
+   already exists. Do not invent a target module name or hierarchy. When no existing module can own
+   the behavior without violating responsibility or dependency direction, require current
+   variation and packaging evidence that a new boundary is necessary; describe its responsibility
+   and variation axis, and cite maintained precedents when available.
+6. **Counter-evidence:** Check the strongest framework, bootstrap, compatibility, packaging,
+   closed-set, default-implementation, or nearby-precedent explanation that could justify the
+   current design.
 
-Reject the candidate when it is only a preference, a theoretical future risk, or a pattern name
-without a demonstrated consequence.
+Use the category-specific reasoning in the other references rather than forcing every problem into
+an ownership smell. For an explicit written-rule violation, prove the exact rule and violation. For
+a test finding, prove the realistic production regression that can escape. If any fact could
+reverse the diagnosis, keep the item as an internal candidate and do not publish it.
 
-## Self-Contained Finding Gate
-
-A confirmed finding must be understandable and actionable without a follow-up question. Explain
-the issue in current ShardingSphere terms rather than using a smell label as the conclusion. Every
-finding must answer:
-
-1. **Where:** Which concrete class, resource, POM, registration, module, or line owns the problem.
-2. **How it is reached:** Which caller, dependency, loader, registration, packaging, or test path
-   establishes the behavior.
-3. **Why it is wrong:** Which specific responsibility, dependency direction, SPI contract, written
-   rule, or maintained project principle is violated.
-4. **What it causes:** Which current correctness, maintenance, extension, packaging, navigation, or
-   test-protection consequence follows from that path.
-5. **What must change:** Which responsibility stays, which concrete artifacts move or change, and
-   which behavior must remain verified. Prove current ownership wrong independently from whether
-   the correct owner already exists. Do not invent a target module name or hierarchy. When no
-   existing module can own the behavior without violating responsibility or dependency direction,
-   require current variation and packaging evidence that a new boundary is necessary; describe
-   its responsibility and variation axis, and cite maintained precedents when available.
-6. **Why the alternative explanation fails:** Which framework, bootstrap, compatibility,
-   packaging, closed-set, default-implementation, or nearby-precedent justification was checked.
-
-Define contextual phrases such as `shared module`, `core policy`, `plugin-specific behavior`, or
-`wrong owner` through the actual consumers and dependencies. If any answer that could reverse the
-conclusion is missing, keep the item as a candidate or evidence limitation rather than a finding.
+Confirm the finding only when all six steps are supported by current repository evidence. Reject
+preferences, theoretical future risks, pattern names without a demonstrated consequence, and any
+candidate whose counter-evidence justifies the current design.
 
 ## Evidence Quality
 
@@ -73,7 +62,8 @@ Prefer evidence in this order:
 4. Engineering inference explicitly connected to the observations above.
 
 Do not use one regex match, one direct-reference search, package names alone, or generic design
-maxims as sufficient proof. When sources conflict, report the conflict and lower confidence.
+maxims as sufficient proof. Treat a decisive source conflict as unresolved and do not confirm the
+finding until the conflict is resolved.
 
 ## Priority
 
@@ -87,12 +77,34 @@ personal preference. Consolidate symptoms that require the same correction into 
 
 ## Confidence
 
+- Use confidence only for the internal publication decision; never include it in the report.
 - **High:** The full relevant path, violated contract, consequence, and counter-evidence are all
   directly supported by current repository facts.
 - **Medium:** The path and consequence are supported, but one non-decisive ownership or runtime
   detail remains inferred.
 - **Low:** A missing consumer, runtime, packaging, contract, or intent fact could reverse the
-  conclusion. Keep it out of findings and list it only as an evidence limitation when material.
+  conclusion. Keep it internal and do not publish it as a finding.
+
+## Remediation Assessment
+
+Assess remediation only after consolidating symptoms with the same root cause and correction
+boundary. The assessment does not affect priority or whether the finding passes the proof gate.
+
+Derive the minimum change scope from the confirmed correction boundary. Name only work required by
+current evidence across production owners and callers, Maven dependencies, SPI contracts and
+registrations, configuration and resources, distribution packaging, compatibility work, and tests.
+Do not inflate the scope with adjacent cleanup or count every indirect consumer as a required edit.
+
+Estimate development effort as a numeric person-day range for one engineer familiar with
+ShardingSphere. Include implementation, dependency and registration changes, required tests, and
+local verification. Exclude review wait time, CI queues, release work, external-team coordination,
+and redesign not required by the finding. Estimate work packages rather than converting file or
+module counts directly into days. Use the lower bound for confirmed work and the upper bound for
+evidence-backed uncertainty. State the assumption that materially controls the range, widen the
+range when necessary, and never replace it with false single-point precision.
+
+Estimate each consolidated finding once. Do not sum findings with overlapping correction boundaries
+unless the user explicitly asks for a deduplicated total estimate.
 
 ## Removal Boundary
 
@@ -102,16 +114,18 @@ code, SPI and `ServiceLoader` registrations, Maven scopes and profiles, test JAR
 distributions, tests, E2E, and external contracts. Follow the repository's required history and
 controlled-removal gates.
 
-Without that evidence, use `suspected unnecessary design` or `purpose unresolved`. Recommend
-simplifying the responsibility, not deleting the artifact. Ordinary audits do not investigate
+Without that evidence, classify the candidate internally as `suspected unnecessary design` or
+`purpose unresolved` and do not publish a removal finding. Ordinary audits do not investigate
 history merely to find old problems.
 
 ## Reporting Discipline
 
-- Cite repository-relative paths and tight line locations when available.
-- Separate observed facts from inference in the evidence text.
-- Explain why the issue matters to the next engineer who changes or extends the code.
+- Publish only the final diagnosis and remediation conclusions defined by `SKILL.md`.
+- Make the title state the root problem and make the diagnosis paragraph state the current concrete
+  consequence. Do not narrate how the conclusion was reached.
+- Cite tight repository-relative locations that let an engineer verify the conclusion without
+  reproducing the internal evidence chain.
 - Give a concrete correction boundary, not a patch, new class hierarchy, or speculative target
-  architecture. Name affected classes, dependencies, registrations, or resources when the evidence
-  requires them.
-- Omit generic compliments, exhaustive candidate logs, and findings that failed the proof gate.
+  architecture.
+- Do not publish capability tags, evidence chains, path walkthroughs, counter-evidence checks,
+  confidence, candidate logs, rejected candidates, or generic compliments.

--- a/.codex/skills/audit-shardingsphere-design/references/spi-plugin-design.md
+++ b/.codex/skills/audit-shardingsphere-design/references/spi-plugin-design.md
@@ -21,7 +21,7 @@
 - [Common Plugin Invariants](#common-plugin-invariants)
 - [Category Profiles](#category-profiles)
 - [High-Value Smells](#high-value-smells)
-- [SPI Placement Finding Contract](#spi-placement-finding-contract)
+- [SPI Placement Proof Gate](#spi-placement-proof-gate)
 
 ## Model
 
@@ -112,11 +112,11 @@ For every smell, inspect counterexamples such as framework discovery constraints
 registries, deliberately closed sets, default implementations, and distribution assembly. Report
 the issue only when those facts do not justify the design.
 
-## SPI Placement Finding Contract
+## SPI Placement Proof Gate
 
-Do not publish a statement such as `a database plugin implementation is packaged in a shared core
-module` as a finding by itself. It names only a candidate smell. For every plugin placement
-finding, report:
+Treat a statement such as `a database plugin implementation is packaged in a shared core module`
+as a candidate smell, not a conclusion. Before confirming a plugin placement finding, establish
+these facts internally:
 
 1. The concrete SPI implementation, current module, and tight source location.
 2. Why the current module is shared or neutral, proven through its POM, consumers, public contract,
@@ -138,15 +138,14 @@ finding, report:
 7. The strongest counterexample checked, including infrastructure-owned variation, bootstrap
    assembly, deliberately closed sets, default implementations, and dependency reversal.
 
-Use actual repository identifiers to summarize `Current ownership`. Summarize `Expected ownership`
-with an existing module when one is proven, or with an evidence-backed responsibility boundary when
-no existing module can own the behavior. For a new boundary, do not invent a module name, path, or
-hierarchy; explain why current owners are invalid, name the implementation, dependencies,
-registrations, and resources it would own, and state the required packaging or assembly changes.
-For example, a proven database placement issue may keep the SPI contract and neutral loader in a
-shared module, move the database implementation, registration, resources, and dedicated
-dependencies to the maintained database plugin module or a proven new database-plugin boundary,
-and keep explicit plugin inclusion in the distribution assembly. This is only a structure for
-reporting; derive every named move from the current repository. If the report cannot identify these
-facts, retain the item as a candidate or evidence limitation rather than asking the reader to infer
-the problem.
+Use actual repository identifiers to derive current ownership. Derive expected ownership from an
+existing module when one is proven, or from an evidence-backed responsibility boundary when no
+existing module can own the behavior. For a new boundary, do not invent a module name, path, or
+hierarchy; establish why current owners are invalid, which implementation, dependencies,
+registrations, and resources the new boundary owns, and which packaging or assembly declarations
+change. If these facts cannot be established, retain the item as an internal candidate and do not
+publish it.
+
+Use this proof only to produce the concise diagnosis, key locations, minimum correction, change
+scope, and development-effort conclusion required by `SKILL.md`. Do not reproduce the numbered
+proof, complete path, counterexamples, or ownership derivation in the report.

--- a/.codex/skills/audit-shardingsphere-design/references/test-design.md
+++ b/.codex/skills/audit-shardingsphere-design/references/test-design.md
@@ -72,6 +72,7 @@ before adding a coverage-only test.
 ## Reporting
 
 Tie every test finding to the production regression that can currently escape or to the production
-design distorted for testing. State the smallest correction direction without generating tests or
-patches. Keep explicit naming, assertion, Mockito, and JUnit rule violations separate from semantic
-test-design findings.
+design distorted for testing. Complete the test entry, setup, invocation, assertion, owner, and
+counter-evidence analysis internally. Publish only the final diagnosis and remediation conclusions
+required by `SKILL.md`; do not output the test-path walkthrough or candidate analysis. Keep explicit
+naming, assertion, Mockito, and JUnit rule violations separate from semantic test-design findings.


### PR DESCRIPTION
- separate internal reasoning from published conclusions
- add minimum change scope and person-day estimates
- keep SPI and test proof details internal
