### PR TITLE
Allow position 0 for from-x and to-y in mask algorithms

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,6 +55,7 @@
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
 1. SQL Federation: Fix SQL Federation pagination binding for long LIMIT parameters - [#39237](https://github.com/apache/shardingsphere/pull/39237)
+1. Mask: Allow position 0 for from-x and to-y in MASK_FROM_X_TO_Y and KEEP_FROM_X_TO_Y - [#39364](https://github.com/apache/shardingsphere/pull/39364)
 
 ### Enhancements
 

--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/MaskAlgorithmPropertiesChecker.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/MaskAlgorithmPropertiesChecker.java
@@ -73,6 +73,24 @@ public final class MaskAlgorithmPropertiesChecker {
         }
     }
     
+    /**
+     * Check non-negative integer.
+     *
+     * @param props properties to be checked
+     * @param propKey properties key to be checked
+     * @param algorithm mask algorithm
+     * @throws AlgorithmInitializationException algorithm initialization exception
+     */
+    public static void checkNonNegativeInteger(final Properties props, final String propKey, final MaskAlgorithm<?, ?> algorithm) {
+        checkRequired(props, propKey, algorithm);
+        try {
+            int integerValue = Integer.parseInt(props.getProperty(propKey));
+            ShardingSpherePreconditions.checkState(integerValue >= 0, () -> new AlgorithmInitializationException(algorithm, "%s must be a non-negative integer.", propKey));
+        } catch (final NumberFormatException ex) {
+            throw new AlgorithmInitializationException(algorithm, "%s must be a valid integer number", propKey);
+        }
+    }
+    
     private static void checkRequired(final Properties props, final String requiredPropKey, final MaskAlgorithm<?, ?> algorithm) {
         ShardingSpherePreconditions.checkContainsKey(props, requiredPropKey, () -> new AlgorithmInitializationException(algorithm, "%s is required", requiredPropKey));
     }

--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithm.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithm.java
@@ -52,12 +52,12 @@ public final class KeepFromXToYMaskAlgorithm implements MaskAlgorithm<Object, St
     }
     
     private Integer createFromX(final Properties props) {
-        MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, FROM_X, this);
+        MaskAlgorithmPropertiesChecker.checkNonNegativeInteger(props, FROM_X, this);
         return Integer.parseInt(props.getProperty(FROM_X));
     }
     
     private Integer createToY(final Properties props) {
-        MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, TO_Y, this);
+        MaskAlgorithmPropertiesChecker.checkNonNegativeInteger(props, TO_Y, this);
         return Integer.parseInt(props.getProperty(TO_Y));
     }
     

--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithm.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithm.java
@@ -52,12 +52,12 @@ public final class MaskFromXToYMaskAlgorithm implements MaskAlgorithm<Object, St
     }
     
     private Integer createFromX(final Properties props) {
-        MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, FROM_X, this);
+        MaskAlgorithmPropertiesChecker.checkNonNegativeInteger(props, FROM_X, this);
         return Integer.parseInt(props.getProperty(FROM_X));
     }
     
     private Integer createToY(final Properties props) {
-        MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, TO_Y, this);
+        MaskAlgorithmPropertiesChecker.checkNonNegativeInteger(props, TO_Y, this);
         return Integer.parseInt(props.getProperty(TO_Y));
     }
     

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/MaskAlgorithmPropertiesCheckerTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/MaskAlgorithmPropertiesCheckerTest.java
@@ -90,4 +90,34 @@ class MaskAlgorithmPropertiesCheckerTest {
         Properties props = PropertiesBuilder.build(new Property("key", "123.0"));
         assertThrows(AlgorithmInitializationException.class, () -> MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, "key", mock(MaskAlgorithm.class)));
     }
