### PR TITLE
Fix incomplete WEIGHT load balancer validation

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,6 +14,7 @@
 
 1. Infra: Avoid retaining transient multi-object lookup keys in `OrderedSPILoader` - [#38980](https://github.com/apache/shardingsphere/pull/38980)
 1. Infra: Fix invalid target selection after counter overflow in `RoundRobinLoadBalanceAlgorithm` - [#39340](https://github.com/apache/shardingsphere/pull/39340)
+1. Infra: Reject incomplete WEIGHT load balancer properties during rule configuration validation - [#39378](https://github.com/apache/shardingsphere/pull/39378)
 1. SQL Parser: Preserve unary NOT as NotExpression for scalar-subquery table extraction in PostgreSQL - [#38187](https://github.com/apache/shardingsphere/pull/38187)
 1. SQL Parser: Fix wrong parameter index parse in MySQL, Doris - [#38624](https://github.com/apache/shardingsphere/pull/38624)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)

--- a/infra/algorithm/type/load-balancer/type/weight/src/main/java/org/apache/shardingsphere/infra/algorithm/loadbalancer/weight/WeightLoadBalanceAlgorithm.java
+++ b/infra/algorithm/type/load-balancer/type/weight/src/main/java/org/apache/shardingsphere/infra/algorithm/loadbalancer/weight/WeightLoadBalanceAlgorithm.java
@@ -62,6 +62,8 @@ public final class WeightLoadBalanceAlgorithm implements LoadBalanceAlgorithm {
     public void check(final String databaseName, final Collection<String> configuredTargetNames) {
         weightConfigMap.keySet().forEach(each -> ShardingSpherePreconditions.checkContains(configuredTargetNames, each,
                 () -> new AlgorithmInitializationException(this, "Target `%s` is required in database `%s`.", each, databaseName)));
+        configuredTargetNames.forEach(each -> ShardingSpherePreconditions.checkContains(weightConfigMap.keySet(), each,
+                () -> new AlgorithmInitializationException(this, "Weight of target `%s` is required in database `%s`.", each, databaseName)));
     }
     
     @HighFrequencyInvocation

--- a/infra/algorithm/type/load-balancer/type/weight/src/test/java/org/apache/shardingsphere/infra/algorithm/loadbalancer/weight/WeightLoadBalanceAlgorithmTest.java
+++ b/infra/algorithm/type/load-balancer/type/weight/src/test/java/org/apache/shardingsphere/infra/algorithm/loadbalancer/weight/WeightLoadBalanceAlgorithmTest.java
@@ -41,9 +41,15 @@ class WeightLoadBalanceAlgorithmTest {
     }
     
     @Test
-    void assertCheck() {
+    void assertCheckWithUnconfiguredTarget() {
         LoadBalanceAlgorithm loadBalanceAlgorithm = TypedSPILoader.getService(LoadBalanceAlgorithm.class, "WEIGHT", PropertiesBuilder.build(new Property("test_read_ds_1", "5")));
         assertThrows(AlgorithmInitializationException.class, () -> loadBalanceAlgorithm.check("foo_db", Collections.singletonList("test_read_ds_0")));
+    }
+    
+    @Test
+    void assertCheckWithMissingWeight() {
+        LoadBalanceAlgorithm loadBalanceAlgorithm = TypedSPILoader.getService(LoadBalanceAlgorithm.class, "WEIGHT", PropertiesBuilder.build(new Property("test_read_ds_0", "5")));
+        assertThrows(AlgorithmInitializationException.class, () -> loadBalanceAlgorithm.check("foo_db", Arrays.asList("test_read_ds_0", "test_read_ds_1")));
     }
     
     @Test


### PR DESCRIPTION
Fixes #39296.

Changes proposed in this pull request:
  - Reject incomplete WEIGHT load balancer properties when a configured read target has no weight.
  - Add regression coverage for missing weights while preserving validation for unconfigured property keys.

Verification:
  - `WeightLoadBalanceAlgorithmTest`: 6 tests passed.
  - `./mvnw spotless:apply -Pcheck -T1C`: passed.
  - `./mvnw checkstyle:check -Pcheck -T1C`: passed.
  - Full Maven check was attempted but could not complete because the local environment has JDK 17 and current `master` requires JDK 21 or later for `shardingsphere-mcp`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
