### PR TITLE
Fix MySQL session character set handling in Proxy

### DIFF
--- a/database/exception/dialect/mysql/src/main/java/org/apache/shardingsphere/database/exception/mysql/exception/CollationCharsetMismatchException.java
+++ b/database/exception/dialect/mysql/src/main/java/org/apache/shardingsphere/database/exception/mysql/exception/CollationCharsetMismatchException.java
@@ -18,37 +18,19 @@
 package org.apache.shardingsphere.database.exception.mysql.exception;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.exception.core.exception.SQLDialectException;
 
 /**
- * Unknown collation exception.
+ * Collation and character set mismatch exception.
  */
+@RequiredArgsConstructor
 @Getter
-public final class UnknownCollationException extends SQLDialectException {
+public final class CollationCharsetMismatchException extends SQLDialectException {
     
-    private static final long serialVersionUID = 6920150607711135228L;
-    
-    private final int collationId;
+    private static final long serialVersionUID = -4699705254666505781L;
     
     private final String collation;
     
-    /**
-     * Construct an unknown collation exception by collation ID.
-     *
-     * @param collationId collation ID
-     */
-    public UnknownCollationException(final int collationId) {
-        this.collationId = collationId;
-        collation = String.valueOf(collationId);
-    }
-    
-    /**
-     * Construct an unknown collation exception by collation name.
-     *
-     * @param collation collation name
-     */
-    public UnknownCollationException(final String collation) {
-        collationId = -1;
-        this.collation = collation;
-    }
+    private final String charset;
 }

--- a/database/exception/dialect/mysql/src/main/java/org/apache/shardingsphere/database/exception/mysql/exception/WrongValueForVariableException.java
+++ b/database/exception/dialect/mysql/src/main/java/org/apache/shardingsphere/database/exception/mysql/exception/WrongValueForVariableException.java
@@ -18,37 +18,19 @@
 package org.apache.shardingsphere.database.exception.mysql.exception;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.exception.core.exception.SQLDialectException;
 
 /**
- * Unknown collation exception.
+ * Wrong value for variable exception.
  */
+@RequiredArgsConstructor
 @Getter
-public final class UnknownCollationException extends SQLDialectException {
+public final class WrongValueForVariableException extends SQLDialectException {
     
-    private static final long serialVersionUID = 6920150607711135228L;
+    private static final long serialVersionUID = 7832630692242160301L;
     
-    private final int collationId;
+    private final String variableName;
     
-    private final String collation;
-    
-    /**
-     * Construct an unknown collation exception by collation ID.
-     *
-     * @param collationId collation ID
-     */
-    public UnknownCollationException(final int collationId) {
-        this.collationId = collationId;
-        collation = String.valueOf(collationId);
-    }
-    
-    /**
-     * Construct an unknown collation exception by collation name.
-     *
-     * @param collation collation name
-     */
-    public UnknownCollationException(final String collation) {
-        collationId = -1;
-        this.collation = collation;
-    }
+    private final String value;
 }

--- a/database/exception/dialect/mysql/src/main/java/org/apache/shardingsphere/database/exception/mysql/mapper/MySQLDialectExceptionMapper.java
+++ b/database/exception/dialect/mysql/src/main/java/org/apache/shardingsphere/database/exception/mysql/mapper/MySQLDialectExceptionMapper.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.database.exception.core.exception.syntax.table.
 import org.apache.shardingsphere.database.exception.core.exception.syntax.table.TableExistsException;
 import org.apache.shardingsphere.database.exception.core.exception.transaction.TableModifyInTransactionException;
 import org.apache.shardingsphere.database.exception.core.mapper.SQLDialectExceptionMapper;
+import org.apache.shardingsphere.database.exception.mysql.exception.CollationCharsetMismatchException;
 import org.apache.shardingsphere.database.exception.mysql.exception.DatabaseAccessDeniedException;
 import org.apache.shardingsphere.database.exception.mysql.exception.ErrorGlobalVariableException;
 import org.apache.shardingsphere.database.exception.mysql.exception.ErrorLocalVariableException;
@@ -41,6 +42,7 @@ import org.apache.shardingsphere.database.exception.mysql.exception.UnknownChars
 import org.apache.shardingsphere.database.exception.mysql.exception.UnknownCollationException;
 import org.apache.shardingsphere.database.exception.mysql.exception.UnknownSystemVariableException;
 import org.apache.shardingsphere.database.exception.mysql.exception.UnsupportedPreparedStatementException;
+import org.apache.shardingsphere.database.exception.mysql.exception.WrongValueForVariableException;
 import org.apache.shardingsphere.database.exception.mysql.vendor.MySQLVendorError;
 import org.apache.shardingsphere.infra.exception.external.sql.vendor.VendorError;
 import org.apache.shardingsphere.infra.exception.generic.UnknownSQLException;
@@ -97,7 +99,15 @@ public final class MySQLDialectExceptionMapper implements SQLDialectExceptionMap
             return toSQLException(MySQLVendorError.ER_UNKNOWN_CHARACTER_SET, ((UnknownCharsetException) sqlDialectException).getCharset());
         }
         if (sqlDialectException instanceof UnknownCollationException) {
-            return toSQLException(MySQLVendorError.ER_UNKNOWN_COLLATION, ((UnknownCollationException) sqlDialectException).getCollationId());
+            return toSQLException(MySQLVendorError.ER_UNKNOWN_COLLATION, ((UnknownCollationException) sqlDialectException).getCollation());
+        }
+        if (sqlDialectException instanceof WrongValueForVariableException) {
+            WrongValueForVariableException ex = (WrongValueForVariableException) sqlDialectException;
+            return toSQLException(MySQLVendorError.ER_WRONG_VALUE_FOR_VAR, ex.getVariableName(), ex.getValue());
+        }
+        if (sqlDialectException instanceof CollationCharsetMismatchException) {
+            CollationCharsetMismatchException ex = (CollationCharsetMismatchException) sqlDialectException;
+            return toSQLException(MySQLVendorError.ER_COLLATION_CHARSET_MISMATCH, ex.getCollation(), ex.getCharset());
         }
         if (sqlDialectException instanceof HandshakeException) {
             return toSQLException(MySQLVendorError.ER_HANDSHAKE_ERROR);

--- a/database/exception/dialect/mysql/src/main/java/org/apache/shardingsphere/database/exception/mysql/vendor/MySQLVendorError.java
+++ b/database/exception/dialect/mysql/src/main/java/org/apache/shardingsphere/database/exception/mysql/vendor/MySQLVendorError.java
@@ -68,7 +68,11 @@ public enum MySQLVendorError implements VendorError {
     
     ER_GLOBAL_VARIABLE(XOpenSQLState.GENERAL_ERROR, 1229, "Variable '%s' is a GLOBAL variable and should be set with SET GLOBAL"),
     
+    ER_WRONG_VALUE_FOR_VAR(XOpenSQLState.SYNTAX_ERROR, 1231, "Variable '%s' can't be set to the value of '%s'"),
+    
     ER_INCORRECT_GLOBAL_LOCAL_VAR(XOpenSQLState.GENERAL_ERROR, 1238, "Variable '%s' is a %s variable"),
+    
+    ER_COLLATION_CHARSET_MISMATCH(XOpenSQLState.SYNTAX_ERROR, 1253, "COLLATION '%s' is not valid for CHARACTER SET '%s'"),
     
     ER_UNKNOWN_COLLATION(XOpenSQLState.GENERAL_ERROR, 1273, "Unknown collation: '%s'"),
     

--- a/database/exception/dialect/mysql/src/test/java/org/apache/shardingsphere/database/exception/mysql/mapper/MySQLDialectExceptionMapperTest.java
+++ b/database/exception/dialect/mysql/src/test/java/org/apache/shardingsphere/database/exception/mysql/mapper/MySQLDialectExceptionMapperTest.java
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.database.exception.core.exception.syntax.table.
 import org.apache.shardingsphere.database.exception.core.exception.syntax.table.TableExistsException;
 import org.apache.shardingsphere.database.exception.core.exception.transaction.TableModifyInTransactionException;
 import org.apache.shardingsphere.database.exception.core.mapper.SQLDialectExceptionMapper;
+import org.apache.shardingsphere.database.exception.mysql.exception.CollationCharsetMismatchException;
 import org.apache.shardingsphere.database.exception.mysql.exception.DatabaseAccessDeniedException;
 import org.apache.shardingsphere.database.exception.mysql.exception.ErrorGlobalVariableException;
 import org.apache.shardingsphere.database.exception.mysql.exception.ErrorLocalVariableException;
@@ -43,6 +44,7 @@ import org.apache.shardingsphere.database.exception.mysql.exception.UnknownChars
 import org.apache.shardingsphere.database.exception.mysql.exception.UnknownCollationException;
 import org.apache.shardingsphere.database.exception.mysql.exception.UnknownSystemVariableException;
 import org.apache.shardingsphere.database.exception.mysql.exception.UnsupportedPreparedStatementException;
+import org.apache.shardingsphere.database.exception.mysql.exception.WrongValueForVariableException;
 import org.apache.shardingsphere.database.exception.mysql.vendor.MySQLVendorError;
 import org.apache.shardingsphere.infra.exception.external.sql.vendor.VendorError;
 import org.apache.shardingsphere.infra.exception.generic.UnknownSQLException;
@@ -123,6 +125,8 @@ class MySQLDialectExceptionMapperTest {
                 Arguments.of("too_many_placeholders", TooManyPlaceholdersException.class, MySQLVendorError.ER_PS_MANY_PARAM),
                 Arguments.of("unknown_charset", UnknownCharsetException.class, MySQLVendorError.ER_UNKNOWN_CHARACTER_SET),
                 Arguments.of("unknown_collation", UnknownCollationException.class, MySQLVendorError.ER_UNKNOWN_COLLATION),
+                Arguments.of("wrong_value_for_variable", WrongValueForVariableException.class, MySQLVendorError.ER_WRONG_VALUE_FOR_VAR),
+                Arguments.of("collation_charset_mismatch", CollationCharsetMismatchException.class, MySQLVendorError.ER_COLLATION_CHARSET_MISMATCH),
                 Arguments.of("handshake", HandshakeException.class, MySQLVendorError.ER_HANDSHAKE_ERROR),
                 Arguments.of("access_denied_without_password", AccessDeniedException.class, MySQLVendorError.ER_ACCESS_DENIED_ERROR),
                 Arguments.of("database_access_denied", DatabaseAccessDeniedException.class, MySQLVendorError.ER_DBACCESS_DENIED_ERROR),

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/codec/MySQLPacketCodecEngine.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/codec/MySQLPacketCodecEngine.java
@@ -86,7 +86,7 @@ public final class MySQLPacketCodecEngine implements DatabasePacketCodecEngine {
     
     @Override
     public void encode(final ChannelHandlerContext context, final DatabasePacket message, final ByteBuf out) {
-        MySQLPacketPayload payload = new MySQLPacketPayload(prepareMessageHeader(out).markWriterIndex(), context.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get());
+        MySQLPacketPayload payload = new MySQLPacketPayload(prepareMessageHeader(out).markWriterIndex(), getResultCharset(context));
         try {
             message.write(payload);
             // CHECKSTYLE:OFF
@@ -101,6 +101,11 @@ public final class MySQLPacketCodecEngine implements DatabasePacketCodecEngine {
                 writeMultiPackets(context, out);
             }
         }
+    }
+    
+    private Charset getResultCharset(final ChannelHandlerContext context) {
+        Charset result = context.channel().attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY).get();
+        return null == result ? context.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get() : result;
     }
     
     private ByteBuf prepareMessageHeader(final ByteBuf out) {

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLCharacterSets.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLCharacterSets.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.database.protocol.mysql.constant;
 
 import lombok.Getter;
+import org.apache.shardingsphere.database.exception.mysql.exception.UnknownCharsetException;
 import org.apache.shardingsphere.database.exception.mysql.exception.UnknownCollationException;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 
@@ -26,6 +27,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -315,6 +318,12 @@ public enum MySQLCharacterSets {
     
     private static final Map<Integer, MySQLCharacterSets> CHARACTER_SET_MAP = Collections.unmodifiableMap(Arrays.stream(values()).collect(Collectors.toMap(each -> each.id, Function.identity())));
     
+    private static final Map<String, MySQLCharacterSets> DEFAULT_COLLATION_MAP = Collections.unmodifiableMap(Arrays.stream(values()).filter(each -> null != each.charset)
+            .collect(Collectors.toMap(MySQLCharacterSets::getCharacterSetName, Function.identity(), MySQLCharacterSets::getDefaultCollation, LinkedHashMap::new)));
+    
+    private static final Map<String, MySQLCharacterSets> COLLATION_MAP = Collections.unmodifiableMap(Arrays.stream(values()).filter(each -> null != each.charset)
+            .collect(Collectors.toMap(MySQLCharacterSets::getCollationName, Function.identity())));
+    
     private final int id;
     
     private final Charset charset;
@@ -329,6 +338,14 @@ public enum MySQLCharacterSets {
         charset = result;
     }
     
+    private static MySQLCharacterSets getDefaultCollation(final MySQLCharacterSets oldValue, final MySQLCharacterSets newValue) {
+        if (LATIN1_SWEDISH_CI == oldValue || LATIN1_SWEDISH_CI == newValue) {
+            return LATIN1_SWEDISH_CI;
+        }
+        String generalCollationName = newValue.getCharacterSetName() + "_general_ci";
+        return generalCollationName.equals(newValue.getCollationName()) ? newValue : oldValue;
+    }
+    
     /**
      * Get character set by id.
      *
@@ -340,5 +357,51 @@ public enum MySQLCharacterSets {
         ShardingSpherePreconditions.checkNotNull(result, () -> new UnknownCollationException(id));
         ShardingSpherePreconditions.checkNotNull(result.getCharset(), () -> new UnknownCollationException(id));
         return result;
+    }
+    
+    /**
+     * Get default collation by character set name.
+     *
+     * @param characterSetName character set name
+     * @return default collation
+     */
+    public static MySQLCharacterSets findByCharacterSetName(final String characterSetName) {
+        String normalizedName = characterSetName.toLowerCase(Locale.ROOT);
+        MySQLCharacterSets result = DEFAULT_COLLATION_MAP.get(normalizedName);
+        ShardingSpherePreconditions.checkNotNull(result, () -> new UnknownCharsetException(normalizedName));
+        return result;
+    }
+    
+    /**
+     * Get character set by collation name.
+     *
+     * @param collationName collation name
+     * @return character set
+     */
+    public static MySQLCharacterSets findByCollationName(final String collationName) {
+        String normalizedName = collationName.toLowerCase(Locale.ROOT);
+        MySQLCharacterSets result = COLLATION_MAP.get(normalizedName);
+        ShardingSpherePreconditions.checkNotNull(result, () -> new UnknownCollationException(normalizedName));
+        return result;
+    }
+    
+    /**
+     * Get character set name.
+     *
+     * @return character set name
+     */
+    public String getCharacterSetName() {
+        String result = name();
+        int separatorIndex = result.indexOf('_');
+        return (-1 == separatorIndex ? result : result.substring(0, separatorIndex)).toLowerCase(Locale.ROOT);
+    }
+    
+    /**
+     * Get collation name.
+     *
+     * @return collation name
+     */
+    public String getCollationName() {
+        return name().toLowerCase(Locale.ROOT);
     }
 }

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLConstants.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLConstants.java
@@ -21,6 +21,7 @@ import io.netty.util.AttributeKey;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -33,6 +34,8 @@ public final class MySQLConstants {
     public static final AttributeKey<AtomicInteger> SEQUENCE_ID_ATTRIBUTE_KEY = AttributeKey.valueOf("MYSQL_SEQUENCE_ID");
     
     public static final AttributeKey<MySQLCharacterSets> CHARACTER_SET_ATTRIBUTE_KEY = AttributeKey.valueOf(MySQLCharacterSets.class.getName());
+    
+    public static final AttributeKey<Charset> RESULT_CHARSET_ATTRIBUTE_KEY = AttributeKey.valueOf("MYSQL_RESULT_CHARSET");
     
     public static final AttributeKey<Integer> OPTION_MULTI_STATEMENTS_ATTRIBUTE_KEY = AttributeKey.valueOf("MYSQL_OPTION_MULTI_STATEMENTS");
     

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/codec/MySQLPacketCodecEngineTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/codec/MySQLPacketCodecEngineTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -141,9 +142,24 @@ class MySQLPacketCodecEngineTest {
         new MySQLPacketCodecEngine().encode(context, actualMessage, byteBuf);
         verify(byteBuf).writeInt(0);
         verify(byteBuf).markWriterIndex();
-        verify(actualMessage).write(any(MySQLPacketPayload.class));
+        ArgumentCaptor<MySQLPacketPayload> payloadCaptor = ArgumentCaptor.forClass(MySQLPacketPayload.class);
+        verify(actualMessage).write(payloadCaptor.capture());
+        assertThat(payloadCaptor.getValue().getCharset(), is(StandardCharsets.UTF_8));
         verify(byteBuf).setMediumLE(0, 4);
         verify(byteBuf).setByte(3, 1);
+    }
+    
+    @Test
+    void assertEncodeWithResultCharset() {
+        when(byteBuf.writeInt(anyInt())).thenReturn(byteBuf);
+        when(byteBuf.markWriterIndex()).thenReturn(byteBuf);
+        when(byteBuf.readableBytes()).thenReturn(8);
+        when(context.channel().attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY).get()).thenReturn(StandardCharsets.ISO_8859_1);
+        MySQLPacket actualMessage = mock(MySQLPacket.class);
+        new MySQLPacketCodecEngine().encode(context, actualMessage, byteBuf);
+        ArgumentCaptor<MySQLPacketPayload> payloadCaptor = ArgumentCaptor.forClass(MySQLPacketPayload.class);
+        verify(actualMessage).write(payloadCaptor.capture());
+        assertThat(payloadCaptor.getValue().getCharset(), is(StandardCharsets.ISO_8859_1));
     }
     
     @Test

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLCharacterSetsTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLCharacterSetsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.database.protocol.mysql.constant;
 
+import org.apache.shardingsphere.database.exception.mysql.exception.UnknownCharsetException;
 import org.apache.shardingsphere.database.exception.mysql.exception.UnknownCollationException;
 import org.junit.jupiter.api.Test;
 
@@ -40,5 +41,45 @@ class MySQLCharacterSetsTest {
     @Test
     void assertFoundUnsupportedCharacterSetById() {
         assertThrows(UnknownCollationException.class, () -> MySQLCharacterSets.findById(63));
+    }
+    
+    @Test
+    void assertFindByCharacterSetName() {
+        assertThat(MySQLCharacterSets.findByCharacterSetName("UTF8MB4"), is(MySQLCharacterSets.UTF8MB4_GENERAL_CI));
+    }
+    
+    @Test
+    void assertFindDefaultCollationByCharacterSetName() {
+        assertThat(MySQLCharacterSets.findByCharacterSetName("latin1"), is(MySQLCharacterSets.LATIN1_SWEDISH_CI));
+    }
+    
+    @Test
+    void assertCharacterSetNotFoundByName() {
+        assertThrows(UnknownCharsetException.class, () -> MySQLCharacterSets.findByCharacterSetName("unknown_charset"));
+    }
+    
+    @Test
+    void assertFindByCollationName() {
+        assertThat(MySQLCharacterSets.findByCollationName("UTF8MB4_BIN"), is(MySQLCharacterSets.UTF8MB4_BIN));
+    }
+    
+    @Test
+    void assertCollationNotFoundByName() {
+        assertThrows(UnknownCollationException.class, () -> MySQLCharacterSets.findByCollationName("unknown_collation"));
+    }
+    
+    @Test
+    void assertGetCharacterSetName() {
+        assertThat(MySQLCharacterSets.UTF8MB4_GENERAL_CI.getCharacterSetName(), is("utf8mb4"));
+    }
+    
+    @Test
+    void assertGetBinaryCharacterSetName() {
+        assertThat(MySQLCharacterSets.BINARY.getCharacterSetName(), is("binary"));
+    }
+    
+    @Test
+    void assertGetCollationName() {
+        assertThat(MySQLCharacterSets.UTF8MB4_GENERAL_CI.getCollationName(), is("utf8mb4_general_ci"));
     }
 }

--- a/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/type/MySQLDALStatementVisitor.java
+++ b/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/type/MySQLDALStatementVisitor.java
@@ -810,11 +810,14 @@ public final class MySQLDALStatementVisitor extends MySQLStatementVisitor implem
         }
         int startIndex = ctx.start.getStartIndex();
         int stopIndex = ctx.stop.getStopIndex();
-        String assignValue = ctx.charsetName().getText();
+        String assignValue = null == ctx.DEFAULT() ? ctx.charsetName().getText() : ctx.DEFAULT().getText();
         List<VariableAssignSegment> result = new LinkedList<>();
         result.add(new VariableAssignSegment(startIndex, stopIndex, new VariableSegment(startIndex, stopIndex, "character_set_client"), assignValue));
         result.add(new VariableAssignSegment(startIndex, stopIndex, new VariableSegment(startIndex, stopIndex, "character_set_results"), assignValue));
         result.add(new VariableAssignSegment(startIndex, stopIndex, new VariableSegment(startIndex, stopIndex, "character_set_connection"), assignValue));
+        if (null != ctx.collateClause()) {
+            result.add(new VariableAssignSegment(startIndex, stopIndex, new VariableSegment(startIndex, stopIndex, "collation_connection"), ctx.collateClause().collationName().getText()));
+        }
         return result;
     }
     
@@ -874,11 +877,12 @@ public final class MySQLDALStatementVisitor extends MySQLStatementVisitor implem
     public ASTNode visitSetCharacter(final SetCharacterContext ctx) {
         int startIndex = null == ctx.CHARSET() ? ctx.CHARACTER().getSymbol().getStartIndex() : ctx.CHARSET().getSymbol().getStartIndex();
         int stopIndex = null == ctx.CHARSET() ? ctx.SET(1).getSymbol().getStopIndex() : ctx.CHARSET().getSymbol().getStopIndex();
-        // TODO Consider setting all three system variables: character_set_client, character_set_results, character_set_connection
-        String variableName = (null == ctx.CHARSET()) ? "character_set_client" : ctx.CHARSET().getText();
-        VariableSegment variable = new VariableSegment(startIndex, stopIndex, variableName);
         String assignValue = (null == ctx.DEFAULT()) ? ctx.charsetName().getText() : ctx.DEFAULT().getText();
-        return new SetStatement(getDatabaseType(), Collections.singletonList(new VariableAssignSegment(startIndex, stopIndex, variable, assignValue)));
+        List<VariableAssignSegment> variableAssigns = new LinkedList<>();
+        variableAssigns.add(new VariableAssignSegment(startIndex, stopIndex, new VariableSegment(startIndex, stopIndex, "character_set_client"), assignValue));
+        variableAssigns.add(new VariableAssignSegment(startIndex, stopIndex, new VariableSegment(startIndex, stopIndex, "character_set_results"), assignValue));
+        variableAssigns.add(new VariableAssignSegment(startIndex, stopIndex, new VariableSegment(startIndex, stopIndex, "collation_connection"), "@@collation_database"));
+        return new SetStatement(getDatabaseType(), variableAssigns);
     }
     
     @Override

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.proxy.backend.connector;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMod
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.DatabaseConnectionManager;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.spi.type.ordered.OrderedSPILoader;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.connection.ConnectionPostProcessor;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.connection.ConnectionResourceLock;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.transaction.ProxyBackendTransactionManager;
@@ -48,6 +50,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -68,6 +72,9 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
     private final Collection<ProxyBackendHandler> inUseProxyBackendHandlers = Collections.newSetFromMap(new ConcurrentHashMap<>(64));
     
     private final Collection<ConnectionPostProcessor> connectionPostProcessors = new LinkedList<>();
+    
+    @Getter(AccessLevel.NONE)
+    private final Set<Connection> connectionsRequiringSessionVariableReplay = Collections.newSetFromMap(new ConcurrentHashMap<>(64));
     
     private final ConnectionResourceLock connectionResourceLock = new ConnectionResourceLock();
     
@@ -109,11 +116,37 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
                 cachedConnections.putAll(cacheKey, newConnections);
             }
         }
+        replaySessionVariablesIfNecessary(result);
         return result;
     }
     
     private String getKey(final String databaseName, final String dataSourceName) {
         return databaseName.toLowerCase() + "." + dataSourceName;
+    }
+    
+    private void replaySessionVariablesIfNecessary(final List<Connection> connections) throws SQLException {
+        if (connectionsRequiringSessionVariableReplay.isEmpty()) {
+            return;
+        }
+        List<Connection> replayConnections = new LinkedList<>();
+        for (Connection each : connections) {
+            if (null != each && connectionsRequiringSessionVariableReplay.contains(each)) {
+                replayConnections.add(each);
+            }
+        }
+        if (replayConnections.isEmpty()) {
+            return;
+        }
+        try {
+            setSessionVariablesIfNecessary(replayConnections);
+        } catch (final SQLException ex) {
+            synchronized (cachedConnections) {
+                cachedConnections.values().removeAll(replayConnections);
+            }
+            throw ex;
+        } finally {
+            connectionsRequiringSessionVariableReplay.removeAll(replayConnections);
+        }
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -144,14 +177,27 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
         if (connectionSession.getRequiredSessionVariableRecorder().isEmpty() || connections.isEmpty()) {
             return;
         }
-        String databaseType = connections.iterator().next().getMetaData().getDatabaseProductName();
-        List<String> setSQLs = connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType);
         try {
+            Optional<String> databaseType = getReplayDatabaseType(connections.iterator().next().getMetaData().getDatabaseProductName());
+            if (!databaseType.isPresent()) {
+                return;
+            }
+            List<String> setSQLs = connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.get());
+            if (setSQLs.isEmpty()) {
+                return;
+            }
             executeSetSessionVariables(connections, setSQLs);
         } catch (final SQLException ex) {
             releaseConnection(connections, ex);
             throw ex;
         }
