### PR TITLE
[ISSUE-39362] Fix from-x and to-y rejecting 0 as a valid position

### DIFF
--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/MaskAlgorithmPropertiesChecker.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/MaskAlgorithmPropertiesChecker.java
@@ -73,6 +73,24 @@ public final class MaskAlgorithmPropertiesChecker {
         }
     }
     
+    /**
+     * check not negative integer.
+     *
+     * @param props properties to be checked
+     * @param propKey properties key to be checked
+     * @param algorithm mask algorithm
+     * @throws AlgorithmInitializationException algorithm initialization exception
+     */
+    public static void checkNotNegativeInteger(final Properties props, final String propKey, final MaskAlgorithm<?, ?> algorithm) {
+        checkRequired(props, propKey, algorithm);
+        try {
+            int integerValue = Integer.parseInt(props.getProperty(propKey));
+            ShardingSpherePreconditions.checkState(integerValue >= 0, () -> new AlgorithmInitializationException(algorithm, "%s must be a not negative integer.", propKey));
+        } catch (final NumberFormatException ex) {
+            throw new AlgorithmInitializationException(algorithm, "%s must be a valid integer number", propKey);
+        }
+    }
+    
     private static void checkRequired(final Properties props, final String requiredPropKey, final MaskAlgorithm<?, ?> algorithm) {
         ShardingSpherePreconditions.checkContainsKey(props, requiredPropKey, () -> new AlgorithmInitializationException(algorithm, "%s is required", requiredPropKey));
     }

--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithm.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithm.java
@@ -52,12 +52,12 @@ public final class KeepFromXToYMaskAlgorithm implements MaskAlgorithm<Object, St
     }
     
     private Integer createFromX(final Properties props) {
-        MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, FROM_X, this);
+        MaskAlgorithmPropertiesChecker.checkNotNegativeInteger(props, FROM_X, this);
         return Integer.parseInt(props.getProperty(FROM_X));
     }
     
     private Integer createToY(final Properties props) {
-        MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, TO_Y, this);
+        MaskAlgorithmPropertiesChecker.checkNotNegativeInteger(props, TO_Y, this);
         return Integer.parseInt(props.getProperty(TO_Y));
     }
     

--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithm.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithm.java
@@ -52,12 +52,12 @@ public final class MaskFromXToYMaskAlgorithm implements MaskAlgorithm<Object, St
     }
     
     private Integer createFromX(final Properties props) {
-        MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, FROM_X, this);
+        MaskAlgorithmPropertiesChecker.checkNotNegativeInteger(props, FROM_X, this);
         return Integer.parseInt(props.getProperty(FROM_X));
     }
     
     private Integer createToY(final Properties props) {
-        MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, TO_Y, this);
+        MaskAlgorithmPropertiesChecker.checkNotNegativeInteger(props, TO_Y, this);
         return Integer.parseInt(props.getProperty(TO_Y));
     }
     

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/MaskAlgorithmPropertiesCheckerTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/MaskAlgorithmPropertiesCheckerTest.java
@@ -90,4 +90,34 @@ class MaskAlgorithmPropertiesCheckerTest {
         Properties props = PropertiesBuilder.build(new Property("key", "123.0"));
         assertThrows(AlgorithmInitializationException.class, () -> MaskAlgorithmPropertiesChecker.checkPositiveInteger(props, "key", mock(MaskAlgorithm.class)));
     }
