### PR TITLE
Match mask table names case-insensitively in DistSQL executors

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 1. Metadata: Fix Oracle metadata version comparison skipping identity and collation columns on 18c and later - [#39104](https://github.com/apache/shardingsphere/pull/39104)
 1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)
 1. DistSQL: Use case-insensitive table name matching in broadcast create and drop executors - [#39200](https://github.com/apache/shardingsphere/pull/39200)
+1. DistSQL: Match mask table names case-insensitively in create and alter executors - [#39361](https://github.com/apache/shardingsphere/pull/39361)
 1. JDBC: Fix stale generated values leaking into prepared statement executeBatch calls without pending batches - [#38160](https://github.com/apache/shardingsphere/pull/38160)
 1. JDBC: Fix MySQL-compatible typed string conversion for `ResultSet#getObject(index, Class<T>)` - [#38444](https://github.com/apache/shardingsphere/pull/38444)
 1. Proxy: Resolve MySQL prepared statement parameter columns for where clause - [#38382](https://github.com/apache/shardingsphere/pull/38382)

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.data
 import org.apache.shardingsphere.distsql.handler.required.DistSQLExecutorCurrentRuleRequired;
 import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.DuplicateRuleException;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.MissingRequiredRuleException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.mask.config.MaskRuleConfiguration;
@@ -35,6 +36,7 @@ import org.apache.shardingsphere.mask.rule.MaskRule;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -51,7 +53,19 @@ public final class AlterMaskRuleExecutor implements DatabaseRuleAlterExecutor<Al
     
     @Override
     public void checkBeforeUpdate(final AlterMaskRuleStatement sqlStatement) {
+        checkDuplicatedRuleNames(sqlStatement);
         checkToBeAlteredRules(sqlStatement);
+    }
+    
+    private void checkDuplicatedRuleNames(final AlterMaskRuleStatement sqlStatement) {
+        Collection<String> uniqueTableNames = new CaseInsensitiveSet<>();
+        Collection<String> duplicatedTableNames = new LinkedList<>();
+        for (String each : getToBeAlteredMaskTableNames(sqlStatement)) {
+            if (!uniqueTableNames.add(each)) {
+                duplicatedTableNames.add(each);
+            }
+        }
+        ShardingSpherePreconditions.checkMustEmpty(duplicatedTableNames, () -> new DuplicateRuleException("mask", database.getName(), duplicatedTableNames));
     }
     
     private void checkToBeAlteredRules(final AlterMaskRuleStatement sqlStatement) {

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mask.distsql.handler.update;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Setter;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.type.DatabaseRuleAlterExecutor;
 import org.apache.shardingsphere.distsql.handler.required.DistSQLExecutorCurrentRuleRequired;
@@ -55,7 +56,7 @@ public final class AlterMaskRuleExecutor implements DatabaseRuleAlterExecutor<Al
     }
     
     private void checkToBeAlteredRules(final AlterMaskRuleStatement sqlStatement) {
-        Collection<String> currentMaskTableNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toList());
+        Collection<String> currentMaskTableNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toCollection(CaseInsensitiveSet::new));
         Collection<String> notExistedMaskTableNames = getToBeAlteredMaskTableNames(sqlStatement).stream().filter(each -> !currentMaskTableNames.contains(each)).collect(Collectors.toList());
         ShardingSpherePreconditions.checkMustEmpty(notExistedMaskTableNames, () -> new MissingRequiredRuleException("Mask", database.getName(), notExistedMaskTableNames));
     }
@@ -71,7 +72,7 @@ public final class AlterMaskRuleExecutor implements DatabaseRuleAlterExecutor<Al
     
     @Override
     public MaskRuleConfiguration buildToBeDroppedRuleConfiguration(final MaskRuleConfiguration toBeAlteredRuleConfig) {
-        Collection<String> toBeAlteredTableNames = toBeAlteredRuleConfig.getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toList());
+        Collection<String> toBeAlteredTableNames = toBeAlteredRuleConfig.getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toCollection(CaseInsensitiveSet::new));
         Collection<MaskColumnRuleConfiguration> columns = rule.getConfiguration().getTables().stream().filter(each -> !toBeAlteredTableNames.contains(each.getName()))
                 .flatMap(each -> each.getColumns().stream()).collect(Collectors.toList());
         columns.addAll(toBeAlteredRuleConfig.getTables().stream().flatMap(each -> each.getColumns().stream()).collect(Collectors.toList()));

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
@@ -34,7 +34,6 @@ import org.apache.shardingsphere.mask.distsql.statement.AlterMaskRuleStatement;
 import org.apache.shardingsphere.mask.rule.MaskRule;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -83,7 +82,13 @@ public final class AlterMaskRuleExecutor implements DatabaseRuleAlterExecutor<Al
                 toBeDroppedAlgorithms.put(each, rule.getConfiguration().getMaskAlgorithms().get(each));
             }
         }