+    }
+    
+    private Optional<String> getReplayDatabaseType(final String databaseType) {
+        DatabaseType protocolType = connectionSession.getProtocolType();
+        DatabaseType trunkProtocolType = protocolType.getTrunkDatabaseType().orElse(protocolType);
+        return TypedSPILoader.findService(DatabaseType.class, databaseType).map(each -> each.getTrunkDatabaseType().orElse(each))
+                .filter(each -> trunkProtocolType.getType().equalsIgnoreCase(each.getType())).map(DatabaseType::getType);
     }
     
     private void executeSetSessionVariables(final List<Connection> connections, final List<String> setSQLs) throws SQLException {
@@ -219,6 +265,19 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
      */
     public int getConnectionSize() {
         return cachedConnections.values().size();
+    }
+    
+    /**
+     * Mark cached connections as requiring session variable replay.
+     */
+    public void markSessionVariablesDirty() {
+        synchronized (cachedConnections) {
+            for (Connection each : cachedConnections.values()) {
+                if (null != each) {
+                    connectionsRequiringSessionVariableReplay.add(each);
+                }
+            }
+        }
     }
     
     /**
@@ -358,6 +417,7 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
                 }
             }
             cachedConnections.clear();
+            connectionsRequiringSessionVariableReplay.clear();
         }
         connectionSession.getPreparedStatementCacheContext().closeAll();
         if (!forceRollback) {
@@ -380,18 +440,20 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
         if (connectionSession.getRequiredSessionVariableRecorder().isEmpty() || values.isEmpty()) {
             return;
         }
-        String databaseType;
-        try {
-            databaseType = values.iterator().next().getMetaData().getDatabaseProductName();
-        } catch (final SQLException ex) {
-            exceptions.add(ex);
-            return;
-        }
-        List<String> resetSQLs = connectionSession.getRequiredSessionVariableRecorder().toResetSQLs(databaseType);
         for (Connection each : values) {
-            try (Statement statement = each.createStatement()) {
-                for (String eachResetSQL : resetSQLs) {
-                    statement.execute(eachResetSQL);
+            try {
+                Optional<String> databaseType = getReplayDatabaseType(each.getMetaData().getDatabaseProductName());
+                if (!databaseType.isPresent()) {
+                    continue;
+                }
+                List<String> resetSQLs = connectionSession.getRequiredSessionVariableRecorder().toResetSQLs(databaseType.get());
+                if (resetSQLs.isEmpty()) {
+                    continue;
+                }
+                try (Statement statement = each.createStatement()) {
+                    for (String eachResetSQL : resetSQLs) {
+                        statement.execute(eachResetSQL);
+                    }
                 }
             } catch (final SQLException ex) {
                 exceptions.add(ex);

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/admin/executor/variable/session/SessionVariableRecordExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/admin/executor/variable/session/SessionVariableRecordExecutor.java
@@ -47,6 +47,7 @@ public final class SessionVariableRecordExecutor {
     public void recordVariable(final String variableName, final String assignValue) {
         if (DatabaseTypedSPILoader.findService(ReplayedSessionVariableProvider.class, databaseType).map(optional -> optional.isNeedToReplay(variableName)).orElse(false)) {
             connectionSession.getRequiredSessionVariableRecorder().setVariable(variableName, assignValue);
+            connectionSession.getDatabaseConnectionManager().markSessionVariablesDirty();
         } else {
             log.debug("Set statement {} = {} was discarded.", variableName, assignValue);
         }
@@ -63,12 +64,17 @@ public final class SessionVariableRecordExecutor {
             log.debug("Set statement {} was discarded.", variables);
             return;
         }
+        boolean recorded = false;
         for (Entry<String, String> entry : variables.entrySet()) {
             if (replayedSessionVariableProvider.get().isNeedToReplay(entry.getKey())) {
                 connectionSession.getRequiredSessionVariableRecorder().setVariable(entry.getKey(), entry.getValue());
+                recorded = true;
             } else {
                 log.debug("Set statement {} = {} was discarded.", entry.getKey(), entry.getValue());
             }
+        }
+        if (recorded) {
+            connectionSession.getDatabaseConnectionManager().markSessionVariablesDirty();
         }
     }
 }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
@@ -89,6 +89,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -335,6 +336,7 @@ class ProxyDatabaseConnectionManagerTest {
     @Test
     void assertGetConnectionsAndReplaySessionVariables() throws SQLException {
         connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "value");
+        when(connectionSession.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
         ProxyContext proxyContext = mock(ProxyContext.class, RETURNS_DEEP_STUBS);
         when(ProxyContext.getInstance()).thenReturn(proxyContext);
         Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
@@ -343,6 +345,75 @@ class ProxyDatabaseConnectionManagerTest {
         List<Connection> actualConnections = databaseConnectionManager.getConnections("foo_db", "", 0, 1, ConnectionMode.CONNECTION_STRICTLY);
         Connection actualConnection = actualConnections.get(0);
         verify(actualConnection.createStatement()).execute("SET key=value");
+    }
+    
+    @Test
+    void assertGetConnectionsWithoutReplayingVariablesForDifferentDatabaseType() throws SQLException {
+        connectionSession.getRequiredSessionVariableRecorder().setVariable("collation_connection", "'utf8mb4_unicode_ci'");
+        when(connectionSession.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        when(connection.getMetaData().getDatabaseProductName()).thenReturn("PostgreSQL");
+        when(backendDataSource.getConnections(anyString(), anyString(), eq(1), any())).thenReturn(Collections.singletonList(connection));
+        assertThat(databaseConnectionManager.getConnections("foo_db", "ds1", 0, 1, ConnectionMode.CONNECTION_STRICTLY), is(Collections.singletonList(connection)));
+        verify(connection, never()).createStatement();
+    }
+    
+    @Test
+    void assertGetConnectionsAndReplaySessionVariablesForBranchProtocol() throws SQLException {
+        connectionSession.getRequiredSessionVariableRecorder().setVariable("collation_connection", "'utf8mb4_unicode_ci'");
+        DatabaseType branchProtocolType = mock(DatabaseType.class);
+        when(branchProtocolType.getTrunkDatabaseType()).thenReturn(Optional.of(TypedSPILoader.getService(DatabaseType.class, "MySQL")));
+        when(connectionSession.getProtocolType()).thenReturn(branchProtocolType);
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        when(connection.getMetaData().getDatabaseProductName()).thenReturn("MySQL");
+        when(backendDataSource.getConnections(anyString(), anyString(), eq(1), any())).thenReturn(Collections.singletonList(connection));
+        assertThat(databaseConnectionManager.getConnections("foo_db", "ds1", 0, 1, ConnectionMode.CONNECTION_STRICTLY), is(Collections.singletonList(connection)));
+        verify(connection.createStatement()).execute("SET collation_connection='utf8mb4_unicode_ci'");
+    }
+    
+    @Test
+    void assertGetConnectionsWithoutReplaySQL() throws SQLException {
+        connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "value");
+        when(connectionSession.getProtocolType()).thenReturn(databaseType);
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        when(connection.getMetaData().getDatabaseProductName()).thenReturn(databaseType.getType());
+        when(backendDataSource.getConnections(anyString(), anyString(), eq(1), any())).thenReturn(Collections.singletonList(connection));
+        assertThat(databaseConnectionManager.getConnections("foo_db", "ds1", 0, 1, ConnectionMode.CONNECTION_STRICTLY), is(Collections.singletonList(connection)));
+        verify(connection, never()).createStatement();
+    }
+    
+    @Test
+    void assertGetCachedConnectionsAndReplayDirtySessionVariables() throws SQLException {
+        connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "value");
+        when(connectionSession.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        when(connection.getMetaData().getDatabaseProductName()).thenReturn("PostgreSQL");
+        databaseConnectionManager.getCachedConnections().put("foo_db.ds1", connection);
+        databaseConnectionManager.markSessionVariablesDirty();
+        assertThat(databaseConnectionManager.getConnections("foo_db", "ds1", 0, 1, ConnectionMode.CONNECTION_STRICTLY), is(Collections.singletonList(connection)));
+        verify(connection.createStatement()).execute("SET key=value");
+    }
+    
+    @Test
+    void assertMarkSessionVariablesDirtyWithNullConnection() {
+        databaseConnectionManager.getCachedConnections().put("foo_db.ds1", null);
+        assertDoesNotThrow(databaseConnectionManager::markSessionVariablesDirty);
+    }
+    
+    @Test
+    void assertGetCachedConnectionsAndFailedToReplayDirtySessionVariables() throws SQLException {
+        connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "value");
+        when(connectionSession.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        when(connection.getMetaData().getDatabaseProductName()).thenReturn("PostgreSQL");
+        SQLException expectedException = new SQLException("");
+        when(connection.createStatement().execute("SET key=value")).thenThrow(expectedException);
+        databaseConnectionManager.getCachedConnections().put("foo_db.ds1", connection);
+        databaseConnectionManager.markSessionVariablesDirty();
+        assertThat(assertThrows(SQLException.class,
+                () -> databaseConnectionManager.getConnections("foo_db", "ds1", 0, 1, ConnectionMode.CONNECTION_STRICTLY)), is(expectedException));
+        verify(connection).close();
+        assertThat(databaseConnectionManager.getConnectionSize(), is(0));
     }
     
     @Test
@@ -356,6 +427,7 @@ class ProxyDatabaseConnectionManagerTest {
     @Test
     void assertGetConnectionsAndFailedToReplaySessionVariables() throws SQLException {
         connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "value");
+        when(connectionSession.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
         Connection connection = null;
         SQLException expectedException = new SQLException("");
         try {
@@ -370,10 +442,23 @@ class ProxyDatabaseConnectionManagerTest {
         }
     }
     
+    @Test
+    void assertGetConnectionsAndFailedToGetReplayDatabaseType() throws SQLException {
+        connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "value");
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        SQLException expectedException = new SQLException("");
+        when(connection.getMetaData().getDatabaseProductName()).thenThrow(expectedException);
+        when(backendDataSource.getConnections(anyString(), anyString(), eq(1), any())).thenReturn(Collections.singletonList(connection));
+        assertThat(assertThrows(SQLException.class,
+                () -> databaseConnectionManager.getConnections("foo_db", "ds1", 0, 1, ConnectionMode.CONNECTION_STRICTLY)), is(expectedException));
+        verify(connection).close();
+    }
+    
     @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     @Test
     void assertGetConnectionsAndFailedToReleaseConnection() throws SQLException {
         connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "value");
+        when(connectionSession.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
         SQLException expectedException = new SQLException("");
         SQLException expectedNextException = new SQLException("");
         Connection firstConnection = mock(Connection.class, RETURNS_DEEP_STUBS);
@@ -616,12 +701,37 @@ class ProxyDatabaseConnectionManagerTest {
     @Test
     void assertCloseConnectionsAndResetVariables() throws SQLException {
         connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "default");
+        when(connectionSession.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
         Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
         when(connection.getMetaData().getDatabaseProductName()).thenReturn("PostgreSQL");
         databaseConnectionManager.getCachedConnections().put("", connection);
         databaseConnectionManager.closeConnections(false);
         verify(connection.createStatement()).execute("RESET ALL");
         assertTrue(connectionSession.getRequiredSessionVariableRecorder().isEmpty());
+    }
+    
+    @Test
+    void assertCloseConnectionsWithoutResettingVariablesForDifferentDatabaseType() throws SQLException {
+        connectionSession.getRequiredSessionVariableRecorder().setVariable("collation_connection", "'utf8mb4_unicode_ci'");
+        when(connectionSession.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        when(connection.getMetaData().getDatabaseProductName()).thenReturn("PostgreSQL");
+        databaseConnectionManager.getCachedConnections().put("", connection);
+        databaseConnectionManager.closeConnections(false);
+        verify(connection, never()).createStatement();
+        verify(connection).close();
+    }
+    
+    @Test
+    void assertCloseConnectionsWithoutResetSQL() throws SQLException {
+        connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "value");
+        when(connectionSession.getProtocolType()).thenReturn(databaseType);
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        when(connection.getMetaData().getDatabaseProductName()).thenReturn(databaseType.getType());
+        databaseConnectionManager.getCachedConnections().put("", connection);
+        databaseConnectionManager.closeConnections(false);
+        verify(connection, never()).createStatement();
+        verify(connection).close();
     }
     
     @Test
@@ -638,6 +748,7 @@ class ProxyDatabaseConnectionManagerTest {
     @Test
     void assertCloseConnectionsAndFailedToResetVariables() throws SQLException {
         connectionSession.getRequiredSessionVariableRecorder().setVariable("key", "default");
+        when(connectionSession.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
         Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
         when(connection.getMetaData().getDatabaseProductName()).thenReturn("PostgreSQL");
         SQLException expectedException = new SQLException("");

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/admin/executor/variable/session/SessionVariableRecordExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/admin/executor/variable/session/SessionVariableRecordExecutorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.
 
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.RequiredSessionVariableRecorder;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
@@ -51,8 +52,11 @@ class SessionVariableRecordExecutorTest {
         RequiredSessionVariableRecorder recorder = mock(RequiredSessionVariableRecorder.class);
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(recorder);
+        ProxyDatabaseConnectionManager databaseConnectionManager = mock(ProxyDatabaseConnectionManager.class);
+        when(connectionSession.getDatabaseConnectionManager()).thenReturn(databaseConnectionManager);
         new SessionVariableRecordExecutor(databaseType, connectionSession).recordVariable("autocommit", "1");
         verify(recorder).setVariable("autocommit", "1");
+        verify(databaseConnectionManager).markSessionVariablesDirty();
     }
     
     @Test
@@ -79,11 +83,14 @@ class SessionVariableRecordExecutorTest {
         RequiredSessionVariableRecorder recorder = mock(RequiredSessionVariableRecorder.class);
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(recorder);
+        ProxyDatabaseConnectionManager databaseConnectionManager = mock(ProxyDatabaseConnectionManager.class);
+        when(connectionSession.getDatabaseConnectionManager()).thenReturn(databaseConnectionManager);
         Map<String, String> variables = new HashMap<>(2, 1F);
         variables.put("var_a", "1");
         variables.put("var_b", "2");
         new SessionVariableRecordExecutor(databaseType, connectionSession).recordVariable(variables);
         verify(recorder).setVariable("var_a", "1");
         verify(recorder, never()).setVariable("var_b", "2");
+        verify(databaseConnectionManager).markSessionVariablesDirty();
     }
 }

--- a/proxy/backend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/backend/firebird/handler/admin/executor/FirebirdSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/backend/firebird/handler/admin/executor/FirebirdSetVariableAdminExecutorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.proxy.backend.firebird.handler.admin.executor;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.ReplayedSessionVariableProvider;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.RequiredSessionVariableRecorder;
@@ -47,13 +48,16 @@ class FirebirdSetVariableAdminExecutorTest {
         FirebirdSetVariableAdminExecutor executor = new FirebirdSetVariableAdminExecutor(setStatement);
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         RequiredSessionVariableRecorder requiredSessionVariableRecorder = mock(RequiredSessionVariableRecorder.class);
+        ProxyDatabaseConnectionManager databaseConnectionManager = mock(ProxyDatabaseConnectionManager.class);
         when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(requiredSessionVariableRecorder);
+        when(connectionSession.getDatabaseConnectionManager()).thenReturn(databaseConnectionManager);
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
             ReplayedSessionVariableProvider replayedSessionVariableProvider = mock(ReplayedSessionVariableProvider.class);
             when(replayedSessionVariableProvider.isNeedToReplay("key")).thenReturn(true);
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(ReplayedSessionVariableProvider.class, databaseType)).thenReturn(Optional.of(replayedSessionVariableProvider));
             executor.execute(connectionSession, mock());
             verify(requiredSessionVariableRecorder).setVariable("key", "value");
+            verify(databaseConnectionManager).markSessionVariablesDirty();
         }
     }
 }

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutor.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutor.java
@@ -218,9 +218,9 @@ public final class MySQLSetVariableAdminExecutor implements DatabaseAdminUpdateE
         for (VariableAssignSegment each : variableAssigns) {
             String variableName = each.getVariable().getVariable();
             if (CHARACTER_SET_CONNECTION.equalsIgnoreCase(variableName)) {
-                result = isKeyword(each.getAssignValue(), "default") ? "DEFAULT" : String.format("'%s'", parseConnectionCharacterSet(each.getAssignValue()).getCollationName());
+                result = String.format("'%s'", parseConnectionCharacterSet(each.getAssignValue()).getCollationName());
             } else if (COLLATION_CONNECTION.equalsIgnoreCase(variableName)) {
-                result = each.getAssignValue();
+                result = String.format("'%s'", parseCollation(each.getAssignValue()).getCollationName());
             }
         }
         return Optional.ofNullable(result);

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutor.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutor.java
@@ -18,7 +18,12 @@
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.database.exception.mysql.exception.CollationCharsetMismatchException;
 import org.apache.shardingsphere.database.exception.mysql.exception.UnknownSystemVariableException;
+import org.apache.shardingsphere.database.exception.mysql.exception.WrongValueForVariableException;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLConstants;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.engine.SQLBindEngine;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
@@ -27,11 +32,11 @@ import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.parser.rule.SQLParserRule;
 import org.apache.shardingsphere.proxy.backend.connector.DatabaseProxyConnectorFactory;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.DatabaseAdminUpdateExecutor;
-import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetSetExecutor;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.SessionVariableRecordExecutor;
 import org.apache.shardingsphere.proxy.backend.handler.data.DatabaseProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.MySQLSystemVariable;
 import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.MySQLSystemVariableScope;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLSessionCharsetContext;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableAssignSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment;
@@ -40,10 +45,14 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatemen
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.SetStatement;
 
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -52,35 +61,169 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public final class MySQLSetVariableAdminExecutor implements DatabaseAdminUpdateExecutor {
     
+    private static final String CHARACTER_SET_CLIENT = "character_set_client";
+    
+    private static final String CHARACTER_SET_RESULTS = "character_set_results";
+    
+    private static final String CHARACTER_SET_CONNECTION = "character_set_connection";
+    
+    private static final String COLLATION_CONNECTION = "collation_connection";
+    
+    private static final Collection<String> IMPERMISSIBLE_CLIENT_CHARACTER_SETS = Arrays.asList("ucs2", "utf16", "utf16le", "utf32");
+    
     private final SetStatement sqlStatement;
     
     @Override
     public void execute(final ConnectionSession connectionSession, final ShardingSphereMetaData metaData) throws SQLException {
-        Map<String, String> sessionVariables = extractSessionVariables();
-        validateSessionVariables(extractSessionVariableSegments());
-        CharsetSetExecutor charsetSetExecutor = new CharsetSetExecutor(sqlStatement.getDatabaseType(), connectionSession);
-        sessionVariables.forEach(charsetSetExecutor::set);
-        new SessionVariableRecordExecutor(sqlStatement.getDatabaseType(), connectionSession).recordVariable(sessionVariables);
+        List<VariableAssignSegment> sessionVariableAssigns = extractSessionVariableAssigns();
+        validateSessionVariables(sessionVariableAssigns.stream().map(VariableAssignSegment::getVariable).collect(Collectors.toList()));
+        validateSetNamesCollation(sessionVariableAssigns);
+        updateCharsetContext(connectionSession, sessionVariableAssigns);
+        SessionVariableRecordExecutor sessionVariableRecordExecutor = new SessionVariableRecordExecutor(sqlStatement.getDatabaseType(), connectionSession);
+        sessionVariableRecordExecutor.recordVariable(extractReplayedSessionVariables(sessionVariableAssigns));
+        getConnectionCollationReplayValue(sessionVariableAssigns).ifPresent(each -> sessionVariableRecordExecutor.recordVariable(COLLATION_CONNECTION, each));
         executeSetGlobalVariablesIfPresent(connectionSession, metaData);
     }
     
-    private Map<String, String> extractSessionVariables() {
-        return sqlStatement.getVariableAssigns().stream().filter(each -> !"global".equalsIgnoreCase(each.getVariable().getScope().orElse("")))
-                .collect(Collectors.toMap(each -> each.getVariable().getVariable(), VariableAssignSegment::getAssignValue));
+    private List<VariableAssignSegment> extractSessionVariableAssigns() {
+        return sqlStatement.getVariableAssigns().stream().filter(each -> !"global".equalsIgnoreCase(each.getVariable().getScope().orElse(""))).collect(Collectors.toList());
     }
     
-    private Collection<VariableSegment> extractSessionVariableSegments() {
-        return sqlStatement.getVariableAssigns().stream().map(VariableAssignSegment::getVariable).filter(each -> !"global".equalsIgnoreCase(each.getScope().orElse(""))).collect(Collectors.toList());
-    }
-    
-    private void validateSessionVariables(final Collection<VariableSegment> sessionVariables) {
-        for (VariableSegment each : sessionVariables) {
+    private void validateSessionVariables(final Collection<VariableSegment> variables) {
+        for (VariableSegment each : variables) {
             if (VariableType.USER == each.getVariableType()) {
                 continue;
             }
             MySQLSystemVariable systemVariable = MySQLSystemVariable.findSystemVariable(each.getVariable()).orElseThrow(() -> new UnknownSystemVariableException(each.getVariable()));
             systemVariable.validateSetTargetScope(MySQLSystemVariableScope.SESSION);
         }
+    }
+    
+    private void validateSetNamesCollation(final List<VariableAssignSegment> variableAssigns) {
+        if (!isSetNamesWithCollation(variableAssigns)) {
+            return;
+        }
+        MySQLCharacterSets characterSet = parseCharacterSet(variableAssigns.get(2).getAssignValue());
+        MySQLCharacterSets collation = parseCollation(variableAssigns.get(3).getAssignValue());
+        if (!characterSet.getCharacterSetName().equals(collation.getCharacterSetName())) {
+            throw new CollationCharsetMismatchException(collation.getCollationName(), characterSet.getCharacterSetName());
+        }
+    }
+    
+    private boolean isSetNamesWithCollation(final List<VariableAssignSegment> variableAssigns) {
+        if (variableAssigns.size() < 4) {
+            return false;
+        }
+        VariableAssignSegment first = variableAssigns.get(0);
+        return CHARACTER_SET_CLIENT.equalsIgnoreCase(first.getVariable().getVariable())
+                && CHARACTER_SET_RESULTS.equalsIgnoreCase(variableAssigns.get(1).getVariable().getVariable())
+                && CHARACTER_SET_CONNECTION.equalsIgnoreCase(variableAssigns.get(2).getVariable().getVariable())
+                && COLLATION_CONNECTION.equalsIgnoreCase(variableAssigns.get(3).getVariable().getVariable())
+                && variableAssigns.subList(1, 4).stream().allMatch(each -> first.getStartIndex() == each.getStartIndex() && first.getStopIndex() == each.getStopIndex());
+    }
+    
+    private void updateCharsetContext(final ConnectionSession connectionSession, final List<VariableAssignSegment> variableAssigns) {
+        if (variableAssigns.stream().noneMatch(each -> isCharsetVariable(each.getVariable().getVariable()))) {
+            return;
+        }
+        MySQLSessionCharsetContext result = MySQLSessionCharsetContext.get(connectionSession.getAttributeMap());
+        for (VariableAssignSegment each : variableAssigns) {
+            result = updateCharsetContext(result, each);
+        }
+        result.apply(connectionSession.getAttributeMap());
+    }
+    
+    private MySQLSessionCharsetContext updateCharsetContext(final MySQLSessionCharsetContext context, final VariableAssignSegment variableAssign) {
+        String variableName = variableAssign.getVariable().getVariable().toLowerCase(Locale.ROOT);
+        switch (variableName) {
+            case CHARACTER_SET_CLIENT:
+                return context.withClientCharacterSet(parseClientCharacterSet(variableAssign.getAssignValue()));
+            case CHARACTER_SET_RESULTS:
+                return updateResultCharacterSet(context, variableAssign.getAssignValue());
+            case CHARACTER_SET_CONNECTION:
+                return context.withConnectionCharacterSet(parseConnectionCharacterSet(variableAssign.getAssignValue()));
+            case COLLATION_CONNECTION:
+                return context.withConnectionCollation(parseCollation(variableAssign.getAssignValue()));
+            default:
+                return context;
+        }
+    }
+    
+    private MySQLCharacterSets parseClientCharacterSet(final String value) {
+        String normalizedValue = formatVariableValue(value).toLowerCase(Locale.ROOT);
+        if (IMPERMISSIBLE_CLIENT_CHARACTER_SETS.contains(normalizedValue)) {
+            throw new WrongValueForVariableException(CHARACTER_SET_CLIENT, normalizedValue);
+        }
+        return parseCharacterSet(value);
+    }
+    
+    private MySQLSessionCharsetContext updateResultCharacterSet(final MySQLSessionCharsetContext context, final String value) {
+        String normalizedValue = formatVariableValue(value).toLowerCase(Locale.ROOT);
+        if (isKeyword(value, "null")) {
+            return context.withoutResultConversion();
+        }
+        return "binary".equals(normalizedValue) ? context.withBinaryResult() : context.withResultCharacterSet(parseCharacterSet(value));
+    }
+    
+    private MySQLCharacterSets parseCharacterSet(final String value) {
+        String normalizedValue = formatVariableValue(value);
+        return isKeyword(value, "default") ? MySQLConstants.DEFAULT_CHARSET : MySQLCharacterSets.findByCharacterSetName(normalizedValue);
+    }
+    
+    private MySQLCharacterSets parseConnectionCharacterSet(final String value) {
+        if (isKeyword(value, "default")) {
+            return parseCollation(value);
+        }
+        MySQLCharacterSets result = parseCharacterSet(value);
+        return "utf8mb4".equals(result.getCharacterSetName())
+                ? MySQLCharacterSets.findByCollationName(MySQLSystemVariable.DEFAULT_COLLATION_FOR_UTF8MB4.getDefaultValue())
+                : result;
+    }
+    
+    private MySQLCharacterSets parseCollation(final String value) {
+        String normalizedValue = formatVariableValue(value);
+        if (isKeyword(value, "@@collation_database")) {
+            return MySQLCharacterSets.findByCollationName(MySQLSystemVariable.COLLATION_DATABASE.getDefaultValue());
+        }
+        return isKeyword(value, "default")
+                ? MySQLCharacterSets.findByCollationName(MySQLSystemVariable.COLLATION_CONNECTION.getDefaultValue())
+                : MySQLCharacterSets.findByCollationName(normalizedValue);
+    }
+    
+    private boolean isKeyword(final String value, final String keyword) {
+        return keyword.equalsIgnoreCase(value.trim());
+    }
+    
+    private String formatVariableValue(final String value) {
+        return QuoteCharacter.SINGLE_QUOTE.isWrapped(value) || QuoteCharacter.QUOTE.isWrapped(value) ? value.substring(1, value.length() - 1) : value.trim();
+    }
+    
+    private Map<String, String> extractReplayedSessionVariables(final Collection<VariableAssignSegment> variableAssigns) {
+        Map<String, String> result = new LinkedHashMap<>();
+        for (VariableAssignSegment each : variableAssigns) {
+            if (!isCharsetVariable(each.getVariable().getVariable())) {
+                result.put(each.getVariable().getVariable(), each.getAssignValue());
+            }
+        }
+        return result;
+    }
+    
+    private boolean isCharsetVariable(final String variableName) {
+        return CHARACTER_SET_CLIENT.equalsIgnoreCase(variableName) || CHARACTER_SET_RESULTS.equalsIgnoreCase(variableName)
+                || CHARACTER_SET_CONNECTION.equalsIgnoreCase(variableName) || COLLATION_CONNECTION.equalsIgnoreCase(variableName);
+    }
+    
+    private Optional<String> getConnectionCollationReplayValue(final Collection<VariableAssignSegment> variableAssigns) {
+        String result = null;
+        for (VariableAssignSegment each : variableAssigns) {
+            String variableName = each.getVariable().getVariable();
+            if (CHARACTER_SET_CONNECTION.equalsIgnoreCase(variableName)) {
+                result = isKeyword(each.getAssignValue(), "default") ? "DEFAULT" : String.format("'%s'", parseConnectionCharacterSet(each.getAssignValue()).getCollationName());
+            } else if (COLLATION_CONNECTION.equalsIgnoreCase(variableName)) {
+                result = each.getAssignValue();
+            }
+        }
+        return Optional.ofNullable(result);
     }
     
     private void executeSetGlobalVariablesIfPresent(final ConnectionSession connectionSession, final ShardingSphereMetaData metaData) throws SQLException {

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSystemVariableQueryExecutor.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSystemVariableQueryExecutor.java
@@ -23,9 +23,10 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResultMetaData;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.raw.metadata.RawQueryResultColumnMetaData;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.raw.metadata.RawQueryResultMetaData;
+import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.raw.type.RawMemoryQueryResult;
+import org.apache.shardingsphere.infra.executor.sql.execute.result.query.type.memory.row.MemoryQueryResultDataRow;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
-import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataMergedResult;
-import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
+import org.apache.shardingsphere.infra.merge.result.impl.transparent.TransparentMergedResult;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.DatabaseAdminExecutor;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.DatabaseAdminQueryExecutor;
@@ -68,12 +69,12 @@ public final class MySQLSystemVariableQueryExecutor implements DatabaseAdminQuer
             ExpressionProjectionSegment projection = projections.get(i);
             VariableSegment variableSegment = (VariableSegment) projection.getExpr();
             MySQLSystemVariableScope scope = variableSegment.getScope().map(MySQLSystemVariableScope::valueFrom).orElse(MySQLSystemVariableScope.DEFAULT);
-            columnsOfRow.add(variables.get(i).getValue(scope, connectionSession));
+            columnsOfRow.add(variables.get(i).getOptionalValue(scope, connectionSession).orElse(null));
             String name = projection.getAliasName().orElseGet(() -> "@@" + variableSegment.getScope().map(s -> s + ".").orElse("") + variableSegment.getVariable());
             columnMetaData.add(new RawQueryResultColumnMetaData("", name, name, Types.VARCHAR, "VARCHAR", 1024, 0));
         }
         queryResultMetaData = new RawQueryResultMetaData(columnMetaData);
-        mergedResult = new LocalDataMergedResult(Collections.singleton(new LocalDataQueryResultRow(columnsOfRow.toArray())));
+        mergedResult = new TransparentMergedResult(new RawMemoryQueryResult(queryResultMetaData, Collections.singletonList(new MemoryQueryResultDataRow(columnsOfRow))));
     }
     
     /**

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/sysvar/MySQLSystemVariable.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/sysvar/MySQLSystemVariable.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.provider.TransactionIsolationValueProvider;
 import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.provider.TransactionReadOnlyValueProvider;
 import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.provider.VersionValueProvider;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.provider.CharsetValueProvider;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 
 import java.util.Arrays;
@@ -144,16 +145,15 @@ public enum MySQLSystemVariable {
     
     BULK_INSERT_BUFFER_SIZE(MySQLSystemVariableFlag.SESSION | MySQLSystemVariableFlag.HINT_UPDATEABLE, "8388608"),
     
-    // TODO Properly handling character set of session.
-    CHARACTER_SET_CLIENT(MySQLSystemVariableFlag.SESSION, "utf8mb4"),
+    CHARACTER_SET_CLIENT(MySQLSystemVariableFlag.SESSION, "utf8mb4", new CharsetValueProvider()),
     
-    CHARACTER_SET_CONNECTION(MySQLSystemVariableFlag.SESSION, "utf8mb4"),
+    CHARACTER_SET_CONNECTION(MySQLSystemVariableFlag.SESSION, "utf8mb4", new CharsetValueProvider()),
     
     CHARACTER_SET_DATABASE(MySQLSystemVariableFlag.SESSION, "utf8mb4"),
     
     CHARACTER_SET_FILESYSTEM(MySQLSystemVariableFlag.SESSION, "binary"),
     
-    CHARACTER_SET_RESULTS(MySQLSystemVariableFlag.SESSION, "utf8mb4"),
+    CHARACTER_SET_RESULTS(MySQLSystemVariableFlag.SESSION, "utf8mb4", new CharsetValueProvider()),
     
     CHARACTER_SET_SERVER(MySQLSystemVariableFlag.SESSION, "utf8mb4"),
     
@@ -163,7 +163,7 @@ public enum MySQLSystemVariable {
     
     CHECK_PROXY_USERS(MySQLSystemVariableFlag.GLOBAL, "0"),
     
-    COLLATION_CONNECTION(MySQLSystemVariableFlag.SESSION, "utf8mb4_unicode_ci"),
+    COLLATION_CONNECTION(MySQLSystemVariableFlag.SESSION, "utf8mb4_unicode_ci", new CharsetValueProvider()),
     
     COLLATION_DATABASE(MySQLSystemVariableFlag.SESSION, "utf8mb4_unicode_ci"),
     
@@ -1113,6 +1113,18 @@ public enum MySQLSystemVariable {
     public String getValue(final MySQLSystemVariableScope scope, final ConnectionSession connectionSession) {
         validateGetScope(scope);
         return variableValueProvider.get(scope, connectionSession, this);
+    }
+    
+    /**
+     * Get optional value of system variable.
+     *
+     * @param scope scope
+     * @param connectionSession connection session
+     * @return optional value
+     */
+    public Optional<String> getOptionalValue(final MySQLSystemVariableScope scope, final ConnectionSession connectionSession) {
+        validateGetScope(scope);
+        return variableValueProvider.getOptional(scope, connectionSession, this);
     }
     
     private void validateGetScope(final MySQLSystemVariableScope scope) {

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/sysvar/MySQLSystemVariableValueProvider.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/sysvar/MySQLSystemVariableValueProvider.java
@@ -19,6 +19,8 @@ package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sys
 
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 
+import java.util.Optional;
+
 /**
  * System variable value provider for MySQL.
  */
@@ -37,5 +39,17 @@ public interface MySQLSystemVariableValueProvider {
      */
     default String get(final MySQLSystemVariableScope scope, final ConnectionSession connectionSession, final MySQLSystemVariable variable) {
         return variable.getDefaultValue();
+    }
+    
+    /**
+     * Get optional variable value.
+     *
+     * @param scope variable scope
+     * @param connectionSession connection session
+     * @param variable system variable
+     * @return optional variable value
+     */
+    default Optional<String> getOptional(final MySQLSystemVariableScope scope, final ConnectionSession connectionSession, final MySQLSystemVariable variable) {
+        return Optional.of(get(scope, connectionSession, variable));
     }
 }

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/sysvar/provider/CharsetValueProvider.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/sysvar/provider/CharsetValueProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.provider;
+
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.MySQLSystemVariable;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.MySQLSystemVariableScope;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.MySQLSystemVariableValueProvider;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLSessionCharsetContext;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+
+import java.util.Optional;
+
+/**
+ * Character set value provider.
+ */
+public final class CharsetValueProvider implements MySQLSystemVariableValueProvider {
+    
+    @Override
+    public String get(final MySQLSystemVariableScope scope, final ConnectionSession connectionSession, final MySQLSystemVariable variable) {
+        return getOptional(scope, connectionSession, variable).orElse("NULL");
+    }
+    
+    @Override
+    public Optional<String> getOptional(final MySQLSystemVariableScope scope, final ConnectionSession connectionSession, final MySQLSystemVariable variable) {
+        MySQLSessionCharsetContext context = MySQLSessionCharsetContext.get(connectionSession.getAttributeMap());
+        switch (variable) {
+            case CHARACTER_SET_CLIENT:
+                return Optional.of(context.getClientCharacterSetName());
+            case CHARACTER_SET_CONNECTION:
+                return Optional.of(context.getConnectionCharacterSetName());
+            case CHARACTER_SET_RESULTS:
+                return context.getResultCharacterSetName();
+            case COLLATION_CONNECTION:
+                return Optional.of(context.getConnectionCollationName());
+            default:
+                return Optional.of(variable.getDefaultValue());
+        }
+    }
+}

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/charset/MySQLSessionCharsetContext.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/charset/MySQLSessionCharsetContext.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset;
+
+import io.netty.util.AttributeKey;
+import io.netty.util.AttributeMap;
+import lombok.Getter;
+import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLConstants;
+
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+/**
+ * MySQL session character set context.
+ */
+@Getter
+public final class MySQLSessionCharsetContext {
+    
+    public static final AttributeKey<MySQLSessionCharsetContext> ATTRIBUTE_KEY = AttributeKey.valueOf(MySQLSessionCharsetContext.class.getName());
+    
+    private final MySQLCharacterSets clientCharacterSet;
+    
+    private final Optional<MySQLCharacterSets> resultCharacterSet;
+    
+    private final Optional<String> resultCharacterSetName;
+    
+    private final MySQLCharacterSets connectionCollation;
+    
+    private MySQLSessionCharsetContext(final MySQLCharacterSets clientCharacterSet, final Optional<MySQLCharacterSets> resultCharacterSet,
+                                       final Optional<String> resultCharacterSetName, final MySQLCharacterSets connectionCollation) {
+        this.clientCharacterSet = clientCharacterSet;
+        this.resultCharacterSet = resultCharacterSet;
+        this.resultCharacterSetName = resultCharacterSetName;
+        this.connectionCollation = connectionCollation;
+    }
+    
+    /**
+     * Create MySQL session character set context.
+     *
+     * @param characterSet initial character set and collation
+     * @return MySQL session character set context
+     */
+    public static MySQLSessionCharsetContext create(final MySQLCharacterSets characterSet) {
+        return new MySQLSessionCharsetContext(characterSet, Optional.of(characterSet), Optional.of(characterSet.getCharacterSetName()), characterSet);
+    }
+    
+    /**
+     * Get MySQL session character set context.
+     *
+     * @param attributeMap attribute map
+     * @return MySQL session character set context
+     */
+    public static MySQLSessionCharsetContext get(final AttributeMap attributeMap) {
+        MySQLSessionCharsetContext result = attributeMap.attr(ATTRIBUTE_KEY).get();
+        return null == result ? create(MySQLConstants.DEFAULT_CHARSET) : result;
+    }
+    
+    /**
+     * Create a context with the specified client character set.
+     *
+     * @param characterSet client character set
+     * @return updated context
+     */
+    public MySQLSessionCharsetContext withClientCharacterSet(final MySQLCharacterSets characterSet) {
+        return new MySQLSessionCharsetContext(characterSet, resultCharacterSet, resultCharacterSetName, connectionCollation);
+    }
+    
+    /**
+     * Create a context with the specified result character set.
+     *
+     * @param characterSet result character set
+     * @return updated context
+     */
+    public MySQLSessionCharsetContext withResultCharacterSet(final MySQLCharacterSets characterSet) {
+        return new MySQLSessionCharsetContext(clientCharacterSet, Optional.of(characterSet), Optional.of(characterSet.getCharacterSetName()), connectionCollation);
+    }
+    
+    /**
+     * Create a context without result conversion for a NULL result character set.
+     *
+     * @return updated context
+     */
+    public MySQLSessionCharsetContext withoutResultConversion() {
+        return new MySQLSessionCharsetContext(clientCharacterSet, Optional.empty(), Optional.empty(), connectionCollation);
+    }
+    
+    /**
+     * Create a context without result conversion for the binary result character set.
+     *
+     * @return updated context
+     */
+    public MySQLSessionCharsetContext withBinaryResult() {
+        return new MySQLSessionCharsetContext(clientCharacterSet, Optional.empty(), Optional.of("binary"), connectionCollation);
+    }
+    
+    /**
+     * Create a context with the default collation of the specified connection character set.
+     *
+     * @param characterSet connection character set and its default collation
+     * @return updated context
+     */
+    public MySQLSessionCharsetContext withConnectionCharacterSet(final MySQLCharacterSets characterSet) {
+        return new MySQLSessionCharsetContext(clientCharacterSet, resultCharacterSet, resultCharacterSetName, characterSet);
+    }
+    
+    /**
+     * Create a context with the specified connection collation.
+     *
+     * @param collation connection collation
+     * @return updated context
+     */
+    public MySQLSessionCharsetContext withConnectionCollation(final MySQLCharacterSets collation) {
+        return new MySQLSessionCharsetContext(clientCharacterSet, resultCharacterSet, resultCharacterSetName, collation);
+    }
+    
+    /**
+     * Get result encoding character set.
+     *
+     * @return result encoding character set
+     */
+    public Charset getResultCharset() {
+        return resultCharacterSet.orElse(clientCharacterSet).getCharset();
+    }
+    
+    /**
+     * Get result metadata collation.
+     *
+     * @return result metadata collation
+     */
+    public MySQLCharacterSets getResultCollation() {
+        return resultCharacterSet.orElse(clientCharacterSet);
+    }
+    
+    /**
+     * Get client character set name.
+     *
+     * @return client character set name
+     */
+    public String getClientCharacterSetName() {
+        return clientCharacterSet.getCharacterSetName();
+    }
+    
+    /**
+     * Get connection character set name.
+     *
+     * @return connection character set name
+     */
+    public String getConnectionCharacterSetName() {
+        return connectionCollation.getCharacterSetName();
+    }
+    
+    /**
+     * Get connection collation name.
+     *
+     * @return connection collation name
+     */
+    public String getConnectionCollationName() {
+        return connectionCollation.getCollationName();
+    }
+    
+    /**
+     * Apply context to protocol attributes.
+     *
+     * @param attributeMap attribute map
+     */
+    public void apply(final AttributeMap attributeMap) {
+        attributeMap.attr(ATTRIBUTE_KEY).set(this);
+        attributeMap.attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).set(clientCharacterSet.getCharset());
+        attributeMap.attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY).set(getResultCharset());
+        attributeMap.attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY).set(getResultCollation());
+    }
+}

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/charset/MySQLSessionCharsetContext.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/charset/MySQLSessionCharsetContext.java
@@ -136,7 +136,7 @@ public final class MySQLSessionCharsetContext {
      * @return result encoding character set
      */
     public Charset getResultCharset() {
-        return resultCharacterSet.orElse(clientCharacterSet).getCharset();
+        return resultCharacterSet.orElse(MySQLConstants.DEFAULT_CHARSET).getCharset();
     }
     
     /**
@@ -145,7 +145,7 @@ public final class MySQLSessionCharsetContext {
      * @return result metadata collation
      */
     public MySQLCharacterSets getResultCollation() {
-        return resultCharacterSet.orElse(clientCharacterSet);
+        return resultCharacterSet.orElse(MySQLConstants.DEFAULT_CHARSET);
     }
     
     /**

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/session/MySQLReplayedSessionVariableProvider.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/session/MySQLReplayedSessionVariableProvider.java
@@ -26,7 +26,7 @@ public final class MySQLReplayedSessionVariableProvider implements ReplayedSessi
     
     @Override
     public boolean isNeedToReplay(final String variableName) {
-        return variableName.startsWith("@");
+        return variableName.startsWith("@") || "collation_connection".equalsIgnoreCase(variableName);
     }
     
     @Override

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
@@ -19,9 +19,15 @@ package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor;
 
 import io.netty.util.DefaultAttributeMap;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.exception.mysql.exception.CollationCharsetMismatchException;
 import org.apache.shardingsphere.database.exception.mysql.exception.ErrorGlobalVariableException;
+import org.apache.shardingsphere.database.exception.mysql.exception.UnknownCharsetException;
+import org.apache.shardingsphere.database.exception.mysql.exception.UnknownCollationException;
 import org.apache.shardingsphere.database.exception.mysql.exception.UnknownSystemVariableException;
+import org.apache.shardingsphere.database.exception.mysql.exception.WrongValueForVariableException;
 import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLConstants;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
@@ -32,6 +38,7 @@ import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnection
 import org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseProxyConnector;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.RequiredSessionVariableRecorder;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLSessionCharsetContext;
 import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableAssignSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment;
@@ -40,6 +47,9 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatemen
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.SetStatement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -48,6 +58,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -83,12 +94,13 @@ class MySQLSetVariableAdminExecutorTest {
     @Test
     void assertExecuteWithCharacterSetResults() throws SQLException {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
-                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "character_set_results"), "'utf8mb4'")));
+                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "character_set_results"), "'latin1'")));
         MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
-        ConnectionSession connectionSession = mock(ConnectionSession.class);
-        when(connectionSession.getAttributeMap()).thenReturn(new DefaultAttributeMap());
+        ConnectionSession connectionSession = mockConnectionSession();
         executor.execute(connectionSession, mock());
         assertThat(connectionSession.getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
+        assertThat(connectionSession.getAttributeMap().attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.ISO_8859_1));
+        assertThat(connectionSession.getAttributeMap().attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY).get(), is(MySQLCharacterSets.LATIN1_SWEDISH_CI));
     }
     
     @Test
@@ -96,12 +108,134 @@ class MySQLSetVariableAdminExecutorTest {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
                 new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "character_set_results"), "NULL")));
         MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
-        ConnectionSession connectionSession = mock(ConnectionSession.class);
-        DefaultAttributeMap attributeMap = new DefaultAttributeMap();
-        attributeMap.attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).set(StandardCharsets.UTF_8);
-        when(connectionSession.getAttributeMap()).thenReturn(attributeMap);
+        ConnectionSession connectionSession = mockConnectionSession();
         executor.execute(connectionSession, mock());
-        assertThat(connectionSession.getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
+        assertThat(MySQLSessionCharsetContext.get(connectionSession.getAttributeMap()).getResultCharacterSetName(), is(Optional.empty()));
+        assertThat(connectionSession.getAttributeMap().attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
+        assertThat(connectionSession.getAttributeMap().attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY).get(), is(MySQLConstants.DEFAULT_CHARSET));
+    }
+    
+    @Test
+    void assertExecuteWithCharacterSetResultsAsBinary() throws SQLException {
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
+                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "character_set_results"), "binary")));
+        ConnectionSession connectionSession = mockConnectionSession();
+        new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock());
+        assertThat(MySQLSessionCharsetContext.get(connectionSession.getAttributeMap()).getResultCharacterSetName(), is(Optional.of("binary")));
+        assertThat(connectionSession.getAttributeMap().attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
+        assertThat(connectionSession.getAttributeMap().attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY).get(), is(MySQLConstants.DEFAULT_CHARSET));
+    }
+    
+    @Test
+    void assertExecuteSetNamesWithCollation() throws SQLException {
+        SetStatement setStatement = parseSetStatement("SET NAMES 'utf8' COLLATE 'utf8_bin'");
+        ConnectionSession connectionSession = mockReplayableConnectionSession();
+        new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock());
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.get(connectionSession.getAttributeMap());
+        assertThat(actual.getClientCharacterSetName(), is("utf8"));
+        assertThat(actual.getResultCharacterSetName(), is(Optional.of("utf8")));
+        assertThat(actual.getConnectionCharacterSetName(), is("utf8"));
+        assertThat(actual.getConnectionCollationName(), is("utf8_bin"));
+        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET collation_connection='utf8_bin'")));
+    }
+    
+    @Test
+    void assertExecuteSetCharacterSet() throws SQLException {
+        SetStatement setStatement = parseSetStatement("SET CHARACTER SET latin1");
+        ConnectionSession connectionSession = mockReplayableConnectionSession();
+        new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock());
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.get(connectionSession.getAttributeMap());
+        assertThat(actual.getClientCharacterSetName(), is("latin1"));
+        assertThat(actual.getResultCharacterSetName(), is(Optional.of("latin1")));
+        assertThat(actual.getConnectionCharacterSetName(), is("utf8mb4"));
+        assertThat(actual.getConnectionCollationName(), is("utf8mb4_unicode_ci"));
+        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET collation_connection=@@collation_database")));
+    }
+    
+    @Test
+    void assertExecuteWithIndependentCharacterSets() throws SQLException {
+        SetStatement setStatement = new SetStatement(databaseType, Arrays.asList(
+                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "character_set_client"), "latin1"),
+                new VariableAssignSegment(1, 1, new VariableSegment(1, 1, "character_set_results"), "utf8mb4"),
+                new VariableAssignSegment(2, 2, new VariableSegment(2, 2, "collation_connection"), "latin1_bin")));
+        ConnectionSession connectionSession = mockReplayableConnectionSession();
+        new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock());
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.get(connectionSession.getAttributeMap());
+        assertThat(actual.getClientCharacterSetName(), is("latin1"));
+        assertThat(actual.getResultCharacterSetName(), is(Optional.of("utf8mb4")));
+        assertThat(actual.getConnectionCharacterSetName(), is("latin1"));
+        assertThat(actual.getConnectionCollationName(), is("latin1_bin"));
+    }
+    
+    @Test
+    void assertExecuteWithCharacterSetConnection() throws SQLException {
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
+                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "character_set_connection"), "latin1")));
+        ConnectionSession connectionSession = mockReplayableConnectionSession();
+        new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock());
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.get(connectionSession.getAttributeMap());
+        assertThat(actual.getConnectionCharacterSetName(), is("latin1"));
+        assertThat(actual.getConnectionCollationName(), is("latin1_swedish_ci"));
+        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()),
+                is(Collections.singletonList("SET collation_connection='latin1_swedish_ci'")));
+    }
+    
+    @Test
+    void assertExecuteWithUtf8mb4CharacterSetConnection() throws SQLException {
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
+                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "character_set_connection"), "utf8mb4")));
+        ConnectionSession connectionSession = mockReplayableConnectionSession();
+        new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock());
+        assertThat(MySQLSessionCharsetContext.get(connectionSession.getAttributeMap()).getConnectionCollation(), is(MySQLCharacterSets.UTF8MB4_UNICODE_CI));
+        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()),
+                is(Collections.singletonList("SET collation_connection='utf8mb4_unicode_ci'")));
+    }
+    
+    @Test
+    void assertExecuteSetNamesDefault() throws SQLException {
+        SetStatement setStatement = parseSetStatement("SET NAMES DEFAULT");
+        ConnectionSession connectionSession = mockReplayableConnectionSession();
+        new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock());
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.get(connectionSession.getAttributeMap());
+        assertThat(actual.getClientCharacterSet(), is(MySQLConstants.DEFAULT_CHARSET));
+        assertThat(actual.getResultCharacterSet(), is(Optional.of(MySQLConstants.DEFAULT_CHARSET)));
+        assertThat(actual.getConnectionCollation(), is(MySQLCharacterSets.UTF8MB4_UNICODE_CI));
+        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET collation_connection=DEFAULT")));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("quotedCharsetKeywordArguments")
+    void assertExecuteWithQuotedCharsetKeyword(final String name, final String variableName, final String value) {
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
+                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, variableName), value)));
+        ConnectionSession connectionSession = mockConnectionSession();
+        assertThrows(UnknownCharsetException.class, () -> new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock()));
+    }
+    
+    @Test
+    void assertExecuteWithQuotedCollationDatabaseVariable() {
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
+                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "collation_connection"), "'@@collation_database'")));
+        assertThrows(UnknownCollationException.class, () -> new MySQLSetVariableAdminExecutor(setStatement).execute(mockConnectionSession(), mock()));
+    }
+    
+    @Test
+    void assertExecuteAtomicallyWithImpermissibleClientCharacterSet() {
+        SetStatement setStatement = new SetStatement(databaseType, Arrays.asList(
+                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "character_set_results"), "utf8mb4"),
+                new VariableAssignSegment(1, 1, new VariableSegment(1, 1, "character_set_client"), "ucs2")));
+        ConnectionSession connectionSession = mockConnectionSession();
+        MySQLSessionCharsetContext expected = MySQLSessionCharsetContext.create(MySQLCharacterSets.LATIN1_SWEDISH_CI);
+        expected.apply(connectionSession.getAttributeMap());
+        assertThrows(WrongValueForVariableException.class, () -> new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock()));
+        assertThat(MySQLSessionCharsetContext.get(connectionSession.getAttributeMap()), is(expected));
+    }
+    
+    @Test
+    void assertExecuteWithMismatchedSetNamesCollation() {
+        SetStatement setStatement = parseSetStatement("SET NAMES latin1 COLLATE utf8mb4_bin");
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        assertThrows(CollationCharsetMismatchException.class, () -> new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock()));
     }
     
     @Test
@@ -132,6 +266,25 @@ class MySQLSetVariableAdminExecutorTest {
         ConnectionContext result = mock(ConnectionContext.class);
         when(result.getCurrentDatabaseName()).thenReturn(Optional.of("foo_db"));
         return result;
+    }
+    
+    private ConnectionSession mockConnectionSession() {
+        ConnectionSession result = mock(ConnectionSession.class);
+        when(result.getAttributeMap()).thenReturn(new DefaultAttributeMap());
+        return result;
+    }
+    
+    private ConnectionSession mockReplayableConnectionSession() {
+        ConnectionSession result = mockConnectionSession();
+        when(result.getRequiredSessionVariableRecorder()).thenReturn(new RequiredSessionVariableRecorder());
+        return result;
+    }
+    
+    private static Stream<Arguments> quotedCharsetKeywordArguments() {
+        return Stream.of(
+                Arguments.of("quoted NULL result", "character_set_results", "'NULL'"),
+                Arguments.of("quoted DEFAULT client", "character_set_client", "'DEFAULT'"),
+                Arguments.of("quoted DEFAULT connection", "character_set_connection", "'DEFAULT'"));
     }
     
     private SetStatement prepareSetStatement() {

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
@@ -149,7 +149,8 @@ class MySQLSetVariableAdminExecutorTest {
         assertThat(actual.getResultCharacterSetName(), is(Optional.of("latin1")));
         assertThat(actual.getConnectionCharacterSetName(), is("utf8mb4"));
         assertThat(actual.getConnectionCollationName(), is("utf8mb4_unicode_ci"));
-        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET collation_connection=@@collation_database")));
+        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()),
+                is(Collections.singletonList("SET collation_connection='utf8mb4_unicode_ci'")));
     }
     
     @Test
@@ -200,7 +201,19 @@ class MySQLSetVariableAdminExecutorTest {
         assertThat(actual.getClientCharacterSet(), is(MySQLConstants.DEFAULT_CHARSET));
         assertThat(actual.getResultCharacterSet(), is(Optional.of(MySQLConstants.DEFAULT_CHARSET)));
         assertThat(actual.getConnectionCollation(), is(MySQLCharacterSets.UTF8MB4_UNICODE_CI));
-        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET collation_connection=DEFAULT")));
+        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()),
+                is(Collections.singletonList("SET collation_connection='utf8mb4_unicode_ci'")));
+    }
+    
+    @Test
+    void assertExecuteWithDefaultConnectionCollation() throws SQLException {
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
+                new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "collation_connection"), "DEFAULT")));
+        ConnectionSession connectionSession = mockReplayableConnectionSession();
+        new MySQLSetVariableAdminExecutor(setStatement).execute(connectionSession, mock());
+        assertThat(MySQLSessionCharsetContext.get(connectionSession.getAttributeMap()).getConnectionCollation(), is(MySQLCharacterSets.UTF8MB4_UNICODE_CI));
+        assertThat(connectionSession.getRequiredSessionVariableRecorder().toSetSQLs(databaseType.getType()),
+                is(Collections.singletonList("SET collation_connection='utf8mb4_unicode_ci'")));
     }
     
     @ParameterizedTest(name = "{0}")
@@ -243,9 +256,8 @@ class MySQLSetVariableAdminExecutorTest {
         SetStatement setStatement = parseSetStatement("SET @test_var = 1");
         assertThat(setStatement.getVariableAssigns().iterator().next().getVariable().getVariableType(), is(VariableType.USER));
         MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
-        ConnectionSession connectionSession = mock(ConnectionSession.class);
-        RequiredSessionVariableRecorder recorder = new RequiredSessionVariableRecorder();
-        when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(recorder);
+        ConnectionSession connectionSession = mockSessionVariableConnectionSession();
+        RequiredSessionVariableRecorder recorder = connectionSession.getRequiredSessionVariableRecorder();
         executor.execute(connectionSession, mock());
         assertThat(recorder.toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET @test_var=1")));
     }
@@ -255,9 +267,8 @@ class MySQLSetVariableAdminExecutorTest {
         SetStatement setStatement = parseSetStatement("SET @test_var := 1");
         assertThat(setStatement.getVariableAssigns().iterator().next().getVariable().getVariableType(), is(VariableType.USER));
         MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
-        ConnectionSession connectionSession = mock(ConnectionSession.class);
-        RequiredSessionVariableRecorder recorder = new RequiredSessionVariableRecorder();
-        when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(recorder);
+        ConnectionSession connectionSession = mockSessionVariableConnectionSession();
+        RequiredSessionVariableRecorder recorder = connectionSession.getRequiredSessionVariableRecorder();
         executor.execute(connectionSession, mock());
         assertThat(recorder.toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET @test_var=1")));
     }
@@ -275,8 +286,15 @@ class MySQLSetVariableAdminExecutorTest {
     }
     
     private ConnectionSession mockReplayableConnectionSession() {
-        ConnectionSession result = mockConnectionSession();
+        ConnectionSession result = mockSessionVariableConnectionSession();
+        when(result.getAttributeMap()).thenReturn(new DefaultAttributeMap());
+        return result;
+    }
+    
+    private ConnectionSession mockSessionVariableConnectionSession() {
+        ConnectionSession result = mock(ConnectionSession.class);
         when(result.getRequiredSessionVariableRecorder()).thenReturn(new RequiredSessionVariableRecorder());
+        when(result.getDatabaseConnectionManager()).thenReturn(mock(ProxyDatabaseConnectionManager.class));
         return result;
     }
     

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSystemVariableQueryExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSystemVariableQueryExecutorTest.java
@@ -17,13 +17,17 @@
 
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor;
 
+import io.netty.util.DefaultAttributeMap;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.exception.mysql.exception.IncorrectGlobalLocalVariableException;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLConstants;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResultMetaData;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.DatabaseAdminExecutor;
 import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.MySQLSystemVariable;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLSessionCharsetContext;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ColumnProjectionSegment;
@@ -40,9 +44,11 @@ import java.util.Optional;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class MySQLSystemVariableQueryExecutorTest {
     
@@ -99,5 +105,22 @@ class MySQLSystemVariableQueryExecutorTest {
         Optional<DatabaseAdminExecutor> executor = MySQLSystemVariableQueryExecutor.tryGetSystemVariableQueryExecutor(selectStatement);
         assertTrue(executor.isPresent());
         assertThrows(IncorrectGlobalLocalVariableException.class, () -> executor.get().execute(null, mock()));
+    }
+    
+    @Test
+    void assertExecuteWithNullCharacterSetResults() throws SQLException {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0)).build();
+        selectStatement.getProjections().getProjections().add(new ExpressionProjectionSegment(
+                0, 0, "@@character_set_results", new VariableSegment(0, 0, "character_set_results")));
+        Optional<DatabaseAdminExecutor> optionalExecutor = MySQLSystemVariableQueryExecutor.tryGetSystemVariableQueryExecutor(selectStatement);
+        assertTrue(optionalExecutor.isPresent());
+        MySQLSystemVariableQueryExecutor executor = (MySQLSystemVariableQueryExecutor) optionalExecutor.get();
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        when(connectionSession.getAttributeMap()).thenReturn(new DefaultAttributeMap());
+        MySQLSessionCharsetContext.create(MySQLConstants.DEFAULT_CHARSET).withoutResultConversion().apply(connectionSession.getAttributeMap());
+        executor.execute(connectionSession, mock());
+        MergedResult actual = executor.getMergedResult();
+        assertTrue(actual.next());
+        assertNull(actual.getValue(1, Object.class));
     }
 }

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/sysvar/provider/CharsetValueProviderTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/sysvar/provider/CharsetValueProviderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.provider;
+
+import io.netty.util.DefaultAttributeMap;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.MySQLSystemVariable;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.MySQLSystemVariableScope;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLSessionCharsetContext;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CharsetValueProviderTest {
+    
+    private final CharsetValueProvider provider = new CharsetValueProvider();
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("sessionValueArguments")
+    void assertGetSessionValue(final String name, final MySQLSystemVariable variable, final String expected) {
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        DefaultAttributeMap attributeMap = new DefaultAttributeMap();
+        MySQLSessionCharsetContext.create(MySQLCharacterSets.LATIN1_SWEDISH_CI).withConnectionCollation(MySQLCharacterSets.UTF8MB4_BIN).apply(attributeMap);
+        when(connectionSession.getAttributeMap()).thenReturn(attributeMap);
+        assertThat(provider.getOptional(MySQLSystemVariableScope.SESSION, connectionSession, variable), is(Optional.of(expected)));
+    }
+    
+    @Test
+    void assertGetNullResultValue() {
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        DefaultAttributeMap attributeMap = new DefaultAttributeMap();
+        MySQLSessionCharsetContext.create(MySQLCharacterSets.LATIN1_SWEDISH_CI).withoutResultConversion().apply(attributeMap);
+        when(connectionSession.getAttributeMap()).thenReturn(attributeMap);
+        assertThat(provider.get(MySQLSystemVariableScope.SESSION, connectionSession, MySQLSystemVariable.CHARACTER_SET_RESULTS), is("NULL"));
+    }
+    
+    @Test
+    void assertGetDefaultValue() {
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        when(connectionSession.getAttributeMap()).thenReturn(new DefaultAttributeMap());
+        assertThat(provider.getOptional(MySQLSystemVariableScope.SESSION, connectionSession, MySQLSystemVariable.AUTOCOMMIT), is(Optional.of("1")));
+    }
+    
+    private static Stream<Arguments> sessionValueArguments() {
+        return Stream.of(
+                Arguments.of("client character set", MySQLSystemVariable.CHARACTER_SET_CLIENT, "latin1"),
+                Arguments.of("connection character set", MySQLSystemVariable.CHARACTER_SET_CONNECTION, "utf8mb4"),
+                Arguments.of("result character set", MySQLSystemVariable.CHARACTER_SET_RESULTS, "latin1"),
+                Arguments.of("connection collation", MySQLSystemVariable.COLLATION_CONNECTION, "utf8mb4_bin"));
+    }
+}

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/charset/MySQLSessionCharsetContextTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/charset/MySQLSessionCharsetContextTest.java
@@ -69,16 +69,27 @@ class MySQLSessionCharsetContextTest {
     
     @Test
     void assertWithoutResultConversion() {
-        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLConstants.DEFAULT_CHARSET).withoutResultConversion();
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLCharacterSets.LATIN1_SWEDISH_CI).withoutResultConversion();
         assertThat(actual.getResultCharacterSetName(), is(Optional.empty()));
+        assertThat(actual.getResultCharset(), is(StandardCharsets.UTF_8));
         assertThat(actual.getResultCollation(), is(MySQLConstants.DEFAULT_CHARSET));
     }
     
     @Test
     void assertWithBinaryResult() {
-        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLConstants.DEFAULT_CHARSET).withBinaryResult();
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLCharacterSets.LATIN1_SWEDISH_CI).withBinaryResult();
         assertThat(actual.getResultCharacterSetName(), is(Optional.of("binary")));
         assertThat(actual.getResultCharset(), is(StandardCharsets.UTF_8));
+        assertThat(actual.getResultCollation(), is(MySQLConstants.DEFAULT_CHARSET));
+    }
+    
+    @Test
+    void assertApplyWithoutResultConversion() {
+        DefaultAttributeMap attributeMap = new DefaultAttributeMap();
+        MySQLSessionCharsetContext.create(MySQLCharacterSets.LATIN1_SWEDISH_CI).withoutResultConversion().apply(attributeMap);
+        assertThat(attributeMap.attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.ISO_8859_1));
+        assertThat(attributeMap.attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
+        assertThat(attributeMap.attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY).get(), is(MySQLConstants.DEFAULT_CHARSET));
     }
     
     @Test

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/charset/MySQLSessionCharsetContextTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/charset/MySQLSessionCharsetContextTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset;
+
+import io.netty.util.DefaultAttributeMap;
+import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLConstants;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MySQLSessionCharsetContextTest {
+    
+    @Test
+    void assertCreate() {
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLCharacterSets.LATIN1_SWEDISH_CI);
+        assertThat(actual.getClientCharacterSetName(), is("latin1"));
+        assertThat(actual.getResultCharacterSetName(), is(Optional.of("latin1")));
+        assertThat(actual.getConnectionCharacterSetName(), is("latin1"));
+        assertThat(actual.getConnectionCollationName(), is("latin1_swedish_ci"));
+    }
+    
+    @Test
+    void assertGetDefaultContext() {
+        assertThat(MySQLSessionCharsetContext.get(new DefaultAttributeMap()).getClientCharacterSet(), is(MySQLConstants.DEFAULT_CHARSET));
+    }
+    
+    @Test
+    void assertGetStoredContext() {
+        DefaultAttributeMap attributeMap = new DefaultAttributeMap();
+        MySQLSessionCharsetContext expected = MySQLSessionCharsetContext.create(MySQLCharacterSets.LATIN1_SWEDISH_CI);
+        attributeMap.attr(MySQLSessionCharsetContext.ATTRIBUTE_KEY).set(expected);
+        assertThat(MySQLSessionCharsetContext.get(attributeMap), is(expected));
+    }
+    
+    @Test
+    void assertWithClientCharacterSet() {
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLConstants.DEFAULT_CHARSET).withClientCharacterSet(MySQLCharacterSets.LATIN1_SWEDISH_CI);
+        assertThat(actual.getClientCharacterSet(), is(MySQLCharacterSets.LATIN1_SWEDISH_CI));
+        assertThat(actual.getResultCharacterSet(), is(Optional.of(MySQLConstants.DEFAULT_CHARSET)));
+    }
+    
+    @Test
+    void assertWithResultCharacterSet() {
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLConstants.DEFAULT_CHARSET).withResultCharacterSet(MySQLCharacterSets.LATIN1_SWEDISH_CI);
+        assertThat(actual.getResultCharacterSet(), is(Optional.of(MySQLCharacterSets.LATIN1_SWEDISH_CI)));
+        assertThat(actual.getResultCharset(), is(StandardCharsets.ISO_8859_1));
+    }
+    
+    @Test
+    void assertWithoutResultConversion() {
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLConstants.DEFAULT_CHARSET).withoutResultConversion();
+        assertThat(actual.getResultCharacterSetName(), is(Optional.empty()));
+        assertThat(actual.getResultCollation(), is(MySQLConstants.DEFAULT_CHARSET));
+    }
+    
+    @Test
+    void assertWithBinaryResult() {
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLConstants.DEFAULT_CHARSET).withBinaryResult();
+        assertThat(actual.getResultCharacterSetName(), is(Optional.of("binary")));
+        assertThat(actual.getResultCharset(), is(StandardCharsets.UTF_8));
+    }
+    
+    @Test
+    void assertWithConnectionCharacterSet() {
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLConstants.DEFAULT_CHARSET).withConnectionCharacterSet(MySQLCharacterSets.LATIN1_SWEDISH_CI);
+        assertThat(actual.getConnectionCharacterSetName(), is("latin1"));
+        assertThat(actual.getConnectionCollationName(), is("latin1_swedish_ci"));
+    }
+    
+    @Test
+    void assertWithConnectionCollation() {
+        MySQLSessionCharsetContext actual = MySQLSessionCharsetContext.create(MySQLConstants.DEFAULT_CHARSET).withConnectionCollation(MySQLCharacterSets.UTF8MB4_BIN);
+        assertThat(actual.getConnectionCharacterSetName(), is("utf8mb4"));
+        assertThat(actual.getConnectionCollation(), is(MySQLCharacterSets.UTF8MB4_BIN));
+    }
+    
+    @Test
+    void assertApply() {
+        DefaultAttributeMap attributeMap = new DefaultAttributeMap();
+        MySQLSessionCharsetContext expected = MySQLSessionCharsetContext.create(MySQLCharacterSets.LATIN1_SWEDISH_CI);
+        expected.apply(attributeMap);
+        assertThat(attributeMap.attr(MySQLSessionCharsetContext.ATTRIBUTE_KEY).get(), is(expected));
+        assertThat(attributeMap.attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.ISO_8859_1));
+        assertThat(attributeMap.attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.ISO_8859_1));
+        assertThat(attributeMap.attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY).get(), is(MySQLCharacterSets.LATIN1_SWEDISH_CI));
+    }
+}

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/session/MySQLReplayedSessionVariableProviderTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/variable/session/MySQLReplayedSessionVariableProviderTest.java
@@ -20,10 +20,14 @@ package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.var
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.ReplayedSessionVariableProvider;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 class MySQLReplayedSessionVariableProviderTest {
     
@@ -31,9 +35,16 @@ class MySQLReplayedSessionVariableProviderTest {
     
     private final ReplayedSessionVariableProvider provider = TypedSPILoader.getService(ReplayedSessionVariableProvider.class, databaseType);
     
-    @Test
-    void assertIsNeedToReplay() {
-        assertTrue(provider.isNeedToReplay("@@tx_isolation"));
-        assertFalse(provider.isNeedToReplay("tx_isolation"));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("replayArguments")
+    void assertIsNeedToReplay(final String name, final String variableName, final boolean expected) {
+        assertThat(provider.isNeedToReplay(variableName), is(expected));
+    }
+    
+    private static Stream<Arguments> replayArguments() {
+        return Stream.of(
+                Arguments.of("user variable", "@@tx_isolation", true),
+                Arguments.of("connection collation", "COLLATION_CONNECTION", true),
+                Arguments.of("discarded system variable", "tx_isolation", false));
     }
 }

--- a/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutorTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoa
 import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetVariableProvider;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.ReplayedSessionVariableProvider;
 import org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor.variable.charset.PostgreSQLCharsetVariableProvider;
@@ -52,7 +53,9 @@ class PostgreSQLResetVariableAdminExecutorTest {
         PostgreSQLResetVariableAdminExecutor executor = new PostgreSQLResetVariableAdminExecutor(new PostgreSQLResetParameterStatement(databaseType, "key"));
         ConnectionSession connectionSession = mock(ConnectionSession.class, RETURNS_DEEP_STUBS);
         RequiredSessionVariableRecorder requiredSessionVariableRecorder = mock(RequiredSessionVariableRecorder.class);
+        ProxyDatabaseConnectionManager databaseConnectionManager = mock(ProxyDatabaseConnectionManager.class);
         when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(requiredSessionVariableRecorder);
+        when(connectionSession.getDatabaseConnectionManager()).thenReturn(databaseConnectionManager);
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(CharsetVariableProvider.class, databaseType)).thenReturn(Optional.empty());
             ReplayedSessionVariableProvider replayedSessionVariableProvider = mock(ReplayedSessionVariableProvider.class);
@@ -60,6 +63,7 @@ class PostgreSQLResetVariableAdminExecutorTest {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(ReplayedSessionVariableProvider.class, databaseType)).thenReturn(Optional.of(replayedSessionVariableProvider));
             executor.execute(connectionSession, mock());
             verify(requiredSessionVariableRecorder).setVariable("key", "DEFAULT");
+            verify(databaseConnectionManager).markSessionVariablesDirty();
         }
     }
     

--- a/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLSetVariableAdminExecutorTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.exception.core.exception.data.InvalidParameterValueException;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetVariableProvider;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.ReplayedSessionVariableProvider;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
@@ -57,13 +58,16 @@ class PostgreSQLSetVariableAdminExecutorTest {
         PostgreSQLSetVariableAdminExecutor executor = new PostgreSQLSetVariableAdminExecutor(setStatement);
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         RequiredSessionVariableRecorder requiredSessionVariableRecorder = mock(RequiredSessionVariableRecorder.class);
+        ProxyDatabaseConnectionManager databaseConnectionManager = mock(ProxyDatabaseConnectionManager.class);
         when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(requiredSessionVariableRecorder);
+        when(connectionSession.getDatabaseConnectionManager()).thenReturn(databaseConnectionManager);
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
             ReplayedSessionVariableProvider replayedSessionVariableProvider = mock(ReplayedSessionVariableProvider.class);
             when(replayedSessionVariableProvider.isNeedToReplay("key")).thenReturn(true);
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(ReplayedSessionVariableProvider.class, databaseType)).thenReturn(Optional.of(replayedSessionVariableProvider));
             executor.execute(connectionSession, mock());
             verify(requiredSessionVariableRecorder).setVariable("key", "value");
+            verify(databaseConnectionManager).markSessionVariablesDirty();
         }
     }
     

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngine.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngine.java
@@ -32,7 +32,6 @@ import org.apache.shardingsphere.database.exception.core.exception.connection.Ac
 import org.apache.shardingsphere.database.exception.core.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.database.exception.mysql.exception.DatabaseAccessDeniedException;
 import org.apache.shardingsphere.database.exception.mysql.exception.HandshakeException;
-import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCapabilityFlag;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLConnectionPhase;
@@ -50,6 +49,7 @@ import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.metadata.user.Grantee;
 import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLSessionCharsetContext;
 import org.apache.shardingsphere.proxy.frontend.authentication.AuthenticationEngine;
 import org.apache.shardingsphere.proxy.frontend.connection.ConnectionIdGenerator;
 import org.apache.shardingsphere.proxy.frontend.mysql.authentication.authenticator.MySQLAuthenticatorType;
@@ -144,8 +144,7 @@ public final class MySQLAuthenticationEngine implements AuthenticationEngine {
     
     private void setCharacterSet(final ChannelHandlerContext context, final MySQLHandshakeResponse41Packet handshakeResponsePacket) {
         MySQLCharacterSets characterSet = MySQLCharacterSets.findById(handshakeResponsePacket.getCharacterSet());
-        context.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).set(characterSet.getCharset());
-        context.channel().attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY).set(characterSet);
+        MySQLSessionCharsetContext.create(characterSet).apply(context.channel());
     }
     
     private void setConnectionAttributes(final ChannelHandlerContext context, final MySQLHandshakeResponse41Packet handshakeResponsePacket) {

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngineTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngineTest.java
@@ -42,6 +42,7 @@ import org.apache.shardingsphere.database.exception.mysql.vendor.MySQLVendorErro
 import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLAuthenticationMethod;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCapabilityFlag;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLConnectionPhase;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLConstants;
 import org.apache.shardingsphere.database.protocol.mysql.packet.generic.MySQLErrPacket;
@@ -59,12 +60,14 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLSessionCharsetContext;
 import org.apache.shardingsphere.proxy.frontend.mysql.ssl.MySQLSSLRequestHandler;
 import org.apache.shardingsphere.proxy.frontend.ssl.ProxySSLContext;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedConstruction.Context;
 import org.mockito.internal.configuration.plugins.Plugins;
@@ -152,6 +155,8 @@ class MySQLAuthenticationEngineTest {
         when(channel.remoteAddress()).thenReturn(new InetSocketAddress("localhost", 3307));
         when(channel.attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(channel.attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
+        when(channel.attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
+        when(channel.attr(MySQLSessionCharsetContext.ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(channel.attr(MySQLConstants.OPTION_MULTI_STATEMENTS_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(channel.attr(MySQLConstants.CONNECTION_ATTRIBUTES_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(channelHandlerContext.channel()).thenReturn(channel);
@@ -316,8 +321,12 @@ class MySQLAuthenticationEngineTest {
         ChannelHandlerContext context = mockChannelHandlerContext();
         ContextManager contextManager = mockContextManager(rule);
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        Attribute<MySQLSessionCharsetContext> charsetContextAttribute = context.channel().attr(MySQLSessionCharsetContext.ATTRIBUTE_KEY);
         authenticationEngine.authenticate(context, getPayload("root", null, authResponse));
         verify(context).writeAndFlush(any(MySQLOKPacket.class));
+        ArgumentCaptor<MySQLSessionCharsetContext> charsetContextCaptor = ArgumentCaptor.forClass(MySQLSessionCharsetContext.class);
+        verify(charsetContextAttribute).set(charsetContextCaptor.capture());
+        assertThat(charsetContextCaptor.getValue().getClientCharacterSet(), is(MySQLCharacterSets.BIG5_CHINESE_CI));
     }
     
     @Test
@@ -383,6 +392,8 @@ class MySQLAuthenticationEngineTest {
         when(channel.parent()).thenReturn(parentChannel);
         when(channel.attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(channel.attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
+        when(channel.attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
+        when(channel.attr(MySQLSessionCharsetContext.ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(channel.attr(MySQLConstants.SEQUENCE_ID_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(channel.attr(MySQLConstants.OPTION_MULTI_STATEMENTS_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(channel.attr(MySQLConstants.CONNECTION_ATTRIBUTES_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
@@ -396,6 +407,8 @@ class MySQLAuthenticationEngineTest {
         doReturn(getRemoteAddress()).when(result).remoteAddress();
         when(result.attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(result.attr(MySQLConstants.CHARACTER_SET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
+        when(result.attr(MySQLConstants.RESULT_CHARSET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
+        when(result.attr(MySQLSessionCharsetContext.ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(result.attr(MySQLConstants.SEQUENCE_ID_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(result.attr(MySQLConstants.OPTION_MULTI_STATEMENTS_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
         when(result.attr(MySQLConstants.CONNECTION_ATTRIBUTES_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));

--- a/test/it/parser/src/main/resources/case/dal/set.xml
+++ b/test/it/parser/src/main/resources/case/dal/set.xml
@@ -95,7 +95,7 @@
             <parameter name="extra_float_digits" />
         </parameter-assign>
     </set-parameter>
-    <set-parameter sql-case-id="set_names">
+    <set-parameter sql-case-id="set_names_mysql">
         <parameter-assign value="'utf8'">
             <parameter name="character_set_client" />
         </parameter-assign>
@@ -104,6 +104,53 @@
         </parameter-assign>
         <parameter-assign value="'utf8'">
             <parameter name="character_set_connection" />
+        </parameter-assign>
+        <parameter-assign value="'utf8_general_ci'">
+            <parameter name="collation_connection" />
+        </parameter-assign>
+    </set-parameter>
+    <set-parameter sql-case-id="set_names_doris">
+        <parameter-assign value="'utf8'">
+            <parameter name="character_set_client" />
+        </parameter-assign>
+        <parameter-assign value="'utf8'">
+            <parameter name="character_set_results" />
+        </parameter-assign>
+        <parameter-assign value="'utf8'">
+            <parameter name="character_set_connection" />
+        </parameter-assign>
+    </set-parameter>
+    <set-parameter sql-case-id="set_names_default_mysql">
+        <parameter-assign value="DEFAULT">
+            <parameter name="character_set_client" />
+        </parameter-assign>
+        <parameter-assign value="DEFAULT">
+            <parameter name="character_set_results" />
+        </parameter-assign>
+        <parameter-assign value="DEFAULT">
+            <parameter name="character_set_connection" />
+        </parameter-assign>
+    </set-parameter>
+    <set-parameter sql-case-id="set_character_set_mysql">
+        <parameter-assign value="latin1">
+            <parameter name="character_set_client" />
+        </parameter-assign>
+        <parameter-assign value="latin1">
+            <parameter name="character_set_results" />
+        </parameter-assign>
+        <parameter-assign value="@@collation_database">
+            <parameter name="collation_connection" />
+        </parameter-assign>
+    </set-parameter>
+    <set-parameter sql-case-id="set_character_set_default_mysql">
+        <parameter-assign value="DEFAULT">
+            <parameter name="character_set_client" />
+        </parameter-assign>
+        <parameter-assign value="DEFAULT">
+            <parameter name="character_set_results" />
+        </parameter-assign>
+        <parameter-assign value="@@collation_database">
+            <parameter name="collation_connection" />
         </parameter-assign>
     </set-parameter>
     <set-parameter sql-case-id="set_character_set_doris">

--- a/test/it/parser/src/main/resources/sql/supported/dal/set.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/set.xml
@@ -39,7 +39,11 @@
     <sql-case id="set_parameter_equal_boolean" value="SET extra_float_digits = true" db-types="PostgreSQL,openGauss" />
     <sql-case id="set_parameter_equal_list" value="SET extra_float_digits = 1,2,3" db-types="PostgreSQL,openGauss" />
     <sql-case id="set_parameter_equal_number_with_signal" value="SET extra_float_digits = -10.5" db-types="PostgreSQL,openGauss" />
-    <sql-case id="set_names" value="SET NAMES 'utf8' COLLATE 'utf8_general_ci'" db-types="MySQL,Doris" />
+    <sql-case id="set_names_mysql" value="SET NAMES 'utf8' COLLATE 'utf8_general_ci'" db-types="MySQL" />
+    <sql-case id="set_names_doris" value="SET NAMES 'utf8' COLLATE 'utf8_general_ci'" db-types="Doris" />
+    <sql-case id="set_names_default_mysql" value="SET NAMES DEFAULT" db-types="MySQL" />
+    <sql-case id="set_character_set_mysql" value="SET CHARACTER SET latin1" db-types="MySQL" />
+    <sql-case id="set_character_set_default_mysql" value="SET CHARACTER SET DEFAULT" db-types="MySQL" />
     <sql-case id="set_character_set_doris" value="SET CHARACTER SET utf8mb4" db-types="Doris" />
     <sql-case id="set_resource_group" value="SET RESOURCE GROUP rg" db-types="MySQL,Doris" />
     <sql-case id="set_charset_mysql" value="SET NAMES 'utf8'" db-types="MySQL" />


### PR DESCRIPTION
Track client, result, and connection character sets independently. Handle SET NAMES, SET CHARACTER SET, NULL and binary results, response encoding, and backend collation replay.
