### PR TITLE
Add SYSTEM_USER to PostgreSQL unparenthesized function names

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,6 +37,7 @@
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)
+1. SQL Binder: Bind PostgreSQL SYSTEM_USER as a niladic function instead of a column - [#39385](https://github.com/apache/shardingsphere/pull/39385)
 1. Metadata: Fix MySQL metadata loading fallback when JDBC catalog is null for named tables - [#38855](https://github.com/apache/shardingsphere/pull/38855)
 1. Metadata: Fix Oracle metadata version comparison skipping identity and collation columns on 18c and later - [#39104](https://github.com/apache/shardingsphere/pull/39104)
 1. Metadata: Fix wrong logic table metadata when config same actual table name in different storage unit - [#39157](https://github.com/apache/shardingsphere/pull/39157)

--- a/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/option/PostgreSQLFunctionOption.java
+++ b/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/option/PostgreSQLFunctionOption.java
@@ -30,7 +30,7 @@ public final class PostgreSQLFunctionOption implements DialectFunctionOption {
     
     private static final Collection<String> UNPARENTHESIZED_FUNCTION_NAMES = new CaseInsensitiveSet<>(Arrays.asList(
             "CURRENT_CATALOG", "CURRENT_DATE", "CURRENT_ROLE", "CURRENT_SCHEMA", "CURRENT_TIME",
-            "CURRENT_TIMESTAMP", "CURRENT_USER", "LOCALTIME", "LOCALTIMESTAMP", "SESSION_USER", "USER"));
+            "CURRENT_TIMESTAMP", "CURRENT_USER", "LOCALTIME", "LOCALTIMESTAMP", "SESSION_USER", "SYSTEM_USER", "USER"));
     
     @Override
     public Collection<String> getUnparenthesizedFunctionNames() {

--- a/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/option/PostgreSQLFunctionOptionTest.java
+++ b/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/option/PostgreSQLFunctionOptionTest.java
@@ -37,6 +37,7 @@ class PostgreSQLFunctionOptionTest {
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("LOCALTIME"));
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("LOCALTIMESTAMP"));
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("SESSION_USER"));
+        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("SYSTEM_USER"));
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("USER"));
     }
 }

--- a/infra/binder/core/pom.xml
+++ b/infra/binder/core/pom.xml
@@ -62,5 +62,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-database-connector-postgresql</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/ColumnSegmentBinderTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/ColumnSegmentBinderTest.java
@@ -377,4 +377,20 @@ class ColumnSegmentBinderTest {
         ColumnSegment actual = ColumnSegmentBinder.bind(columnSegment, SegmentType.PROJECTION, bindContext, LinkedHashMultimap.create(), LinkedHashMultimap.create());
         assertThat(actual, is(columnSegment));
     }
+    
+    @Test
+    void assertBindUnparenthesizedSystemUserWithTableContextForPostgreSQL() {
+        Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
+        ColumnSegment boundOrderIdColumn = new ColumnSegment(0, 0, new IdentifierValue("order_id"));
+        boundOrderIdColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
+                new IdentifierValue("t_order"), new IdentifierValue("order_id"), TableSourceType.PHYSICAL_TABLE));
+        tableBinderContexts.put(CaseInsensitiveString.of("t_order"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderIdColumn)), TableSourceType.PHYSICAL_TABLE));
+        SelectStatement selectStatement = mock(SelectStatement.class);
+        when(selectStatement.getDatabaseType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
+        SQLStatementBinderContext bindContext = new SQLStatementBinderContext(mock(ShardingSphereMetaData.class), "foo_db", new HintValueContext(), selectStatement);
+        ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("SYSTEM_USER"));
+        ColumnSegment actual = ColumnSegmentBinder.bind(columnSegment, SegmentType.PROJECTION, bindContext, tableBinderContexts, LinkedHashMultimap.create());
+        assertThat(actual, is(columnSegment));
+    }
 }

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/ColumnSegmentBinderTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/ColumnSegmentBinderTest.java
@@ -367,4 +367,14 @@ class ColumnSegmentBinderTest {
         assertTrue(actual.getOwner().isPresent());
         assertThat(actual.getOwner().get().getIdentifier().getValue(), is("EXCLUDED"));
     }
