### PR TITLE
Preserve actual identifiers in pipeline reads

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/StandardPipelineTableMetaDataLoader.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/StandardPipelineTableMetaDataLoader.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.core.metadata.loader;
 
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.DataConsistencyCheckUtils;
@@ -25,8 +26,12 @@ import org.apache.shardingsphere.data.pipeline.core.exception.PipelineInternalEx
 import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineColumnMetaData;
 import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineIndexMetaData;
 import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineTableMetaData;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.metadata.identifier.ShardingSphereIdentifier;
+import org.apache.shardingsphere.infra.metadata.identifier.IdentifierCasePolicyResolver;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -50,20 +55,23 @@ public final class StandardPipelineTableMetaDataLoader implements PipelineTableM
     
     private final PipelineDataSource dataSource;
     
-    private final Map<ShardingSphereIdentifier, PipelineTableMetaData> tableMetaDataMap = new ConcurrentHashMap<>();
+    private volatile IdentifierCasePolicy tableIdentifierCasePolicy;
+    
+    private final Map<TableMetaDataCacheKey, PipelineTableMetaData> tableMetaDataMap = new ConcurrentHashMap<>();
     
     @Override
     public PipelineTableMetaData getTableMetaData(final String schemaName, final String tableName) {
-        PipelineTableMetaData result = tableMetaDataMap.get(new ShardingSphereIdentifier(tableName));
+        String qualifiedSchemaName = getQualifiedSchemaName(schemaName, new DatabaseTypeRegistry(dataSource.getDatabaseType()));
+        PipelineTableMetaData result = findTableMetaData(qualifiedSchemaName, tableName);
         if (null != result) {
             return result;
         }
         try {
-            loadTableMetaData(schemaName, tableName);
+            loadTableMetaData(qualifiedSchemaName, tableName);
         } catch (final SQLException ex) {
             throw new PipelineInternalException(String.format("Load meta data for schema '%s' and table '%s' failed", schemaName, tableName), ex);
         }
-        result = tableMetaDataMap.get(new ShardingSphereIdentifier(tableName));
+        result = findTableMetaData(qualifiedSchemaName, tableName);
         if (null == result) {
             log.warn("Can not load meta data for table '{}'", tableName);
         }
@@ -72,8 +80,8 @@ public final class StandardPipelineTableMetaDataLoader implements PipelineTableM
     
     private void loadTableMetaData(final String schemaName, final String tableName) throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
-            DatabaseTypeRegistry databaseTypeRegistry = new DatabaseTypeRegistry(dataSource.getDatabaseType());
-            tableMetaDataMap.putAll(loadTableMetaData(connection, databaseTypeRegistry.getDialectDatabaseMetaData().getSchemaOption().isSchemaAvailable() ? schemaName : null, tableName));
+            Map<ShardingSphereIdentifier, PipelineTableMetaData> loadedTableMetaData = loadTableMetaData(connection, schemaName, tableName);
+            loadedTableMetaData.forEach((key, value) -> tableMetaDataMap.put(new TableMetaDataCacheKey(schemaName, key.getValue()), value));
         }
     }
     
@@ -142,5 +150,46 @@ public final class StandardPipelineTableMetaDataLoader implements PipelineTableM
             columnNames.addAll(entry.getValue().values());
         }
         return result;
