### PR TITLE
Fix swapped message arguments in duplicate readwrite-splitting error

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -50,6 +50,7 @@
 1. Pipeline: Fix MySQL zero-value temporal binlog decoding with fractional precision in migration - [#38629](https://github.com/apache/shardingsphere/pull/38629)
 1. Pipeline: Fix escape MySQL JSON binlog control characters - [#38800](https://github.com/apache/shardingsphere/pull/38800)
 1. Pipeline: Use UTF-8 to decode MySQL JSON binlog string and key values instead of the JVM default charset - [#39140](https://github.com/apache/shardingsphere/pull/39140)
+1. Readwrite-splitting: Fix swapped data source type and name in duplicate actual data source error message - [#39372](https://github.com/apache/shardingsphere/pull/39372)
 1. Sharding: Support ORDER BY MySQL VARBINARY column by wrapping byte[] values in a Comparable adapter - [#38699](https://github.com/apache/shardingsphere/pull/38699)
 1. Sharding: Fix generated actual index names exceeding database identifier length limits while preserving legacy generated index name compatibility - [#38449](https://github.com/apache/shardingsphere/pull/38449)
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)

--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/exception/actual/DuplicateReadwriteSplittingActualDataSourceException.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/exception/actual/DuplicateReadwriteSplittingActualDataSourceException.java
@@ -31,6 +31,6 @@ public final class DuplicateReadwriteSplittingActualDataSourceException extends 
     
     public DuplicateReadwriteSplittingActualDataSourceException(final ReadwriteSplittingDataSourceType dataSourceType,
                                                                 final String dataSourceName, final ReadwriteSplittingRuleExceptionIdentifier exceptionIdentifier) {
-        super(XOpenSQLState.DUPLICATE, 4, "Readwrite-splitting %s data source '%s' is duplicated in %s.", dataSourceName, dataSourceType, exceptionIdentifier);
+        super(XOpenSQLState.DUPLICATE, 4, "Readwrite-splitting %s data source '%s' is duplicated in %s.", dataSourceType, dataSourceName, exceptionIdentifier);
     }
 }

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingDataSourceRuleConfigurationCheckerTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingDataSourceRuleConfigurationCheckerTest.java
@@ -28,10 +28,13 @@ import org.apache.shardingsphere.readwritesplitting.exception.logic.MissingRequi
 import org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource;
 import org.junit.jupiter.api.Test;
 
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -71,8 +74,12 @@ class ReadwriteSplittingDataSourceRuleConfigurationCheckerTest {
     @Test
     void assertCheckWithDuplicatedWriteDataSourceName() {
         ReadwriteSplittingDataSourceGroupRuleConfiguration config = new ReadwriteSplittingDataSourceGroupRuleConfiguration("foo_group", "write_ds", Arrays.asList("read_ds0", "read_ds1"), "foo_algo");
-        assertThrows(DuplicateReadwriteSplittingActualDataSourceException.class, () -> new ReadwriteSplittingDataSourceRuleConfigurationChecker("foo_db",
-                config, Collections.singletonMap("write_ds", new MockedDataSource())).check(new HashSet<>(Collections.singleton("write_ds")), Collections.emptyList(), Collections.emptyList()));
+        SQLException actual = assertThrows(DuplicateReadwriteSplittingActualDataSourceException.class, () -> new ReadwriteSplittingDataSourceRuleConfigurationChecker("foo_db", config,
+                Collections.singletonMap("write_ds", new MockedDataSource())).check(new HashSet<>(Collections.singleton("write_ds")), Collections.emptyList(), Collections.emptyList()))
+                .toSQLException();
+        assertThat(actual.getErrorCode(), is(20204));
+        assertThat(actual.getSQLState(), is("42S01"));
+        assertThat(actual.getMessage(), is("Readwrite-splitting WRITE data source 'write_ds' is duplicated in database.data_source_rule: 'foo_db'.'foo_group'."));
     }
     
     @Test


### PR DESCRIPTION
Fixes #39370.

Changes proposed in this pull request:
  - Pass `dataSourceType` before `dataSourceName` to the format string in `DuplicateReadwriteSplittingActualDataSourceException`, matching its own parameter declaration order.
  - Restores the contract documented for error code 20204 in `docs/document/content/user-manual/error-code/sql-error-code.en.md` line 214: `Readwrite-splitting [READ/WRITE] data source '%s' is duplicated in %s.` The documentation is already correct, so no doc change is needed.
  - Aligns with the sibling exceptions in the same package, which all pass the data source type first: `ReadwriteSplittingActualDataSourceNotFoundException`, `MissingRequiredReadwriteSplittingActualDataSourceException`, `InvalidReadwriteSplittingActualDataSourceInlineExpressionException`.
  - Asserts error code, SQL state and message in `ReadwriteSplittingDataSourceRuleConfigurationCheckerTest.assertCheckWithDuplicatedWriteDataSourceName()`, following the assertion style #39343 added in `StandardReadwriteSplittingDataSourceRouterTest`. The test fails on master with `Readwrite-splitting write_ds data source 'WRITE' is duplicated in ...`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)