-        return new MaskRuleConfiguration(Collections.emptyList(), toBeDroppedAlgorithms);
+        return new MaskRuleConfiguration(getToBeDroppedTables(toBeAlteredRuleConfig, toBeAlteredTableNames), toBeDroppedAlgorithms);
+    }
+    
+    private Collection<MaskTableRuleConfiguration> getToBeDroppedTables(final MaskRuleConfiguration toBeAlteredRuleConfig, final Collection<String> toBeAlteredTableNames) {
+        Collection<String> toBeAlteredCaseSensitiveTableNames = toBeAlteredRuleConfig.getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toSet());
+        return rule.getConfiguration().getTables().stream()
+                .filter(each -> toBeAlteredTableNames.contains(each.getName()) && !toBeAlteredCaseSensitiveTableNames.contains(each.getName())).collect(Collectors.toList());
     }
     
     @Override

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutor.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutor.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.mask.rule.MaskRule;
 import org.apache.shardingsphere.mask.spi.MaskAlgorithm;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.stream.Collectors;
 
@@ -59,11 +60,16 @@ public final class CreateMaskRuleExecutor implements DatabaseRuleCreateExecutor<
     }
     
     private void checkDuplicatedRuleNames(final CreateMaskRuleStatement sqlStatement) {
-        if (null != rule) {
-            Collection<String> currentRuleNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toCollection(CaseInsensitiveSet::new));
-            Collection<String> duplicatedRuleNames = sqlStatement.getRules().stream().map(MaskRuleSegment::getTableName).filter(currentRuleNames::contains).collect(Collectors.toList());
-            ShardingSpherePreconditions.checkMustEmpty(duplicatedRuleNames, () -> new DuplicateRuleException("mask", database.getName(), duplicatedRuleNames));
+        Collection<String> duplicatedRuleNames = getDuplicatedRuleNames(sqlStatement);
+        ShardingSpherePreconditions.checkMustEmpty(duplicatedRuleNames, () -> new DuplicateRuleException("mask", database.getName(), duplicatedRuleNames));
+    }
+    
+    private Collection<String> getDuplicatedRuleNames(final CreateMaskRuleStatement sqlStatement) {
+        if (null == rule) {
+            return Collections.emptyList();
         }
+        Collection<String> currentRuleNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toCollection(CaseInsensitiveSet::new));
+        return sqlStatement.getRules().stream().map(MaskRuleSegment::getTableName).filter(currentRuleNames::contains).collect(Collectors.toList());
     }
     
     private void checkAlgorithms(final CreateMaskRuleStatement sqlStatement) {
@@ -74,7 +80,15 @@ public final class CreateMaskRuleExecutor implements DatabaseRuleCreateExecutor<
     
     @Override
     public MaskRuleConfiguration buildToBeCreatedRuleConfiguration(final CreateMaskRuleStatement sqlStatement) {
-        return MaskRuleStatementConverter.convert(sqlStatement.getRules());
+        return MaskRuleStatementConverter.convert(getToBeCreatedRuleSegments(sqlStatement));
+    }
+    
+    private Collection<MaskRuleSegment> getToBeCreatedRuleSegments(final CreateMaskRuleStatement sqlStatement) {
+        if (!ifNotExists) {
+            return sqlStatement.getRules();
+        }
+        Collection<String> duplicatedRuleNames = getDuplicatedRuleNames(sqlStatement);
+        return sqlStatement.getRules().stream().filter(each -> !duplicatedRuleNames.contains(each.getTableName())).collect(Collectors.toList());
     }
     
     @Override

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutor.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mask.distsql.handler.update;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Setter;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.type.DatabaseRuleCreateExecutor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
@@ -59,7 +60,7 @@ public final class CreateMaskRuleExecutor implements DatabaseRuleCreateExecutor<
     
     private void checkDuplicatedRuleNames(final CreateMaskRuleStatement sqlStatement) {
         if (null != rule) {
-            Collection<String> currentRuleNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toList());
+            Collection<String> currentRuleNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toCollection(CaseInsensitiveSet::new));
             Collection<String> duplicatedRuleNames = sqlStatement.getRules().stream().map(MaskRuleSegment::getTableName).filter(currentRuleNames::contains).collect(Collectors.toList());
             ShardingSpherePreconditions.checkMustEmpty(duplicatedRuleNames, () -> new DuplicateRuleException("mask", database.getName(), duplicatedRuleNames));
         }

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.mask.distsql.handler.update;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.DatabaseRuleDefinitionExecutor;
 import org.apache.shardingsphere.distsql.segment.AlgorithmSegment;
 import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
