### PR TITLE
Evaluate inline expressions in readwrite-splitting data source names

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -54,6 +54,7 @@
 1. Sharding: Fix generated actual index names exceeding database identifier length limits while preserving legacy generated index name compatibility - [#38449](https://github.com/apache/shardingsphere/pull/38449)
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
+1. Readwrite-splitting: Evaluate inline expressions in data source names of rule configuration checker - [#39374](https://github.com/apache/shardingsphere/pull/39374)
 1. SQL Federation: Fix SQL Federation pagination binding for long LIMIT parameters - [#39237](https://github.com/apache/shardingsphere/pull/39237)
 
 ### Enhancements

--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingRuleConfigurationChecker.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingRuleConfigurationChecker.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.algorithm.loadbalancer.spi.LoadBalanceAlg
 import org.apache.shardingsphere.infra.config.rule.checker.DatabaseRuleConfigurationChecker;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.external.sql.identifier.SQLExceptionIdentifier;
+import org.apache.shardingsphere.infra.expr.entry.InlineExpressionParserFactory;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.readwritesplitting.config.ReadwriteSplittingRuleConfiguration;
@@ -31,6 +32,7 @@ import org.apache.shardingsphere.readwritesplitting.constant.ReadwriteSplittingO
 
 import javax.sql.DataSource;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -64,7 +66,7 @@ public final class ReadwriteSplittingRuleConfigurationChecker implements Databas
             }
             LoadBalanceAlgorithm loadBalancer = loadBalancers.get(each.getLoadBalancerName());
             ShardingSpherePreconditions.checkNotNull(loadBalancer, () -> new UnregisteredAlgorithmException("Load balancer", each.getLoadBalancerName(), new SQLExceptionIdentifier(databaseName)));
-            loadBalancer.check(databaseName, each.getReadDataSourceNames());
+            loadBalancer.check(databaseName, getActualDataSourceNames(each.getReadDataSourceNames()));
         }
     }
     
@@ -73,12 +75,16 @@ public final class ReadwriteSplittingRuleConfigurationChecker implements Databas
         Collection<String> result = new LinkedHashSet<>();
         for (ReadwriteSplittingDataSourceGroupRuleConfiguration each : ruleConfig.getDataSourceGroups()) {
             if (null != each.getWriteDataSourceName()) {
-                result.add(each.getWriteDataSourceName());
+                result.addAll(getActualDataSourceNames(Collections.singleton(each.getWriteDataSourceName())));
             }
-            if (!each.getReadDataSourceNames().isEmpty()) {
-                result.addAll(each.getReadDataSourceNames());
-            }
+            result.addAll(getActualDataSourceNames(each.getReadDataSourceNames()));
         }
+        return result;
+    }
+    
+    private Collection<String> getActualDataSourceNames(final Collection<String> dataSourceNames) {
+        Collection<String> result = new LinkedHashSet<>();
+        dataSourceNames.forEach(each -> result.addAll(InlineExpressionParserFactory.newInstance(each).splitAndEvaluate()));
         return result;
     }
     

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
@@ -102,6 +102,18 @@ class ReadwriteSplittingRuleConfigurationCheckerTest {
     }
     
     @Test