+    
+    @Test
+    void assertCheckNonNegativeIntegerSuccessWithZero() {
+        Properties props = PropertiesBuilder.build(new Property("key", "0"));
+        assertDoesNotThrow(() -> MaskAlgorithmPropertiesChecker.checkNonNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
+    
+    @Test
+    void assertCheckNonNegativeIntegerSuccessWithPositive() {
+        Properties props = PropertiesBuilder.build(new Property("key", "123"));
+        assertDoesNotThrow(() -> MaskAlgorithmPropertiesChecker.checkNonNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
+    
+    @Test
+    void assertCheckNonNegativeIntegerFailedWithNegative() {
+        Properties props = PropertiesBuilder.build(new Property("key", "-1"));
+        assertThrows(AlgorithmInitializationException.class, () -> MaskAlgorithmPropertiesChecker.checkNonNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
+    
+    @Test
+    void assertCheckNonNegativeIntegerFailedWithoutKey() {
+        Properties props = new Properties();
+        assertThrows(AlgorithmInitializationException.class, () -> MaskAlgorithmPropertiesChecker.checkNonNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
+    
+    @Test
+    void assertCheckNonNegativeIntegerFailedWithNotInteger() {
+        Properties props = PropertiesBuilder.build(new Property("key", "123.0"));
+        assertThrows(AlgorithmInitializationException.class, () -> MaskAlgorithmPropertiesChecker.checkNonNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
 }

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithmTest.java
@@ -51,6 +51,12 @@ class KeepFromXToYMaskAlgorithmTest {
         MaskAlgorithmAssertions.assertMask(type, props, plainValue, maskedValue);
     }
     
+    @ParameterizedTest(name = "{0}: {1}")
+    @ArgumentsSource(AlgorithmMaskExecuteWithZeroFromXArgumentsProvider.class)
+    void assertMaskWithZeroFromX(final String type, @SuppressWarnings("unused") final String name, final Properties props, final Object plainValue, final Object maskedValue) {
+        MaskAlgorithmAssertions.assertMask(type, props, plainValue, maskedValue);
+    }
+    
     private static final class AlgorithmInitArgumentsProvider extends MaskAlgorithmInitArgumentsProvider {
         
         AlgorithmInitArgumentsProvider() {
@@ -104,6 +110,21 @@ class KeepFromXToYMaskAlgorithmTest {
                     new MaskAlgorithmExecuteCaseAssert("plain_value_length_equals_from_X_plus_one", "abc123", "*****3"),
                     new MaskAlgorithmExecuteCaseAssert("plain_value_length_less_than_to_Y_plus_one", "abc12", "*****"),
                     new MaskAlgorithmExecuteCaseAssert("plain_value_length_equals_to_Y_plus_one", "abc123", "*****3"));
+        }
+    }
+    
+    private static final class AlgorithmMaskExecuteWithZeroFromXArgumentsProvider extends MaskAlgorithmExecuteArgumentsProvider {
+        
+        AlgorithmMaskExecuteWithZeroFromXArgumentsProvider() {
+            super("KEEP_FROM_X_TO_Y", PropertiesBuilder.build(new Property("from-x", "0"), new Property("to-y", "2"), new Property("replace-char", "*")));
+        }
+        
+        @Override
+        protected Collection<MaskAlgorithmExecuteCaseAssert> getCaseAsserts() {
+            return Arrays.asList(
+                    new MaskAlgorithmExecuteCaseAssert("normal", "abc123456", "abc******"),
+                    new MaskAlgorithmExecuteCaseAssert("plain_value_length_equals_to_Y_plus_one", "abc", "abc"),
+                    new MaskAlgorithmExecuteCaseAssert("plain_value_length_less_than_to_Y_plus_one", "ab", "ab"));
         }
     }
 }

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithmTest.java
@@ -51,6 +51,12 @@ class MaskFromXToYMaskAlgorithmTest {
         MaskAlgorithmAssertions.assertMask(type, props, plainValue, maskedValue);
     }
     
+    @ParameterizedTest(name = "{0}: {1}")
+    @ArgumentsSource(AlgorithmMaskExecuteWithZeroFromXArgumentsProvider.class)
+    void assertMaskWithZeroFromX(final String type, @SuppressWarnings("unused") final String name, final Properties props, final Object plainValue, final Object maskedValue) {
+        MaskAlgorithmAssertions.assertMask(type, props, plainValue, maskedValue);
+    }
+    
     private static final class AlgorithmInitArgumentsProvider extends MaskAlgorithmInitArgumentsProvider {
         
         AlgorithmInitArgumentsProvider() {
@@ -102,6 +108,21 @@ class MaskFromXToYMaskAlgorithmTest {
                     new MaskAlgorithmExecuteCaseAssert("length_equals_from_X_plus_one", "abc123", "abc12*"),
                     new MaskAlgorithmExecuteCaseAssert("length_less_than_to_Y_plus_one", "abc12", "abc12"),
                     new MaskAlgorithmExecuteCaseAssert("length_equals_to_Y_plus_one", "abc123", "abc12*"));
+        }
+    }
+    
+    private static final class AlgorithmMaskExecuteWithZeroFromXArgumentsProvider extends MaskAlgorithmExecuteArgumentsProvider {
+        
+        AlgorithmMaskExecuteWithZeroFromXArgumentsProvider() {
+            super("MASK_FROM_X_TO_Y", PropertiesBuilder.build(new Property("from-x", "0"), new Property("to-y", "2"), new Property("replace-char", "*")));
+        }
+        
+        @Override
+        protected Collection<MaskAlgorithmExecuteCaseAssert> getCaseAsserts() {
+            return Arrays.asList(
+                    new MaskAlgorithmExecuteCaseAssert("normal", "abc123456", "***123456"),
+                    new MaskAlgorithmExecuteCaseAssert("length_equals_to_Y_plus_one", "abc", "***"),
+                    new MaskAlgorithmExecuteCaseAssert("length_less_than_to_Y_plus_one", "ab", "**"));
         }
     }
 }


### PR DESCRIPTION
Fixes #39362.

Changes proposed in this pull request:
  - `MASK_FROM_X_TO_Y` and `KEEP_FROM_X_TO_Y` reject `from-x: 0` / `to-y: 0` with `AlgorithmInitializationException`, although `mask.en.md` and `mask.cn.md` both document them as `start position (from 0)` / `end position (from 0)`.
  - The runtime is already 0-based: `MaskFromXToYMaskAlgorithm.mask()` uses `fromX` directly as a char array index, so position 0 works once initialization accepts it.
  - Add `MaskAlgorithmPropertiesChecker.checkNonNegativeInteger()` and switch the four position-typed call sites (`from-x`, `to-y` in both algorithms) to it.
  - Keep `checkPositiveInteger()` unchanged: `first-n` / `last-m` in `KeepFirstNLastMMaskAlgorithm` and `MaskFirstNLastMMaskAlgorithm` are counts, not positions, so `> 0` stays correct for them.
  - Negative values are still rejected; the existing `negative_from_X` / `negative_to_Y` init cases still pass.
  - Add checker unit tests for zero, positive, negative, missing key and non-integer input, plus `from-x=0` execute cases to both algorithm tests.
  - No documentation change: the docs already describe the intended contract, the code did not honour it.
  - Verified with `./mvnw install -pl features/mask/core -am` plus repository-wide spotless, checkstyle and apache-rat: 159 tests pass.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
