### PR TITLE
Refactor MariaDB database metadata delegation

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/AbstractDelegatingDialectDatabaseMetaData.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/AbstractDelegatingDialectDatabaseMetaData.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.connector.core.metadata.database.metadata;
+
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.NullsOrderType;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.altertable.DialectAlterTableOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.column.DialectColumnOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.connection.DialectConnectionOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.function.DialectFunctionOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.index.DialectIndexOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.join.DialectJoinOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.keygen.DialectGeneratedKeyOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.pagination.DialectPaginationOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.sql.DialectSQLOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.sqlbatch.DialectSQLBatchOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.table.DialectDriverQuerySystemCatalogOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.version.DialectProtocolVersionOption;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Delegating dialect database meta data.
+ *
+ * <p>Subclasses own database type identity and may override dialect-specific behavior.</p>
+ */
+public abstract class AbstractDelegatingDialectDatabaseMetaData implements DialectDatabaseMetaData {
+    
+    private final DialectDatabaseMetaData delegate;
+    
+    /**
+     * Construct a delegating dialect database meta data.
+     *
+     * @param delegate dialect database meta data delegate
+     * @throws NullPointerException if delegate is null
+     */
+    protected AbstractDelegatingDialectDatabaseMetaData(final DialectDatabaseMetaData delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+    
+    @Override
+    public QuoteCharacter getQuoteCharacter() {
+        return delegate.getQuoteCharacter();
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return delegate.getIdentifierPatternType();
+    }
+    
+    @Override
+    public NullsOrderType getDefaultNullsOrderType() {
+        return delegate.getDefaultNullsOrderType();
+    }
+    
+    @Override
+    public DialectDataTypeOption getDataTypeOption() {
+        return delegate.getDataTypeOption();
+    }
+    
+    @Override
+    public Optional<DialectDriverQuerySystemCatalogOption> getDriverQuerySystemCatalogOption() {
+        return delegate.getDriverQuerySystemCatalogOption();
+    }
+    
+    @Override
+    public DialectSchemaOption getSchemaOption() {
+        return delegate.getSchemaOption();
+    }
+    
+    @Override
+    public DialectColumnOption getColumnOption() {
+        return delegate.getColumnOption();
+    }
+    
+    @Override
+    public DialectIndexOption getIndexOption() {
+        return delegate.getIndexOption();
+    }
+    
+    @Override
+    public DialectConnectionOption getConnectionOption() {
+        return delegate.getConnectionOption();
+    }
+    
+    @Override
+    public DialectTransactionOption getTransactionOption() {
+        return delegate.getTransactionOption();
+    }
+    
+    @Override
+    public DialectJoinOption getJoinOption() {
+        return delegate.getJoinOption();
+    }
+    
+    @Override
+    public DialectPaginationOption getPaginationOption() {
+        return delegate.getPaginationOption();
+    }
+    
+    @Override
+    public Optional<DialectGeneratedKeyOption> getGeneratedKeyOption() {
+        return delegate.getGeneratedKeyOption();
+    }
+    
+    @Override
+    public Optional<DialectAlterTableOption> getAlterTableOption() {
+        return delegate.getAlterTableOption();
+    }
+    
+    @Override
+    public DialectSQLBatchOption getSQLBatchOption() {
+        return delegate.getSQLBatchOption();
+    }
+    
+    @Override
+    public DialectSQLOption getSQLOption() {
+        return delegate.getSQLOption();
+    }
+    
+    @Override
+    public DialectProtocolVersionOption getProtocolVersionOption() {
+        return delegate.getProtocolVersionOption();
+    }
+    
+    @Override
+    public DialectFunctionOption getFunctionOption() {
+        return delegate.getFunctionOption();
+    }
+    
+    @Override
+    public abstract String getDatabaseType();
+}

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/AbstractDelegatingDialectDatabaseMetaDataTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/AbstractDelegatingDialectDatabaseMetaDataTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.connector.core.metadata.database.metadata;
+
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.NullsOrderType;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.altertable.DialectAlterTableOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.column.DialectColumnOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.connection.DialectConnectionOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.function.DialectFunctionOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.index.DialectIndexOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.join.DialectJoinOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.keygen.DialectGeneratedKeyOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.pagination.DialectPaginationOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.sql.DialectSQLOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.sqlbatch.DialectSQLBatchOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.table.DialectDriverQuerySystemCatalogOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.version.DialectProtocolVersionOption;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class AbstractDelegatingDialectDatabaseMetaDataTest {
+    
+    private final DialectDatabaseMetaData delegate = mock(DialectDatabaseMetaData.class);
+    
+    private final DialectDatabaseMetaData metaData = new FixtureDelegatingDialectDatabaseMetaData(delegate);
+    
+    @Test
+    void assertDelegate() {
+        when(delegate.getQuoteCharacter()).thenReturn(QuoteCharacter.BACK_QUOTE);
+        assertThat(metaData.getQuoteCharacter(), is(delegate.getQuoteCharacter()));
+        when(delegate.getIdentifierPatternType()).thenReturn(IdentifierPatternType.KEEP_ORIGIN);
+        assertThat(metaData.getIdentifierPatternType(), is(delegate.getIdentifierPatternType()));
+        when(delegate.getDefaultNullsOrderType()).thenReturn(NullsOrderType.HIGH);
+        assertThat(metaData.getDefaultNullsOrderType(), is(delegate.getDefaultNullsOrderType()));
+        when(delegate.getDataTypeOption()).thenReturn(mock(DialectDataTypeOption.class));
+        assertThat(metaData.getDataTypeOption(), is(delegate.getDataTypeOption()));
+        when(delegate.getDriverQuerySystemCatalogOption()).thenReturn(Optional.of(mock(DialectDriverQuerySystemCatalogOption.class)));
+        assertThat(metaData.getDriverQuerySystemCatalogOption(), is(delegate.getDriverQuerySystemCatalogOption()));
+        when(delegate.getSchemaOption()).thenReturn(mock(DialectSchemaOption.class));
+        assertThat(metaData.getSchemaOption(), is(delegate.getSchemaOption()));
+        when(delegate.getColumnOption()).thenReturn(mock(DialectColumnOption.class));
+        assertThat(metaData.getColumnOption(), is(delegate.getColumnOption()));
+        when(delegate.getIndexOption()).thenReturn(mock(DialectIndexOption.class));
+        assertThat(metaData.getIndexOption(), is(delegate.getIndexOption()));
+        when(delegate.getConnectionOption()).thenReturn(mock(DialectConnectionOption.class));
+        assertThat(metaData.getConnectionOption(), is(delegate.getConnectionOption()));
+        when(delegate.getTransactionOption()).thenReturn(mock(DialectTransactionOption.class));
+        assertThat(metaData.getTransactionOption(), is(delegate.getTransactionOption()));
+        when(delegate.getJoinOption()).thenReturn(mock(DialectJoinOption.class));
+        assertThat(metaData.getJoinOption(), is(delegate.getJoinOption()));
+        when(delegate.getPaginationOption()).thenReturn(mock(DialectPaginationOption.class));
+        assertThat(metaData.getPaginationOption(), is(delegate.getPaginationOption()));
+        when(delegate.getGeneratedKeyOption()).thenReturn(Optional.of(mock(DialectGeneratedKeyOption.class)));
+        assertThat(metaData.getGeneratedKeyOption(), is(delegate.getGeneratedKeyOption()));
+        when(delegate.getAlterTableOption()).thenReturn(Optional.of(mock(DialectAlterTableOption.class)));
+        assertThat(metaData.getAlterTableOption(), is(delegate.getAlterTableOption()));
+        when(delegate.getSQLBatchOption()).thenReturn(mock(DialectSQLBatchOption.class));
+        assertThat(metaData.getSQLBatchOption(), is(delegate.getSQLBatchOption()));
+        when(delegate.getSQLOption()).thenReturn(mock(DialectSQLOption.class));
+        assertThat(metaData.getSQLOption(), is(delegate.getSQLOption()));
+        when(delegate.getProtocolVersionOption()).thenReturn(mock(DialectProtocolVersionOption.class));
+        assertThat(metaData.getProtocolVersionOption(), is(delegate.getProtocolVersionOption()));
+        when(delegate.getFunctionOption()).thenReturn(mock(DialectFunctionOption.class));
+        assertThat(metaData.getFunctionOption(), is(delegate.getFunctionOption()));
+    }
+    
+    @Test
+    void assertRejectNullDelegate() {
+        assertThrows(NullPointerException.class, () -> new FixtureDelegatingDialectDatabaseMetaData(null));
+    }
+    
+    @Test
+    void assertBranchIdentity() {
+        assertThat(metaData.getDatabaseType(), is("BRANCH"));
+        assertThat(metaData.getType().getType(), is("BRANCH"));
+        verifyNoInteractions(delegate);
+    }
+    
+    private static final class FixtureDelegatingDialectDatabaseMetaData extends AbstractDelegatingDialectDatabaseMetaData {
+        
+        private FixtureDelegatingDialectDatabaseMetaData(final DialectDatabaseMetaData delegate) {
+            super(delegate);
+        }
+        
+        @Override
+        public String getDatabaseType() {
+            return "BRANCH";
+        }
+    }
+}

--- a/database/connector/dialect/mariadb/src/main/java/org/apache/shardingsphere/database/connector/mariadb/metadata/database/MariaDBDatabaseMetaData.java
+++ b/database/connector/dialect/mariadb/src/main/java/org/apache/shardingsphere/database/connector/mariadb/metadata/database/MariaDBDatabaseMetaData.java
@@ -17,85 +17,26 @@
 
 package org.apache.shardingsphere.database.connector.mariadb.metadata.database;
 
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.NullsOrderType;
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.column.DialectColumnOption;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.connection.DialectConnectionOption;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.join.DialectJoinOption;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.keygen.DialectGeneratedKeyOption;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.AbstractDelegatingDialectDatabaseMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.transaction.DDLCommitPolicy;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.version.DialectProtocolVersionOption;
 import org.apache.shardingsphere.database.connector.mysql.metadata.database.MySQLDatabaseMetaData;
 
 import java.util.Collections;
-import java.util.Optional;
 
 /**
  * Database meta data of MariaDB.
  */
-public final class MariaDBDatabaseMetaData implements DialectDatabaseMetaData {
+public final class MariaDBDatabaseMetaData extends AbstractDelegatingDialectDatabaseMetaData {
     
-    private final DialectDatabaseMetaData delegate = new MySQLDatabaseMetaData();
-    
-    @Override
-    public QuoteCharacter getQuoteCharacter() {
-        return delegate.getQuoteCharacter();
-    }
-    
-    @Override
-    public IdentifierPatternType getIdentifierPatternType() {
-        return delegate.getIdentifierPatternType();
-    }
-    
-    @Override
-    public NullsOrderType getDefaultNullsOrderType() {
-        return delegate.getDefaultNullsOrderType();
-    }
-    
-    @Override
-    public DialectDataTypeOption getDataTypeOption() {
-        return delegate.getDataTypeOption();
-    }
-    
-    @Override
-    public DialectColumnOption getColumnOption() {
-        return delegate.getColumnOption();
-    }
-    
-    @Override
-    public DialectSchemaOption getSchemaOption() {
-        return delegate.getSchemaOption();
-    }
-    
-    @Override
-    public DialectConnectionOption getConnectionOption() {
-        return delegate.getConnectionOption();
+    public MariaDBDatabaseMetaData() {
+        super(new MySQLDatabaseMetaData());
     }
     
     @Override
     public DialectTransactionOption getTransactionOption() {
         return new DialectTransactionOption(false, DDLCommitPolicy.NO_ADDITIONAL_COMMIT, true, false, true, false, false,
                 Collections.singleton("org.mariadb.jdbc.MariaDbDataSource"));
-    }
-    
-    @Override
-    public DialectJoinOption getJoinOption() {
-        return delegate.getJoinOption();
-    }
-    
-    @Override
-    public Optional<DialectGeneratedKeyOption> getGeneratedKeyOption() {
-        return delegate.getGeneratedKeyOption();
-    }
-    
-    @Override
-    public DialectProtocolVersionOption getProtocolVersionOption() {
-        return delegate.getProtocolVersionOption();
     }
     
     @Override


### PR DESCRIPTION
What: Add a database-neutral metadata delegation base and migrate MariaDB while preserving its transaction differences.

Why: Centralizing complete delegation prevents branch metadata from drifting when the trunk implementation evolves.

Changes proposed in this pull request:
  - Refactor MariaDB database metadata delegation

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