+import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.DuplicateRuleException;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.MissingRequiredRuleException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -82,6 +83,15 @@ class AlterMaskRuleExecutorTest {
         }
         when(database.getName()).thenReturn("foo_db");
         assertThrows(expectedException, () -> executor.checkBeforeUpdate(sqlStatement));
+    }
+    
+    @Test
+    void assertCheckBeforeUpdateWithCaseCollidingTablesInOneStatement() {
+        executor.setRule(mock(MaskRule.class));
+        when(database.getName()).thenReturn("foo_db");
+        AlterMaskRuleStatement sqlStatement = new AlterMaskRuleStatement(
+                Arrays.asList(createRuleSegment("t_order", "order_id", "MD5"), createRuleSegment("T_ORDER", "user_id", "MD5")));
+        assertThrows(DuplicateRuleException.class, () -> executor.checkBeforeUpdate(sqlStatement));
     }
     
     @Test

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
@@ -30,6 +30,8 @@ import org.apache.shardingsphere.mask.distsql.segment.MaskColumnSegment;
 import org.apache.shardingsphere.mask.distsql.segment.MaskRuleSegment;
 import org.apache.shardingsphere.mask.distsql.statement.AlterMaskRuleStatement;
 import org.apache.shardingsphere.mask.rule.MaskRule;
+import org.apache.shardingsphere.mode.spi.rule.RuleChangedItemType;
+import org.apache.shardingsphere.mode.spi.rule.RuleItemConfigurationChangedProcessor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,6 +45,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -108,10 +111,30 @@ class AlterMaskRuleExecutorTest {
         executor.setRule(createRule(createCurrentRuleConfigurationWithAlgorithms()));
         MaskTableRuleConfiguration toBeAlteredTable = new MaskTableRuleConfiguration("T_ORDER", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "t_order_order_id_sm3")));
         MaskRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(new MaskRuleConfiguration(Collections.singleton(toBeAlteredTable), Collections.emptyMap()));
-        assertTrue(actual.getTables().isEmpty());
+        assertThat(actual.getTables().size(), is(1));
+        assertThat(actual.getTables().iterator().next().getName(), is("t_order"));
         assertThat(actual.getMaskAlgorithms().size(), is(2));
         assertTrue(actual.getMaskAlgorithms().containsKey("order_mask"));
         assertTrue(actual.getMaskAlgorithms().containsKey("unused_mask"));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    void assertUpdatePathWithDifferentTableNameCase() {
+        MaskRuleConfiguration currentRuleConfig = createCurrentRuleConfigurationWithAlgorithms();
+        executor.setRule(createRule(currentRuleConfig));
+        MaskTableRuleConfiguration toBeAlteredTable = new MaskTableRuleConfiguration("T_ORDER", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "t_order_order_id_sm3")));
+        MaskRuleConfiguration toBeDroppedRuleConfig = executor.buildToBeDroppedRuleConfiguration(new MaskRuleConfiguration(Collections.singleton(toBeAlteredTable), Collections.emptyMap()));
+        RuleItemConfigurationChangedProcessor<MaskRuleConfiguration, MaskTableRuleConfiguration> processor = TypedSPILoader.getService(
+                RuleItemConfigurationChangedProcessor.class, new RuleChangedItemType("mask", "tables"));
+        processor.changeRuleItemConfiguration("T_ORDER", currentRuleConfig, toBeAlteredTable);
+        for (MaskTableRuleConfiguration each : toBeDroppedRuleConfig.getTables()) {
+            processor.dropRuleItemConfiguration(each.getName(), currentRuleConfig);
+        }
+        Collection<MaskTableRuleConfiguration> actual = currentRuleConfig.getTables().stream().filter(each -> "t_order".equalsIgnoreCase(each.getName())).collect(Collectors.toList());
+        assertThat(actual.size(), is(1));
+        assertThat(actual.iterator().next().getName(), is("T_ORDER"));
+        assertThat(actual.iterator().next().getColumns().iterator().next().getMaskAlgorithm(), is("t_order_order_id_sm3"));
     }
     
     @Test
