### PR TITLE
Fix Javadoc of AlterReadwriteSplittingStorageUnitStatusStatement

### DIFF
--- a/features/readwrite-splitting/distsql/statement/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/statement/AlterReadwriteSplittingStorageUnitStatusStatement.java
+++ b/features/readwrite-splitting/distsql/statement/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/statement/AlterReadwriteSplittingStorageUnitStatusStatement.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.attribute.S
 import org.apache.shardingsphere.sql.parser.statement.core.statement.attribute.type.FromDatabaseSQLStatementAttribute;
 
 /**
- * Set readwrite-splitting status statement.
+ * Alter readwrite-splitting storage unit status statement.
  */
 @Getter
 public final class AlterReadwriteSplittingStorageUnitStatusStatement extends UpdatableRALStatement {


### PR DESCRIPTION
No issue: Javadoc fix, submitted under the documentation contribution track.

Changes proposed in this pull request:
  - Change the class Javadoc of `AlterReadwriteSplittingStorageUnitStatusStatement` from `Set readwrite-splitting status statement.` to `Alter readwrite-splitting storage unit status statement.`
  - The Javadoc still describes the pre-rename class name: #21901 renamed `SetReadwriteSplittingStatusStatement` to `AlterReadwriteSplittingStorageUnitStatusStatement` without updating the Javadoc added in #12687.
  - The DistSQL grammar has no `SET` form. `readwrite-splitting/RALStatement.g4` defines `ALTER READWRITE_SPLITTING RULE ruleName (ENABLE | DISABLE) storageUnitName (FROM databaseName)?`, so the Javadoc names a keyword that does not exist.
  - The corrected wording is already used in the repository by `AlterReadwriteSplittingStorageUnitStatusExecutor` and by the parser IT assert and test case classes.
  - Comment-only change: no behavior change, no unit test and no Release Notes entry.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.

- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)