### PR TITLE
[ISSUE-39370] Fix dataSourceType and dataSourceName swapped in exception message

### DIFF
--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/exception/actual/DuplicateReadwriteSplittingActualDataSourceException.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/exception/actual/DuplicateReadwriteSplittingActualDataSourceException.java
@@ -31,6 +31,6 @@ public final class DuplicateReadwriteSplittingActualDataSourceException extends 
     
     public DuplicateReadwriteSplittingActualDataSourceException(final ReadwriteSplittingDataSourceType dataSourceType,
                                                                 final String dataSourceName, final ReadwriteSplittingRuleExceptionIdentifier exceptionIdentifier) {
-        super(XOpenSQLState.DUPLICATE, 4, "Readwrite-splitting %s data source '%s' is duplicated in %s.", dataSourceName, dataSourceType, exceptionIdentifier);
+        super(XOpenSQLState.DUPLICATE, 4, "Readwrite-splitting %s data source '%s' is duplicated in %s.", dataSourceType, dataSourceName, exceptionIdentifier);
     }
 }


### PR DESCRIPTION
### Bug Description

`DuplicateReadwriteSplittingActualDataSourceException` passes `dataSourceName` and `dataSourceType` in the wrong order to the format string. The format expects `%s` (type) then `%s` (name), but the arguments pass name first, then type.

### Fix

Swapped the arguments to match the format string parameter order.

Closes #39370