+    
+    @Test
+    void assertCheckNotNegativeIntegerSuccessWithPositive() {
+        Properties props = PropertiesBuilder.build(new Property("key", "123"));
+        assertDoesNotThrow(() -> MaskAlgorithmPropertiesChecker.checkNotNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
+    
+    @Test
+    void assertCheckNotNegativeIntegerSuccessWithZero() {
+        Properties props = PropertiesBuilder.build(new Property("key", "0"));
+        assertDoesNotThrow(() -> MaskAlgorithmPropertiesChecker.checkNotNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
+    
+    @Test
+    void assertCheckNotNegativeIntegerFailedWithoutKey() {
+        Properties props = new Properties();
+        assertThrows(AlgorithmInitializationException.class, () -> MaskAlgorithmPropertiesChecker.checkNotNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
+    
+    @Test
+    void assertCheckNotNegativeIntegerFailedWithNegative() {
+        Properties props = PropertiesBuilder.build(new Property("key", "-1"));
+        assertThrows(AlgorithmInitializationException.class, () -> MaskAlgorithmPropertiesChecker.checkNotNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
+    
+    @Test
+    void assertCheckNotNegativeIntegerFailedWithNotInteger() {
+        Properties props = PropertiesBuilder.build(new Property("key", "123.0"));
+        assertThrows(AlgorithmInitializationException.class, () -> MaskAlgorithmPropertiesChecker.checkNotNegativeInteger(props, "key", mock(MaskAlgorithm.class)));
+    }
 }

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithmTest.java
@@ -122,8 +122,8 @@ class KeepFromXToYMaskAlgorithmTest {
         @Override
         protected Collection<MaskAlgorithmExecuteCaseAssert> getCaseAsserts() {
             return Arrays.asList(
-                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_normal", "abc123456", "***123456"),
-                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_short", "ab", "***"),
+                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_normal", "abc123456", "abc******"),
+                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_short", "ab", "ab"),
                     new MaskAlgorithmExecuteCaseAssert("zero_from_x_empty", "", ""));
         }
     }

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithmTest.java
@@ -51,6 +51,12 @@ class KeepFromXToYMaskAlgorithmTest {
         MaskAlgorithmAssertions.assertMask(type, props, plainValue, maskedValue);
     }
     
+    @ParameterizedTest(name = "{0}: {1}")
+    @ArgumentsSource(AlgorithmMaskExecuteWithZeroFromXArgumentsProvider.class)
+    void assertMaskWithZeroFromX(final String type, @SuppressWarnings("unused") final String name, final Properties props, final Object plainValue, final Object maskedValue) {
+        MaskAlgorithmAssertions.assertMask(type, props, plainValue, maskedValue);
+    }
+    
     private static final class AlgorithmInitArgumentsProvider extends MaskAlgorithmInitArgumentsProvider {
         
         AlgorithmInitArgumentsProvider() {
@@ -104,6 +110,21 @@ class KeepFromXToYMaskAlgorithmTest {
                     new MaskAlgorithmExecuteCaseAssert("plain_value_length_equals_from_X_plus_one", "abc123", "*****3"),
                     new MaskAlgorithmExecuteCaseAssert("plain_value_length_less_than_to_Y_plus_one", "abc12", "*****"),
                     new MaskAlgorithmExecuteCaseAssert("plain_value_length_equals_to_Y_plus_one", "abc123", "*****3"));
+        }
+    }
+    
+    private static final class AlgorithmMaskExecuteWithZeroFromXArgumentsProvider extends MaskAlgorithmExecuteArgumentsProvider {
+        
+        AlgorithmMaskExecuteWithZeroFromXArgumentsProvider() {
+            super("KEEP_FROM_X_TO_Y", PropertiesBuilder.build(new Property("from-x", "0"), new Property("to-y", "2"), new Property("replace-char", "*")));
+        }
+        
+        @Override
+        protected Collection<MaskAlgorithmExecuteCaseAssert> getCaseAsserts() {
+            return Arrays.asList(
+                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_normal", "abc123456", "***123456"),
+                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_short", "ab", "***"),
+                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_empty", "", ""));
         }
     }
 }

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithmTest.java
@@ -51,6 +51,12 @@ class MaskFromXToYMaskAlgorithmTest {
         MaskAlgorithmAssertions.assertMask(type, props, plainValue, maskedValue);
     }
     
+    @ParameterizedTest(name = "{0}: {1}")
+    @ArgumentsSource(AlgorithmMaskExecuteWithZeroFromXArgumentsProvider.class)
+    void assertMaskWithZeroFromX(final String type, @SuppressWarnings("unused") final String name, final Properties props, final Object plainValue, final Object maskedValue) {
+        MaskAlgorithmAssertions.assertMask(type, props, plainValue, maskedValue);
+    }
+    
     private static final class AlgorithmInitArgumentsProvider extends MaskAlgorithmInitArgumentsProvider {
         
         AlgorithmInitArgumentsProvider() {
@@ -102,6 +108,21 @@ class MaskFromXToYMaskAlgorithmTest {
                     new MaskAlgorithmExecuteCaseAssert("length_equals_from_X_plus_one", "abc123", "abc12*"),
                     new MaskAlgorithmExecuteCaseAssert("length_less_than_to_Y_plus_one", "abc12", "abc12"),
                     new MaskAlgorithmExecuteCaseAssert("length_equals_to_Y_plus_one", "abc123", "abc12*"));
+        }
+    }
+    
+    private static final class AlgorithmMaskExecuteWithZeroFromXArgumentsProvider extends MaskAlgorithmExecuteArgumentsProvider {
+        
+        AlgorithmMaskExecuteWithZeroFromXArgumentsProvider() {
+            super("MASK_FROM_X_TO_Y", PropertiesBuilder.build(new Property("from-x", "0"), new Property("to-y", "2"), new Property("replace-char", "*")));
+        }
+        
+        @Override
+        protected Collection<MaskAlgorithmExecuteCaseAssert> getCaseAsserts() {
+            return Arrays.asList(
+                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_normal", "abc123456", "***123456"),
+                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_short", "ab", "***"),
+                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_empty", "", ""));
         }
     }
 }

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithmTest.java
@@ -121,7 +121,7 @@ class MaskFromXToYMaskAlgorithmTest {
         protected Collection<MaskAlgorithmExecuteCaseAssert> getCaseAsserts() {
             return Arrays.asList(
                     new MaskAlgorithmExecuteCaseAssert("zero_from_x_normal", "abc123456", "***123456"),
-                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_short", "ab", "***"),
+                    new MaskAlgorithmExecuteCaseAssert("zero_from_x_short", "ab", "**"),
                     new MaskAlgorithmExecuteCaseAssert("zero_from_x_empty", "", ""));
         }
     }


### PR DESCRIPTION
### Bug Description

`from-x` and `to-y` in `MASK_FROM_X_TO_Y` and `KEEP_FROM_X_TO_Y` are 0-based positions, but the validation uses `checkPositiveInteger` which rejects 0. This prevents masking from the very first character.

### Fix

1. Added `checkNotNegativeInteger` to `MaskAlgorithmPropertiesChecker` that allows 0.
2. Changed `MaskFromXToYMaskAlgorithm` and `KeepFromXToYMaskAlgorithm` to use `checkNotNegativeInteger` for `from-x` and `to-y`.

Closes #39362