### PR TITLE
Fix Oracle LOG table alias parsing

### DIFF
--- a/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -499,6 +499,7 @@ dmlTableAlias
     | SINGLE_H
     | V1
     | LENGTH
+    | LOG
     | CHILD
     ;
 

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -15102,4 +15102,13 @@
         </from>
     </select>
 
+    <select sql-case-id="select_with_log_table_alias_oracle">
+        <from>
+            <simple-table name="t_order" alias="LOG" start-index="14" stop-index="24" />
+        </from>
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+    </select>
+
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -561,5 +561,6 @@
     <sql-case id="select_oracle_percentile_cont_window" value="SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY price) OVER (PARTITION BY status) AS median_price FROM t_product" db-types="Oracle" />
     <sql-case id="select_oracle_first_value_ignore_nulls_window" value="SELECT FIRST_VALUE(price) IGNORE NULLS OVER (ORDER BY product_id) AS first_price FROM t_product" db-types="Oracle" />
     <sql-case id="select_oracle_first_value_window" value="SELECT FIRST_VALUE(price) OVER (ORDER BY product_id) AS first_price FROM t_product" db-types="Oracle" />
+    <sql-case id="select_with_log_table_alias_oracle" value="SELECT * FROM t_order LOG" db-types="Oracle" />
     <sql-case id="select_for_system_version_as_of_hive" value="SELECT * FROM table_a FOR SYSTEM_VERSION AS OF 1234567;" db-types="Hive" />
 </sql-cases>


### PR DESCRIPTION
Changes proposed in this pull request:
- Allow `LOG` to be parsed as an Oracle DML table alias.
- Add an Oracle parser integration case for `SELECT * FROM t_order LOG`.

`LOG` already has an Oracle keyword token, but it was not included in `dmlTableAlias`. As a result, valid SQL using `LOG` as an unquoted table alias was rejected. The change adds the token at that grammar boundary and verifies the resulting table alias segment.

Oracle documents that nonquoted identifiers cannot be reserved words, while other keywords and function names are not reserved. `LOG` is documented as a numeric function and is not listed as an Oracle SQL reserved word:
- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/Database-Object-Names-and-Qualifiers.html
- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/Oracle-SQL-Reserved-Words.html
- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/LOG.html

Verification:
- Oracle parser integration tests: 1806 passed
- `./mvnw spotless:apply -Pcheck -T1C`
- `./mvnw checkstyle:check -Pcheck -T1C`
- `./mvnw clean install -B -T1C -Pcheck`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed the full Maven check locally.
- [x] Documentation changes are not required for this parser compatibility fix.
- [x] I have added a corresponding parser integration test.
- [ ] I have updated the Release Notes of the current development version.