@@ -146,9 +169,9 @@ class AlterMaskRuleExecutorTest {
         algorithmConfigs.put("order_mask", new AlgorithmConfiguration("MD5", new Properties()));
         algorithmConfigs.put("user_mask", new AlgorithmConfiguration("MD5", new Properties()));
         algorithmConfigs.put("unused_mask", new AlgorithmConfiguration("SM3", new Properties()));
-        return new MaskRuleConfiguration(Arrays.asList(
+        return new MaskRuleConfiguration(new LinkedList<>(Arrays.asList(
                 new MaskTableRuleConfiguration("t_order", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "order_mask"))),
-                new MaskTableRuleConfiguration("t_user", Collections.singleton(new MaskColumnRuleConfiguration("user_id", "user_mask")))), algorithmConfigs);
+                new MaskTableRuleConfiguration("t_user", Collections.singleton(new MaskColumnRuleConfiguration("user_id", "user_mask"))))), algorithmConfigs);
     }
     
     private MaskRule createRule(final MaskRuleConfiguration ruleConfig) {

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
@@ -95,17 +95,22 @@ class AlterMaskRuleExecutorTest {
     
     @Test
     void assertBuildToBeDroppedRuleConfiguration() {
-        Map<String, AlgorithmConfiguration> currentAlgorithms = new LinkedHashMap<>(3, 1F);
-        currentAlgorithms.put("order_mask", new AlgorithmConfiguration("MD5", new Properties()));
-        currentAlgorithms.put("user_mask", new AlgorithmConfiguration("MD5", new Properties()));
-        currentAlgorithms.put("unused_mask", new AlgorithmConfiguration("SM3", new Properties()));
-        executor.setRule(createRule(new MaskRuleConfiguration(Arrays.asList(
-                new MaskTableRuleConfiguration("t_order", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "order_mask"))),
-                new MaskTableRuleConfiguration("t_user", Collections.singleton(new MaskColumnRuleConfiguration("user_id", "user_mask")))), currentAlgorithms)));
+        executor.setRule(createRule(createCurrentRuleConfigurationWithAlgorithms()));
         MaskTableRuleConfiguration toBeAlteredTable = new MaskTableRuleConfiguration("t_order", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "order_mask")));
         MaskRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(new MaskRuleConfiguration(Collections.singleton(toBeAlteredTable), Collections.emptyMap()));
         assertTrue(actual.getTables().isEmpty());
         assertThat(actual.getMaskAlgorithms().size(), is(1));
+        assertTrue(actual.getMaskAlgorithms().containsKey("unused_mask"));
+    }
+    
+    @Test
+    void assertBuildToBeDroppedRuleConfigurationWithDifferentTableNameCase() {
+        executor.setRule(createRule(createCurrentRuleConfigurationWithAlgorithms()));
+        MaskTableRuleConfiguration toBeAlteredTable = new MaskTableRuleConfiguration("T_ORDER", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "t_order_order_id_sm3")));
+        MaskRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(new MaskRuleConfiguration(Collections.singleton(toBeAlteredTable), Collections.emptyMap()));
+        assertTrue(actual.getTables().isEmpty());
+        assertThat(actual.getMaskAlgorithms().size(), is(2));
+        assertTrue(actual.getMaskAlgorithms().containsKey("order_mask"));
         assertTrue(actual.getMaskAlgorithms().containsKey("unused_mask"));
     }
     