+    void assertCheckWeightLoadBalanceWithInlineExpressionDataSourceNames() {
+        ReadwriteSplittingRuleConfiguration ruleConfig = mock(ReadwriteSplittingRuleConfiguration.class);
+        Collection<ReadwriteSplittingDataSourceGroupRuleConfiguration> configs = Collections.singleton(
+                createDataSourceGroupRuleConfiguration("write_ds_0", Collections.singletonList("read_ds_${0..1}")));
+        when(ruleConfig.getDataSourceGroups()).thenReturn(configs);
+        AlgorithmConfiguration algorithm = new AlgorithmConfiguration("WEIGHT", PropertiesBuilder.build(new Property("read_ds_0", "1"), new Property("read_ds_1", "2")));
+        when(ruleConfig.getLoadBalancers()).thenReturn(Collections.singletonMap("weight_ds", algorithm));
+        DatabaseRuleConfigurationChecker checker = OrderedSPILoader.getServicesByClass(DatabaseRuleConfigurationChecker.class, Collections.singleton(ruleConfig.getClass())).get(ruleConfig.getClass());
+        assertDoesNotThrow(() -> checker.check("test", ruleConfig, mockDataSources(), Collections.emptyList()));
+    }
+    
+    @Test
     void assertCheckWhenConfigOtherRulesDatasource() {
         ReadwriteSplittingRuleConfiguration ruleConfig = createContainsOtherRulesDatasourceConfiguration();
         DatabaseRuleConfigurationChecker checker = OrderedSPILoader.getServicesByClass(DatabaseRuleConfigurationChecker.class, Collections.singleton(ruleConfig.getClass())).get(ruleConfig.getClass());
@@ -147,6 +159,15 @@ class ReadwriteSplittingRuleConfigurationCheckerTest {
         ReadwriteSplittingRuleConfiguration ruleConfig = new ReadwriteSplittingRuleConfiguration(Collections.singleton(dataSourceGroupConfig), Collections.emptyMap());
         DatabaseRuleConfigurationChecker checker = OrderedSPILoader.getServicesByClass(DatabaseRuleConfigurationChecker.class, Collections.singleton(ruleConfig.getClass())).get(ruleConfig.getClass());
         assertThat(checker.getRequiredDataSourceNames(ruleConfig), is(new LinkedHashSet<>(Arrays.asList("write_ds", "read_ds0", "read_ds1"))));
+    }
+    
+    @Test
+    void assertGetRequiredDataSourceNamesWithInlineExpression() {
+        ReadwriteSplittingDataSourceGroupRuleConfiguration dataSourceGroupConfig = new ReadwriteSplittingDataSourceGroupRuleConfiguration(
+                "foo_group_${0..1}", "write_ds_${0..1}", Collections.singletonList("read_ds_${0..1}"), "foo_algo");
+        ReadwriteSplittingRuleConfiguration ruleConfig = new ReadwriteSplittingRuleConfiguration(Collections.singleton(dataSourceGroupConfig), Collections.emptyMap());
+        DatabaseRuleConfigurationChecker checker = OrderedSPILoader.getServicesByClass(DatabaseRuleConfigurationChecker.class, Collections.singleton(ruleConfig.getClass())).get(ruleConfig.getClass());
+        assertThat(checker.getRequiredDataSourceNames(ruleConfig), is(new LinkedHashSet<>(Arrays.asList("write_ds_0", "write_ds_1", "read_ds_0", "read_ds_1"))));
     }
     
     @Test


### PR DESCRIPTION
Fixes #39373.

Changes proposed in this pull request:
  - `getRequiredDataSourceNames()` returned the configured write and read names verbatim, so a documented configuration such as `write_ds_${0..1}` was reported as a required storage unit and rejected with `MissingRequiredStorageUnitsException`.
  - `checkLoadBalancer()` passed the configured read names verbatim to `LoadBalanceAlgorithm.check()`, so a `WEIGHT` load balancer keyed by the evaluated names failed with `AlgorithmInitializationException`.
  - Both defects share one root cause, so a single private `getActualDataSourceNames()` helper fixes both; fixing only the first still fails on the second for the same configuration.
  - The checker now sees the names `ReadwriteSplittingRule.createStaticDataSourceGroupRules()` builds at runtime and `ReadwriteSplittingDataSourceRuleConfigurationChecker.checkActualSourceNames()` already validates, matching the sibling `ShardingRuleConfigurationChecker.getRequiredDataSourceNames()`.
  - Plain names are unaffected because `splitAndEvaluate()` returns a single element list for them; the existing checker tests still pass unchanged.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)