+    
+    @Test
+    void assertBindUnparenthesizedSystemUserForPostgreSQL() {
+        SelectStatement selectStatement = mock(SelectStatement.class);
+        when(selectStatement.getDatabaseType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
+        SQLStatementBinderContext bindContext = new SQLStatementBinderContext(mock(ShardingSphereMetaData.class), "foo_db", new HintValueContext(), selectStatement);
+        ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("SYSTEM_USER"));
+        ColumnSegment actual = ColumnSegmentBinder.bind(columnSegment, SegmentType.PROJECTION, bindContext, LinkedHashMultimap.create(), LinkedHashMultimap.create());
+        assertThat(actual, is(columnSegment));
+    }
 }

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -15300,5 +15300,10 @@
             <simple-table name="t_order" start-index="32" stop-index="38" />
         </from>
     </select>
+    <select sql-case-id="select_system_user_postgresql">
+        <projections start-index="7" stop-index="17">
+            <column-projection name="SYSTEM_USER" start-index="7" stop-index="17" />
+        </projections>
+    </select>
 
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -539,6 +539,7 @@
     <sql-case id="select_limit_parameter" value="SELECT * FROM t4 LIMIT ?;" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_limit_complex_expr" value="SELECT * FROM t4 LIMIT (CASE WHEN true THEN 10 ELSE 20 END);" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_func" value="select public.int4range(400, 500, '[]');" db-types="PostgreSQL" />
+    <sql-case id="select_system_user_postgresql" value="SELECT SYSTEM_USER" db-types="PostgreSQL" />
     <sql-case id="select_ltrim_function" value="SELECT LTRIM('  barbar')" db-types="MySQL,Doris" />
     <sql-case id="select_element_at" value="SELECT element_at(k1, 1) FROM t_order" db-types="Doris" />
     <sql-case id="select_array_subscript" value="SELECT k1[1] FROM t_order" db-types="Doris" />


### PR DESCRIPTION
Fixes #39384

## Problem

PostgreSQL 16 added the SQL standard `SYSTEM_USER` niladic function, but `PostgreSQLFunctionOption` does not list it. `ColumnSegmentBinder` therefore classifies a bare `SYSTEM_USER` as a column reference and throws `ColumnNotFoundException: Unknown column 'SYSTEM_USER' in 'field list'.`

`MySQLFunctionOption` and `SQLServerFunctionOption` already include it.

## Changes

- Add `SYSTEM_USER` to `PostgreSQLFunctionOption`, and the matching assertion to `PostgreSQLFunctionOptionTest`.
- Add a binder test covering `SYSTEM_USER` in a PostgreSQL projection.
- Add `shardingsphere-database-connector-postgresql` at test scope to `infra/binder/core`.
- Add a parser IT case for `SELECT SYSTEM_USER` under PostgreSQL.

## On the pom change

`infra/binder/core` previously had only `shardingsphere-database-connector-hive` on its test classpath. Any binder test naming another dialect silently resolved to `DefaultFunctionOption`, whose unparenthesized name set is empty, so a test for this bug could not fail correctly without the dialect present. This follows the same test-scope pattern already used in `infra/common` and `kernel/sql-federation/executor`.

## No grammar change needed

Unlike SQL92 (#39099 / #39102), the PostgreSQL grammar does not declare `SYSTEM_USER` as a keyword token, so it already lexes as an identifier and parses as a column projection. The added parser IT case passes without touching any `.g4` file, and documents that difference.

## Open question

`OpenGaussDatabaseMetaData#getFunctionOption` returns `new PostgreSQLFunctionOption()`, so openGauss inherits `SYSTEM_USER` from this change. openGauss forked from PostgreSQL 9.2, which predates the function. Should openGauss get its own `OpenGaussFunctionOption`, following the existing `OpenGaussSchemaOption` and `OpenGaussDataTypeOption`? I kept this PR minimal and did not do it; happy to add it if preferred.

## Verification

- `./mvnw test -pl infra/binder/core,database/connector/dialect/postgresql` — 385 tests, 0 failures
- `./mvnw test -pl test/it/parser -Dtest=InternalPostgreSQLParserIT` — 1152 tests, 0 failures
- `./mvnw checkstyle:check -Pcheck` and `./mvnw spotless:check -Pcheck` on both modules — clean
- Binder test confirmed failing on master before the fix