@@ -122,7 +127,9 @@ class AlterMaskRuleExecutorTest {
                         createCurrentRuleConfiguration(Collections.singleton("t_order")), MissingRequiredRuleException.class),
                 Arguments.of("one table exists and one missing",
                         new AlterMaskRuleStatement(Arrays.asList(createRuleSegment("t_order", "order_id", "MD5"), createRuleSegment("t_missing", "user_id", "AES"))),
-                        createCurrentRuleConfiguration(Collections.singleton("t_order")), MissingRequiredRuleException.class));
+                        createCurrentRuleConfiguration(Collections.singleton("t_order")), MissingRequiredRuleException.class),
+                Arguments.of("existing table in different case", new AlterMaskRuleStatement(Collections.singleton(createRuleSegment("T_ORDER", "order_id", "MD5"))),
+                        createCurrentRuleConfiguration(Collections.singleton("t_order")), null));
     }
     
     private static MaskRuleSegment createRuleSegment(final String tableName, final String columnName, final String algorithmType) {
@@ -132,6 +139,16 @@ class AlterMaskRuleExecutorTest {
     private static MaskRuleConfiguration createCurrentRuleConfiguration(final Collection<String> tableNames) {
         Collection<MaskTableRuleConfiguration> tableRuleConfigs = tableNames.stream().map(each -> new MaskTableRuleConfiguration(each, Collections.emptyList())).collect(Collectors.toList());
         return new MaskRuleConfiguration(tableRuleConfigs, Collections.emptyMap());
+    }
+    
+    private static MaskRuleConfiguration createCurrentRuleConfigurationWithAlgorithms() {
+        Map<String, AlgorithmConfiguration> algorithmConfigs = new LinkedHashMap<>(3, 1F);
+        algorithmConfigs.put("order_mask", new AlgorithmConfiguration("MD5", new Properties()));
+        algorithmConfigs.put("user_mask", new AlgorithmConfiguration("MD5", new Properties()));
+        algorithmConfigs.put("unused_mask", new AlgorithmConfiguration("SM3", new Properties()));
+        return new MaskRuleConfiguration(Arrays.asList(
+                new MaskTableRuleConfiguration("t_order", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "order_mask"))),
+                new MaskTableRuleConfiguration("t_user", Collections.singleton(new MaskColumnRuleConfiguration("user_id", "user_mask")))), algorithmConfigs);
     }
     
     private MaskRule createRule(final MaskRuleConfiguration ruleConfig) {

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutorTest.java
@@ -55,7 +55,16 @@ class CreateMaskRuleExecutorTest {
     void assertExecuteUpdateWithDuplicateMaskRule() {
         MaskRule rule = mock(MaskRule.class);
         when(rule.getConfiguration()).thenReturn(getCurrentRuleConfiguration());
-        assertThrows(DuplicateRuleException.class, () -> new DistSQLUpdateExecuteEngine(createDuplicatedSQLStatement(false, "MD5"), "foo_db", mockContextManager(rule), null).executeUpdate());
+        assertThrows(DuplicateRuleException.class,
+                () -> new DistSQLUpdateExecuteEngine(createDuplicatedSQLStatement(false, "MD5", "t_mask", "t_order"), "foo_db", mockContextManager(rule), null).executeUpdate());
+    }
+    
+    @Test
+    void assertExecuteUpdateWithDuplicateMaskRuleInDifferentCase() {
+        MaskRule rule = mock(MaskRule.class);
+        when(rule.getConfiguration()).thenReturn(getCurrentRuleConfiguration());
+        assertThrows(DuplicateRuleException.class,
+                () -> new DistSQLUpdateExecuteEngine(createDuplicatedSQLStatement(false, "MD5", "T_MASK", "T_ORDER"), "foo_db", mockContextManager(rule), null).executeUpdate());
     }
     
     @Test
@@ -93,11 +102,11 @@ class CreateMaskRuleExecutorTest {
         return new CreateMaskRuleStatement(ifNotExists, rules);
     }
     
-    private CreateMaskRuleStatement createDuplicatedSQLStatement(final boolean ifNotExists, final String algorithmType) {
+    private CreateMaskRuleStatement createDuplicatedSQLStatement(final boolean ifNotExists, final String algorithmType, final String maskTableName, final String orderTableName) {
         MaskColumnSegment tMaskColumnSegment = new MaskColumnSegment("user_id", new AlgorithmSegment(algorithmType, new Properties()));
         MaskColumnSegment tOrderColumnSegment = new MaskColumnSegment("order_id", new AlgorithmSegment(algorithmType, new Properties()));
-        MaskRuleSegment tMaskRuleSegment = new MaskRuleSegment("t_mask", Collections.singleton(tMaskColumnSegment));
-        MaskRuleSegment tOrderRuleSegment = new MaskRuleSegment("t_order", Collections.singleton(tOrderColumnSegment));
+        MaskRuleSegment tMaskRuleSegment = new MaskRuleSegment(maskTableName, Collections.singleton(tMaskColumnSegment));
+        MaskRuleSegment tOrderRuleSegment = new MaskRuleSegment(orderTableName, Collections.singleton(tOrderColumnSegment));
         Collection<MaskRuleSegment> rules = new LinkedList<>();
         rules.add(tMaskRuleSegment);
         rules.add(tOrderRuleSegment);

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutorTest.java
@@ -18,10 +18,12 @@
 package org.apache.shardingsphere.mask.distsql.handler.update;
 
 import org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine;
+import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.DatabaseRuleDefinitionExecutor;
 import org.apache.shardingsphere.distsql.segment.AlgorithmSegment;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.DuplicateRuleException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mask.config.MaskRuleConfiguration;
 import org.apache.shardingsphere.mask.config.rule.MaskTableRuleConfiguration;
 import org.apache.shardingsphere.mask.distsql.segment.MaskColumnSegment;
@@ -89,6 +91,22 @@ class CreateMaskRuleExecutorTest {
         new DistSQLUpdateExecuteEngine(sqlStatement, "foo_db", contextManager, null).executeUpdate();
         MetaDataManagerPersistService metaDataManagerPersistService = contextManager.getPersistServiceFacade().getModeFacade().getMetaDataManagerService();
         assertDoesNotThrow(() -> metaDataManagerPersistService.alterRuleConfiguration(any(), ArgumentMatchers.argThat(this::assertRuleConfiguration)));
+    }
+    
+    @Test
+    void assertBuildToBeCreatedRuleConfigurationWithIfNotExistsWhenTableNameCaseDiffers() {
+        CreateMaskRuleExecutor executor = (CreateMaskRuleExecutor) TypedSPILoader.getService(DatabaseRuleDefinitionExecutor.class, CreateMaskRuleStatement.class);
+        executor.setDatabase(mock(ShardingSphereDatabase.class));
+        MaskRule rule = mock(MaskRule.class);
+        when(rule.getConfiguration()).thenReturn(getCurrentRuleConfiguration());
+        executor.setRule(rule);
+        CreateMaskRuleStatement sqlStatement = createDuplicatedSQLStatement(true, "MD5", "T_ORDER", "t_new");
+        executor.checkBeforeUpdate(sqlStatement);
+        MaskRuleConfiguration actual = executor.buildToBeCreatedRuleConfiguration(sqlStatement);
+        assertThat(actual.getTables().size(), is(1));
+        assertThat(actual.getTables().iterator().next().getName(), is("t_new"));
+        assertThat(actual.getMaskAlgorithms().size(), is(1));
+        assertTrue(actual.getMaskAlgorithms().containsKey("t_new_order_id_md5"));
     }
     
     private CreateMaskRuleStatement createSQLStatement(final boolean ifNotExists, final String algorithmType) {


### PR DESCRIPTION
Fixes #39359.

Changes proposed in this pull request:
  - Collect current mask table names into `CaseInsensitiveSet` in `CreateMaskRuleExecutor.checkDuplicatedRuleNames()`, so `CREATE MASK RULE T_ORDER` on an existing `t_order` is rejected as duplicate instead of persisting a second table node.
  - Collect current mask table names into `CaseInsensitiveSet` in `AlterMaskRuleExecutor.checkToBeAlteredRules()`, so `ALTER MASK RULE T_ORDER` on an existing `t_order` is no longer rejected as missing.
  - Collect altered table names into `CaseInsensitiveSet` in `AlterMaskRuleExecutor.buildToBeDroppedRuleConfiguration()`, so the altered table's stale algorithm is dropped instead of staying counted as in use.
  - Reuses the idiom already used by `DropMaskRuleExecutor` in the same module; `MaskRule.tables` is a `CaseInsensitiveMap` and `ShowMaskRuleExecutor` already matches with `equalsIgnoreCase`, so create and alter were the only case-sensitive paths left.
  - Completes #32755, which made mask show and drop case-insensitive but left create and alter; #39200 applied the same fix to broadcast.
  - Adds one regression test per site; all three fail before this change.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