+    }
+    
+    private String getQualifiedSchemaName(final String schemaName, final DatabaseTypeRegistry databaseTypeRegistry) {
+        return null == schemaName || !databaseTypeRegistry.getDialectDatabaseMetaData().getSchemaOption().isSchemaAvailable() ? null : schemaName;
+    }
+    
+    private PipelineTableMetaData findTableMetaData(final String schemaName, final String tableName) {
+        PipelineTableMetaData result = tableMetaDataMap.get(new TableMetaDataCacheKey(schemaName, tableName));
+        if (null != result) {
+            return result;
+        }
+        return tableMetaDataMap.entrySet().stream()
+                .filter(entry -> null == schemaName ? null == entry.getKey().schemaName : schemaName.equals(entry.getKey().schemaName))
+                .filter(entry -> isSameTable(entry.getKey().tableName, tableName)).map(Entry::getValue).findFirst().orElse(null);
+    }
+    
+    private boolean isSameTable(final String storedTableName, final String tableName) {
+        return storedTableName.equals(tableName) || getTableIdentifierCasePolicy().matches(storedTableName, tableName, QuoteCharacter.NONE);
+    }
+    
+    private IdentifierCasePolicy getTableIdentifierCasePolicy() {
+        IdentifierCasePolicy result = tableIdentifierCasePolicy;
+        if (null == result) {
+            synchronized (this) {
+                result = tableIdentifierCasePolicy;
+                if (null == result) {
+                    result = IdentifierCasePolicyResolver.resolveStorage(dataSource.getDatabaseType(), dataSource).getPolicy(IdentifierScope.TABLE);
+                    tableIdentifierCasePolicy = result;
+                }
+            }
+        }
+        return result;
+    }
+    
+    @RequiredArgsConstructor
+    @EqualsAndHashCode
+    private static final class TableMetaDataCacheKey {
+        
+        private final String schemaName;
+        
+        private final String tableName;
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/segment/PipelineSQLSegmentBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/segment/PipelineSQLSegmentBuilder.java
@@ -23,6 +23,8 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
 
+import java.util.function.Function;
+
 /**
  * Pipeline SQL segment builder.
  */
@@ -48,6 +50,16 @@ public final class PipelineSQLSegmentBuilder {
     }
     
     /**
+     * Get escaped actual identifier.
+     *
+     * @param identifier actual identifier to be processed
+     * @return escaped actual identifier
+     */
+    public String getEscapedActualIdentifier(final String identifier) {
+        return "*".equals(identifier) ? identifier : dialectDatabaseMetaData.getQuoteCharacter().wrap(identifier);
+    }
+    
+    /**
      * Get qualified table name.
      *
      * @param schemaName schema name
@@ -55,12 +67,7 @@ public final class PipelineSQLSegmentBuilder {
      * @return qualified table name
      */
     public String getQualifiedTableName(final String schemaName, final String tableName) {
-        StringBuilder result = new StringBuilder();
-        if (dialectDatabaseMetaData.getSchemaOption().isSchemaAvailable() && !Strings.isNullOrEmpty(schemaName)) {
-            result.append(getEscapedIdentifier(schemaName)).append('.');
-        }
-        result.append(getEscapedIdentifier(tableName));
-        return result.toString();
+        return buildQualifiedTableName(schemaName, tableName, this::getEscapedIdentifier);
     }
     
     /**
@@ -71,5 +78,25 @@ public final class PipelineSQLSegmentBuilder {
      */
     public String getQualifiedTableName(final QualifiedTable qualifiedTable) {
         return getQualifiedTableName(qualifiedTable.getSchemaName(), qualifiedTable.getTableName());
+    }
+    
+    /**
+     * Get qualified actual table name.
+     *
+     * @param schemaName actual schema name
+     * @param tableName actual table name
+     * @return qualified actual table name
+     */
+    public String getQualifiedActualTableName(final String schemaName, final String tableName) {
+        return buildQualifiedTableName(schemaName, tableName, this::getEscapedActualIdentifier);
+    }
+    
+    private String buildQualifiedTableName(final String schemaName, final String tableName, final Function<String, String> identifierEscaper) {
+        StringBuilder result = new StringBuilder();
+        if (dialectDatabaseMetaData.getSchemaOption().isSchemaAvailable() && !Strings.isNullOrEmpty(schemaName)) {
+            result.append(identifierEscaper.apply(schemaName)).append('.');
+        }
+        result.append(identifierEscaper.apply(tableName));
+        return result.toString();
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryCalculateSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryCalculateSQLBuilder.java
@@ -62,10 +62,10 @@ public final class PipelineInventoryCalculateSQLBuilder {
     
     private String buildRangeQueryOrderingSQL0(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final Range<?> range,
                                                final List<String> shardingColumnsNames) {
-        String qualifiedTableName = sqlSegmentBuilder.getQualifiedTableName(qualifiedTable);
-        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedIdentifier).collect(Collectors.joining(","));
+        String qualifiedTableName = sqlSegmentBuilder.getQualifiedActualTableName(qualifiedTable.getSchemaName(), qualifiedTable.getTableName());
+        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedActualIdentifier).collect(Collectors.joining(","));
         String firstUniqueKey = uniqueKeys.get(0);
-        String orderByColumns = joinColumns(uniqueKeys, shardingColumnsNames).stream().map(each -> sqlSegmentBuilder.getEscapedIdentifier(each) + " ASC").collect(Collectors.joining(", "));
+        String orderByColumns = joinColumns(uniqueKeys, shardingColumnsNames).stream().map(each -> sqlSegmentBuilder.getEscapedActualIdentifier(each) + " ASC").collect(Collectors.joining(", "));
         if (null != range.getLowerBound() && null != range.getUpperBound()) {
             return String.format("SELECT %s FROM %s WHERE %s AND %s ORDER BY %s", queryColumns, qualifiedTableName,
                     buildRangeQueryLowerCondition(range.isLowerInclusive(), firstUniqueKey),
@@ -84,11 +84,11 @@ public final class PipelineInventoryCalculateSQLBuilder {
     
     private String buildRangeQueryLowerCondition(final boolean inclusive, final String firstUniqueKey) {
         String delimiter = inclusive ? ">=?" : ">?";
-        return sqlSegmentBuilder.getEscapedIdentifier(firstUniqueKey) + delimiter;
+        return sqlSegmentBuilder.getEscapedActualIdentifier(firstUniqueKey) + delimiter;
     }
     
     private String buildRangeQueryUpperCondition(final String firstUniqueKey) {
-        return sqlSegmentBuilder.getEscapedIdentifier(firstUniqueKey) + "<=?";
+        return sqlSegmentBuilder.getEscapedActualIdentifier(firstUniqueKey) + "<=?";
     }
     
     /**
@@ -101,9 +101,9 @@ public final class PipelineInventoryCalculateSQLBuilder {
      * @return built SQL
      */
     public String buildPointQuerySQL(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final List<String> shardingColumnsNames) {
-        String qualifiedTableName = sqlSegmentBuilder.getQualifiedTableName(qualifiedTable);
-        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedIdentifier).collect(Collectors.joining(","));
-        String equalsConditions = joinColumns(uniqueKeys, shardingColumnsNames).stream().map(each -> sqlSegmentBuilder.getEscapedIdentifier(each) + "=?").collect(Collectors.joining(" AND "));
+        String qualifiedTableName = sqlSegmentBuilder.getQualifiedActualTableName(qualifiedTable.getSchemaName(), qualifiedTable.getTableName());
+        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedActualIdentifier).collect(Collectors.joining(","));
+        String equalsConditions = joinColumns(uniqueKeys, shardingColumnsNames).stream().map(each -> sqlSegmentBuilder.getEscapedActualIdentifier(each) + "=?").collect(Collectors.joining(" AND "));
         return String.format("SELECT %s FROM %s WHERE %s", queryColumns, qualifiedTableName, equalsConditions);
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryDumpSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryDumpSQLBuilder.java
@@ -43,8 +43,8 @@ public final class PipelineInventoryDumpSQLBuilder {
      * @return built SQL
      */
     public String buildFetchAllSQL(final String schemaName, final String tableName, final Collection<String> columnNames) {
-        String qualifiedTableName = sqlSegmentBuilder.getQualifiedTableName(schemaName, tableName);
-        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedIdentifier).collect(Collectors.joining(","));
+        String qualifiedTableName = sqlSegmentBuilder.getQualifiedActualTableName(schemaName, tableName);
+        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedActualIdentifier).collect(Collectors.joining(","));
         return String.format("SELECT %s FROM %s", queryColumns, qualifiedTableName);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelinePrepareSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelinePrepareSQLBuilder.java
@@ -67,7 +67,7 @@ public final class PipelinePrepareSQLBuilder {
      * @return count SQL
      */
     public String buildCountSQL(final String schemaName, final String tableName) {
-        return String.format("SELECT COUNT(*) FROM %s", sqlSegmentBuilder.getQualifiedTableName(schemaName, tableName));
+        return String.format("SELECT COUNT(*) FROM %s", sqlSegmentBuilder.getQualifiedActualTableName(schemaName, tableName));
     }
     
     /**
@@ -79,7 +79,7 @@ public final class PipelinePrepareSQLBuilder {
      * @return estimated count SQL
      */
     public Optional<String> buildEstimatedCountSQL(final String catalogName, final String schemaName, final String tableName) {
-        return dialectSQLBuilder.buildEstimatedCountSQL(catalogName, sqlSegmentBuilder.getQualifiedTableName(schemaName, tableName));
+        return dialectSQLBuilder.buildEstimatedCountSQL(catalogName, sqlSegmentBuilder.getQualifiedActualTableName(schemaName, tableName));
     }
     
     /**
@@ -91,8 +91,8 @@ public final class PipelinePrepareSQLBuilder {
      * @return min max unique key SQL
      */
     public String buildUniqueKeyMinMaxValuesSQL(final String schemaName, final String tableName, final String uniqueKey) {
-        String escapedUniqueKey = sqlSegmentBuilder.getEscapedIdentifier(uniqueKey);
-        return String.format("SELECT MIN(%s), MAX(%s) FROM %s", escapedUniqueKey, escapedUniqueKey, sqlSegmentBuilder.getQualifiedTableName(schemaName, tableName));
+        String escapedUniqueKey = sqlSegmentBuilder.getEscapedActualIdentifier(uniqueKey);
+        return String.format("SELECT MIN(%s), MAX(%s) FROM %s", escapedUniqueKey, escapedUniqueKey, sqlSegmentBuilder.getQualifiedActualTableName(schemaName, tableName));
     }
     
     /**
@@ -103,7 +103,7 @@ public final class PipelinePrepareSQLBuilder {
      * @return check SQL
      */
     public String buildCheckEmptyTableSQL(final String schemaName, final String tableName) {
-        return dialectSQLBuilder.buildCheckEmptyTableSQL(sqlSegmentBuilder.getQualifiedTableName(schemaName, tableName));
+        return dialectSQLBuilder.buildCheckEmptyTableSQL(sqlSegmentBuilder.getQualifiedActualTableName(schemaName, tableName));
     }
     
     /**
@@ -116,8 +116,8 @@ public final class PipelinePrepareSQLBuilder {
      * @return split SQL
      */
     public String buildSplitByUniqueKeyRangedSQL(final String schemaName, final String tableName, final String uniqueKey, final boolean hasLowerBound) {
-        String escapedUniqueKey = sqlSegmentBuilder.getEscapedIdentifier(uniqueKey);
-        String subQueryClause = dialectSQLBuilder.buildSplitByUniqueKeyRangedSubqueryClause(sqlSegmentBuilder.getQualifiedTableName(schemaName, tableName), escapedUniqueKey, hasLowerBound);
+        String escapedUniqueKey = sqlSegmentBuilder.getEscapedActualIdentifier(uniqueKey);
+        String subQueryClause = dialectSQLBuilder.buildSplitByUniqueKeyRangedSubqueryClause(sqlSegmentBuilder.getQualifiedActualTableName(schemaName, tableName), escapedUniqueKey, hasLowerBound);
         return String.format("SELECT MAX(%s), COUNT(1), MIN(%s) FROM (%s) t", escapedUniqueKey, escapedUniqueKey, subQueryClause);
     }
 }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/StandardPipelineTableMetaDataLoaderTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/StandardPipelineTableMetaDataLoaderTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.metadata.loader;
+
+import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSource;
+import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineTableMetaData;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StandardPipelineTableMetaDataLoaderTest {
+    
+    @Test
+    void assertGetTableMetaDataWithActualIdentifiers() throws SQLException {
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        ResultSet tables = mockTablesResultSet();
+        ResultSet primaryKeys = mockEmptyResultSet();
+        ResultSet indexes = mockEmptyResultSet();
+        ResultSet columns = mockColumnsResultSet("USER_ID");
+        when(databaseMetaData.getTables("foo_db", "TEST", "T_USER", null)).thenReturn(tables);
+        when(databaseMetaData.getPrimaryKeys("foo_db", "TEST", "T_USER")).thenReturn(primaryKeys);
+        when(databaseMetaData.getIndexInfo("foo_db", "TEST", "T_USER", true, true)).thenReturn(indexes);
+        when(databaseMetaData.getColumns("foo_db", "TEST", "T_USER", "%")).thenReturn(columns);
+        PipelineTableMetaData actual = new StandardPipelineTableMetaDataLoader(createPipelineDataSource(databaseMetaData)).getTableMetaData("TEST", "T_USER");
+        assertThat(actual.getColumnNames().get(0), is("USER_ID"));
+        verify(databaseMetaData).getTables("foo_db", "TEST", "T_USER", null);
+    }
+    
+    @Test
+    void assertGetTableMetaDataWithQualifiedCacheIdentity() throws SQLException {
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        setUpTableMetaData(databaseMetaData, "TEST", "T_USER", "UPPER_ID");
+        setUpTableMetaData(databaseMetaData, "test", "T_USER", "LOWER_ID");
+        StandardPipelineTableMetaDataLoader loader = new StandardPipelineTableMetaDataLoader(createPipelineDataSource(databaseMetaData));
+        assertThat(loader.getTableMetaData("TEST", "T_USER").getColumnNames().get(0), is("UPPER_ID"));
+        assertThat(loader.getTableMetaData("test", "T_USER").getColumnNames().get(0), is("LOWER_ID"));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(ints = {1, 2})
+    void assertGetTableMetaDataWithCaseInsensitiveMySQLTableCacheIdentity(final int lowerCaseTableNames) throws SQLException {
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        setUpTableMetaData(databaseMetaData, null, "T_USER", "USER_ID");
+        StandardPipelineTableMetaDataLoader loader = new StandardPipelineTableMetaDataLoader(createMySQLPipelineDataSource(databaseMetaData, lowerCaseTableNames));
+        assertThat(loader.getTableMetaData(null, "T_USER").getColumnNames().get(0), is("USER_ID"));
+        assertThat(loader.getTableMetaData(null, "t_user").getColumnNames().get(0), is("USER_ID"));
+        verify(databaseMetaData).getTables("foo_db", null, "T_USER", null);
+    }
+    
+    @Test
+    void assertGetTableMetaDataWithCaseSensitiveMySQLTableCacheIdentity() throws SQLException {
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        setUpTableMetaData(databaseMetaData, null, "T_USER", "USER_ID");
+        StandardPipelineTableMetaDataLoader loader = new StandardPipelineTableMetaDataLoader(createMySQLPipelineDataSource(databaseMetaData, 0));
+        assertThat(loader.getTableMetaData(null, "T_USER").getColumnNames().get(0), is("USER_ID"));
+        ResultSet tables = mockEmptyResultSet();
+        when(databaseMetaData.getTables("foo_db", null, "t_user", null)).thenReturn(tables);
+        assertNull(loader.getTableMetaData(null, "t_user"));
+        verify(databaseMetaData).getTables("foo_db", null, "t_user", null);
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getMySQLCasePolicyFallbackArguments")
+    void assertGetTableMetaDataWithMySQLCasePolicyFallback(final String name, final Integer lowerCaseTableNames, final boolean queryFailed) throws SQLException {
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        setUpTableMetaData(databaseMetaData, null, "T_USER", "USER_ID");
+        StandardPipelineTableMetaDataLoader loader = new StandardPipelineTableMetaDataLoader(createMySQLPipelineDataSource(databaseMetaData, lowerCaseTableNames, queryFailed));
+        assertThat(name, loader.getTableMetaData(null, "T_USER").getColumnNames().get(0), is("USER_ID"));
+        assertThat(name, loader.getTableMetaData(null, "t_user").getColumnNames().get(0), is("USER_ID"));
+        verify(databaseMetaData).getTables("foo_db", null, "T_USER", null);
+    }
+    
+    private PipelineDataSource createPipelineDataSource(final DatabaseMetaData databaseMetaData) throws SQLException {
+        return createPipelineDataSource(databaseMetaData, TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
+    }
+    
+    private PipelineDataSource createPipelineDataSource(final DatabaseMetaData databaseMetaData, final DatabaseType databaseType) throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getCatalog()).thenReturn("foo_db");
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        return createPipelineDataSource(dataSource, databaseType);
+    }
+    
+    private PipelineDataSource createPipelineDataSource(final DataSource dataSource, final DatabaseType databaseType) {
+        return new PipelineDataSource(dataSource, databaseType);
+    }
+    
+    private PipelineDataSource createMySQLPipelineDataSource(final DatabaseMetaData databaseMetaData, final int lowerCaseTableNames) throws SQLException {
+        return createMySQLPipelineDataSource(databaseMetaData, lowerCaseTableNames, false);
+    }
+    
+    private PipelineDataSource createMySQLPipelineDataSource(final DatabaseMetaData databaseMetaData, final Integer lowerCaseTableNames, final boolean queryFailed) throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        if (queryFailed) {
+            when(connection.prepareStatement("SELECT @@lower_case_table_names")).thenThrow(new SQLException("Query failed"));
+        } else {
+            setUpMySQLCasePolicyResult(connection, lowerCaseTableNames);
+        }
+        when(connection.getCatalog()).thenReturn("foo_db");
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        return createPipelineDataSource(dataSource, TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+    }
+    
+    private void setUpMySQLCasePolicyResult(final Connection connection, final Integer lowerCaseTableNames) throws SQLException {
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(connection.prepareStatement("SELECT @@lower_case_table_names")).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(null != lowerCaseTableNames);
+        if (null != lowerCaseTableNames) {
+            when(resultSet.getInt(1)).thenReturn(lowerCaseTableNames);
+        }
+    }
+    
+    private static Stream<Arguments> getMySQLCasePolicyFallbackArguments() {
+        return Stream.of(Arguments.of("no_result_row", null, false), Arguments.of("sql_exception", null, true), Arguments.of("unexpected_config", 3, false));
+    }
+    
+    private void setUpTableMetaData(final DatabaseMetaData databaseMetaData, final String schemaName, final String tableName, final String columnName) throws SQLException {
+        ResultSet tables = mockTablesResultSet(tableName);
+        ResultSet primaryKeys = mockEmptyResultSet();
+        ResultSet indexes = mockEmptyResultSet();
+        ResultSet columns = mockColumnsResultSet(columnName);
+        when(databaseMetaData.getTables("foo_db", schemaName, tableName, null)).thenReturn(tables);
+        when(databaseMetaData.getPrimaryKeys("foo_db", schemaName, tableName)).thenReturn(primaryKeys);
+        when(databaseMetaData.getIndexInfo("foo_db", schemaName, tableName, true, true)).thenReturn(indexes);
+        when(databaseMetaData.getColumns("foo_db", schemaName, tableName, "%")).thenReturn(columns);
+    }
+    
+    private ResultSet mockTablesResultSet() throws SQLException {
+        return mockTablesResultSet("T_USER");
+    }
+    
+    private ResultSet mockTablesResultSet(final String tableName) throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(true, false);
+        when(result.getString("TABLE_NAME")).thenReturn(tableName);
+        return result;
+    }
+    
+    private ResultSet mockColumnsResultSet(final String columnName) throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(true, false);
+        when(result.getInt("ORDINAL_POSITION")).thenReturn(1);
+        when(result.getString("COLUMN_NAME")).thenReturn(columnName);
+        when(result.getInt("DATA_TYPE")).thenReturn(Types.BIGINT);
+        when(result.getString("TYPE_NAME")).thenReturn("int8");
+        when(result.getString("IS_NULLABLE")).thenReturn("NO");
+        return result;
+    }
+    
+    private ResultSet mockEmptyResultSet() throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(false);
+        return result;
+    }
+}

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/segment/PipelineSQLSegmentBuilderTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/segment/PipelineSQLSegmentBuilderTest.java
@@ -42,6 +42,18 @@ class PipelineSQLSegmentBuilderTest {
     }
     
     @Test
+    void assertGetEscapedActualIdentifier() {
+        assertThat(postgresqlBuilder.getEscapedActualIdentifier("T_Order"), is("\"T_Order\""));
+        assertThat(postgresqlBuilder.getEscapedActualIdentifier("*"), is("*"));
+    }
+    
+    @Test
+    void assertGetQualifiedActualTableName() {
+        assertThat(postgresqlBuilder.getQualifiedActualTableName("TEST", "T_Order"), is("\"TEST\".\"T_Order\""));
+        assertThat(mysqlBuilder.getQualifiedActualTableName("SHARDING_DB", "T_Order"), is("`T_Order`"));
+    }
+    
+    @Test
     void assertGetQualifiedTableNameWithUnsupportedSchema() {
         assertThat(mysqlBuilder.getQualifiedTableName("foo_schema", "foo_tbl"), is("`foo_tbl`"));
         assertThat(mysqlBuilder.getQualifiedTableName(new QualifiedTable("foo_schema", "foo_tbl")), is("`foo_tbl`"));

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryDumpSQLBuilderTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryDumpSQLBuilderTest.java
@@ -38,4 +38,11 @@ class PipelineInventoryDumpSQLBuilderTest {
         actual = sqlBuilder.buildFetchAllSQL(null, "t_order", Collections.singletonList("*"));
         assertThat(actual, is("SELECT * FROM t_order"));
     }
+    
+    @Test
+    void assertBuildFetchAllSQLWithActualIdentifiers() {
+        PipelineInventoryDumpSQLBuilder postgresqlSQLBuilder = new PipelineInventoryDumpSQLBuilder(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
+        assertThat(postgresqlSQLBuilder.buildFetchAllSQL("TEST", "T_ORDER", Arrays.asList("ID", "STATUS", "*")),
+                is("SELECT \"ID\",\"STATUS\",* FROM \"TEST\".\"T_ORDER\""));
+    }
 }

--- a/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/PipelineInventoryCalculateSQLBuilderTest.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/PipelineInventoryCalculateSQLBuilderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.postgresql.sqlbuilder;
+
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.Range;
+import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql.PipelineInventoryCalculateSQLBuilder;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class PipelineInventoryCalculateSQLBuilderTest {
+    
+    private final PipelineInventoryCalculateSQLBuilder sqlBuilder =
+            new PipelineInventoryCalculateSQLBuilder(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
+    
+    @Test
+    void assertBuildRangeQueryOrderingSQLWithActualIdentifiers() {
+        assertThat(sqlBuilder.buildRangeQueryOrderingSQL(new QualifiedTable("TEST", "T_ORDER"), Arrays.asList("ID", "STATUS"), Collections.singletonList("ID"),
+                Range.closed(1, 5), true, Collections.singletonList("TENANT_ID")),
+                is("SELECT \"ID\",\"STATUS\" FROM \"TEST\".\"T_ORDER\" WHERE \"ID\">=? AND \"ID\"<=? ORDER BY \"ID\" ASC, \"TENANT_ID\" ASC LIMIT ?"));
+    }
+    
+    @Test
+    void assertBuildPointQuerySQLWithActualIdentifiers() {
+        assertThat(sqlBuilder.buildPointQuerySQL(new QualifiedTable("TEST", "T_ORDER"), Arrays.asList("ID", "STATUS"), Collections.singletonList("ID"), Collections.emptyList()),
+                is("SELECT \"ID\",\"STATUS\" FROM \"TEST\".\"T_ORDER\" WHERE \"ID\"=?"));
+    }
+}

--- a/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/PipelinePrepareSQLBuilderTest.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/PipelinePrepareSQLBuilderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.postgresql.sqlbuilder;
+
+import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql.PipelinePrepareSQLBuilder;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class PipelinePrepareSQLBuilderTest {
+    
+    private final PipelinePrepareSQLBuilder sqlBuilder = new PipelinePrepareSQLBuilder(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
+    
+    @Test
+    void assertBuildCountSQLWithActualIdentifiers() {
+        assertThat(sqlBuilder.buildCountSQL("TEST", "T_ORDER"), is("SELECT COUNT(*) FROM \"TEST\".\"T_ORDER\""));
+    }
+    
+    @Test
+    void assertBuildEstimatedCountSQLWithActualIdentifiers() {
+        assertThat(sqlBuilder.buildEstimatedCountSQL("foo_catalog", "TEST", "T_ORDER"),
+                is(Optional.of("SELECT reltuples::integer FROM pg_class WHERE oid='\"TEST\".\"T_ORDER\"'::regclass::oid;")));
+    }
+    
+    @Test
+    void assertBuildUniqueKeyMinMaxValuesSQLWithActualIdentifiers() {
+        assertThat(sqlBuilder.buildUniqueKeyMinMaxValuesSQL("TEST", "T_ORDER", "ID"),
+                is("SELECT MIN(\"ID\"), MAX(\"ID\") FROM \"TEST\".\"T_ORDER\""));
+    }
+    
+    @Test
+    void assertBuildCheckEmptyTableSQLWithActualIdentifiers() {
+        assertThat(sqlBuilder.buildCheckEmptyTableSQL("TEST", "T_ORDER"), is("SELECT * FROM \"TEST\".\"T_ORDER\" LIMIT 1"));
+    }
+    
+    @Test
+    void assertBuildSplitByUniqueKeyRangedSQLWithActualIdentifiers() {
+        assertThat(sqlBuilder.buildSplitByUniqueKeyRangedSQL("TEST", "T_ORDER", "ID", true),
+                is("SELECT MAX(\"ID\"), COUNT(1), MIN(\"ID\") FROM (SELECT \"ID\" FROM \"TEST\".\"T_ORDER\" WHERE \"ID\">? ORDER BY \"ID\" LIMIT ?) t"));
+    }
+}


### PR DESCRIPTION

Changes proposed in this pull request:
  - Preserve actual identifiers in pipeline reads

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
