### PR TITLE
Fix PostgreSQL function projection column label case folding

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,6 +37,7 @@
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)
+1. SQL Binder: Fix wrong column label case for PostgreSQL and openGauss function projections - [#39393](https://github.com/apache/shardingsphere/pull/39393)
 1. Metadata: Fix MySQL metadata loading fallback when JDBC catalog is null for named tables - [#38855](https://github.com/apache/shardingsphere/pull/38855)
 1. Metadata: Fix Oracle metadata version comparison skipping identity and collation columns on 18c and later - [#39104](https://github.com/apache/shardingsphere/pull/39104)
 1. Metadata: Fix wrong logic table metadata when config same actual table name in different storage unit - [#39157](https://github.com/apache/shardingsphere/pull/39157)

--- a/infra/binder/dialect/opengauss/src/test/java/org/apache/shardingsphere/infra/binder/opengauss/OpenGaussProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/opengauss/src/test/java/org/apache/shardingsphere/infra/binder/opengauss/OpenGaussProjectionIdentifierExtractorTest.java
@@ -65,7 +65,12 @@ class OpenGaussProjectionIdentifierExtractorTest {
     
     @Test
     void assertGetColumnNameFromFunctionExpression() {
-        assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "SUM(ID)", new FunctionSegment(0, 0, "SUM", "SUM(ID)"))), is("SUM"));
+        assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "SUM(ID)", new FunctionSegment(0, 0, "SUM", "SUM(ID)"))), is("sum"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromQuotedFunctionExpression() {
+        assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "\"MyFunc\"(ID)", new FunctionSegment(0, 0, "\"MyFunc\"", "\"MyFunc\"(ID)"))), is("MyFunc"));
     }
     
     @Test

--- a/infra/binder/dialect/opengauss/src/test/java/org/apache/shardingsphere/infra/binder/opengauss/OpenGaussProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/opengauss/src/test/java/org/apache/shardingsphere/infra/binder/opengauss/OpenGaussProjectionIdentifierExtractorTest.java
@@ -55,6 +55,11 @@ class OpenGaussProjectionIdentifierExtractorTest {
     }
     
     @Test
+    void assertGetIdentifierValueWithUnicodeQuotedAlias() {
+        assertThat(extractor.getIdentifierValue(new IdentifierValue("U&\"MyAlias\"", QuoteCharacter.NONE)), is("MyAlias"));
+    }
+    
+    @Test
     void assertGetColumnNameFromFunction() {
         assertThat(extractor.getColumnNameFromFunction("Function", "FunctionExpression"), is("function"));
     }

--- a/infra/binder/dialect/opengauss/src/test/java/org/apache/shardingsphere/infra/binder/opengauss/OpenGaussProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/opengauss/src/test/java/org/apache/shardingsphere/infra/binder/opengauss/OpenGaussProjectionIdentifierExtractorTest.java
@@ -35,6 +35,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.Windo
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,6 +72,35 @@ class OpenGaussProjectionIdentifierExtractorTest {
     @Test
     void assertGetColumnNameFromQuotedFunctionExpression() {
         assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "\"MyFunc\"(ID)", new FunctionSegment(0, 0, "\"MyFunc\"", "\"MyFunc\"(ID)"))), is("MyFunc"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromUnicodeQuotedFunctionExpression() {
+        assertThat(extractor.getColumnNameFromExpression(
+                new ExpressionProjectionSegment(0, 0, "U&\"MyFunc\"(ID)", new FunctionSegment(0, 0, "U&\"MyFunc\"", "U&\"MyFunc\"(ID)"))), is("MyFunc"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromUnicodeQuotedFunctionExpressionWithUescapeClause() {
+        assertThat(extractor.getColumnNameFromExpression(
+                new ExpressionProjectionSegment(0, 0, "u&\"d!0061t\" UESCAPE '!'(ID)", new FunctionSegment(0, 0, "u&\"d!0061t\"UESCAPE'!'", "u&\"d!0061t\" UESCAPE '!'(ID)"))), is("dat"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromFunctionExpressionWithNonAsciiName() {
+        assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "ÄBC(ID)", new FunctionSegment(0, 0, "ÄBC", "ÄBC(ID)"))), is("Äbc"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromFunctionExpressionWithTurkishDefaultLocale() {
+        Locale originalLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("tr", "TR"));
+        try {
+            assertThat(extractor.getIdentifierValue(new IdentifierValue("INITCAP", QuoteCharacter.NONE)), is("initcap"));
+            assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "INITCAP(ID)", new FunctionSegment(0, 0, "INITCAP", "INITCAP(ID)"))), is("initcap"));
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
     
     @Test

--- a/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLIdentifierUtils.java
+++ b/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLIdentifierUtils.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.binder.postgresql;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.OptionalInt;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,8 +41,9 @@ public final class PostgreSQLIdentifierUtils {
     /**
      * Fold unquoted identifier to lower case as PostgreSQL does.
      *
-     * <p>PostgreSQL folds ASCII {@code A}-{@code Z} only and leaves other characters unchanged,
-     * so JVM default locale rules must not be applied here.</p>
+     * <p>With a multibyte server encoding, which UTF-8 makes the common case, PostgreSQL folds ASCII {@code A}-{@code Z}
+     * only and leaves other characters unchanged. JVM default locale rules must not be applied here, since they fold
+     * {@code I} to a dotless {@code i} under a Turkish locale and fold non-ASCII letters PostgreSQL leaves alone.</p>
      *
      * @param identifier identifier to be folded
      * @return folded identifier
@@ -64,7 +66,7 @@ public final class PostgreSQLIdentifierUtils {
      */
     public static boolean isUnicodeQuoted(final String identifier) {
         return identifier.length() > 3 && ('U' == identifier.charAt(0) || 'u' == identifier.charAt(0)) && '&' == identifier.charAt(1) && '"' == identifier.charAt(2)
-                && identifier.lastIndexOf('"') > 2;
+                && identifier.indexOf('"', 3) >= 0;
     }
     
     /**
@@ -74,9 +76,8 @@ public final class PostgreSQLIdentifierUtils {
      * @return unquoted identifier
      */
     public static String unquoteUnicode(final String identifier) {
-        int endQuoteIndex = identifier.lastIndexOf('"');
-        String content = identifier.substring(3, endQuoteIndex).replace("\"\"", "\"");
-        return decodeUnicodeEscapes(content, getUnicodeEscapeCharacter(identifier.substring(endQuoteIndex + 1)));
+        int endQuoteIndex = identifier.indexOf('"', 3);
+        return decodeUnicodeEscapes(identifier.substring(3, endQuoteIndex), getUnicodeEscapeCharacter(identifier.substring(endQuoteIndex + 1)));
     }
     
     private static char getUnicodeEscapeCharacter(final String uescapeClause) {
@@ -110,25 +111,22 @@ public final class PostgreSQLIdentifierUtils {
         boolean isLongEscape = escapeIndex + 1 < content.length() && '+' == content.charAt(escapeIndex + 1);
         int digitsBeginIndex = isLongEscape ? escapeIndex + 2 : escapeIndex + 1;
         int digitsEndIndex = digitsBeginIndex + (isLongEscape ? LONG_UNICODE_ESCAPE_LENGTH : SHORT_UNICODE_ESCAPE_LENGTH);
-        if (digitsEndIndex > content.length()) {
+        OptionalInt codePoint = digitsEndIndex > content.length() ? OptionalInt.empty() : parseCodePoint(content.substring(digitsBeginIndex, digitsEndIndex));
+        if (!codePoint.isPresent()) {
             result.append(content.charAt(escapeIndex));
             return escapeIndex + 1;
         }
-        String digits = content.substring(digitsBeginIndex, digitsEndIndex);
-        if (!isHexDigits(digits)) {
-            result.append(content.charAt(escapeIndex));
-            return escapeIndex + 1;
-        }
-        result.appendCodePoint(Integer.parseInt(digits, 16));
+        result.appendCodePoint(codePoint.getAsInt());
         return digitsEndIndex;
     }
     
-    private static boolean isHexDigits(final String digits) {
+    private static OptionalInt parseCodePoint(final String digits) {
         for (int i = 0; i < digits.length(); i++) {
             if (-1 == Character.digit(digits.charAt(i), 16)) {
-                return false;
+                return OptionalInt.empty();
             }
         }
-        return true;
+        int result = Integer.parseInt(digits, 16);
+        return Character.isValidCodePoint(result) ? OptionalInt.of(result) : OptionalInt.empty();
     }
 }

--- a/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLIdentifierUtils.java
+++ b/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLIdentifierUtils.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.postgresql;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * PostgreSQL identifier utility class.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PostgreSQLIdentifierUtils {
+    
+    private static final Pattern UESCAPE_CLAUSE_PATTERN = Pattern.compile("\\s*UESCAPE\\s*'(.)'\\s*", Pattern.CASE_INSENSITIVE);
+    
+    private static final char DEFAULT_UNICODE_ESCAPE_CHARACTER = '\\';
+    
+    private static final int SHORT_UNICODE_ESCAPE_LENGTH = 4;
+    
+    private static final int LONG_UNICODE_ESCAPE_LENGTH = 6;
+    
+    /**
+     * Fold unquoted identifier to lower case as PostgreSQL does.
+     *
+     * <p>PostgreSQL folds ASCII {@code A}-{@code Z} only and leaves other characters unchanged,
+     * so JVM default locale rules must not be applied here.</p>
+     *
+     * @param identifier identifier to be folded
+     * @return folded identifier
+     */
+    public static String fold(final String identifier) {
+        char[] result = identifier.toCharArray();
+        for (int i = 0; i < result.length; i++) {
+            if (result[i] >= 'A' && result[i] <= 'Z') {
+                result[i] += 'a' - 'A';
+            }
+        }
+        return new String(result);
+    }
+    
+    /**
+     * Judge whether identifier is a Unicode quoted identifier.
+     *
+     * @param identifier identifier to be judged
+     * @return is Unicode quoted identifier or not
+     */
+    public static boolean isUnicodeQuoted(final String identifier) {
+        return identifier.length() > 3 && ('U' == identifier.charAt(0) || 'u' == identifier.charAt(0)) && '&' == identifier.charAt(1) && '"' == identifier.charAt(2)
+                && identifier.lastIndexOf('"') > 2;
+    }
+    
+    /**
+     * Unquote Unicode quoted identifier and decode its escape sequences.
+     *
+     * @param identifier Unicode quoted identifier to be unquoted
+     * @return unquoted identifier
+     */
+    public static String unquoteUnicode(final String identifier) {
+        int endQuoteIndex = identifier.lastIndexOf('"');
+        String content = identifier.substring(3, endQuoteIndex).replace("\"\"", "\"");
+        return decodeUnicodeEscapes(content, getUnicodeEscapeCharacter(identifier.substring(endQuoteIndex + 1)));
+    }
+    
+    private static char getUnicodeEscapeCharacter(final String uescapeClause) {
+        Matcher matcher = UESCAPE_CLAUSE_PATTERN.matcher(uescapeClause);
+        return matcher.matches() ? matcher.group(1).charAt(0) : DEFAULT_UNICODE_ESCAPE_CHARACTER;
+    }
+    
+    private static String decodeUnicodeEscapes(final String content, final char escapeCharacter) {
+        StringBuilder result = new StringBuilder(content.length());
+        int index = 0;
+        while (index < content.length()) {
+            char currentChar = content.charAt(index);
+            if (escapeCharacter != currentChar) {
+                result.append(currentChar);
+                index++;
+            } else if (isEscapedEscapeCharacter(content, index, escapeCharacter)) {
+                result.append(escapeCharacter);
+                index += 2;
+            } else {
+                index = appendCodePoint(result, content, index);
+            }
+        }
+        return result.toString();
+    }
+    
+    private static boolean isEscapedEscapeCharacter(final String content, final int escapeIndex, final char escapeCharacter) {
+        return escapeIndex + 1 < content.length() && escapeCharacter == content.charAt(escapeIndex + 1);
+    }
+    
+    private static int appendCodePoint(final StringBuilder result, final String content, final int escapeIndex) {
+        boolean isLongEscape = escapeIndex + 1 < content.length() && '+' == content.charAt(escapeIndex + 1);
+        int digitsBeginIndex = isLongEscape ? escapeIndex + 2 : escapeIndex + 1;
+        int digitsEndIndex = digitsBeginIndex + (isLongEscape ? LONG_UNICODE_ESCAPE_LENGTH : SHORT_UNICODE_ESCAPE_LENGTH);
+        if (digitsEndIndex > content.length()) {
+            result.append(content.charAt(escapeIndex));
+            return escapeIndex + 1;
+        }
+        String digits = content.substring(digitsBeginIndex, digitsEndIndex);
+        if (!isHexDigits(digits)) {
+            result.append(content.charAt(escapeIndex));
+            return escapeIndex + 1;
+        }
+        result.appendCodePoint(Integer.parseInt(digits, 16));
+        return digitsEndIndex;
+    }
+    
+    private static boolean isHexDigits(final String digits) {
+        for (int i = 0; i < digits.length(); i++) {
+            if (-1 == Character.digit(digits.charAt(i), 16)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLIdentifierUtils.java
+++ b/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLIdentifierUtils.java
@@ -32,6 +32,10 @@ public final class PostgreSQLIdentifierUtils {
     
     private static final Pattern UESCAPE_CLAUSE_PATTERN = Pattern.compile("\\s*UESCAPE\\s*'(.)'\\s*", Pattern.CASE_INSENSITIVE);
     
+    private static final String UNICODE_QUOTE_PREFIX = "U&\"";
+    
+    private static final String LOWER_CASE_UNICODE_QUOTE_PREFIX = "u&\"";
+    
     private static final char DEFAULT_UNICODE_ESCAPE_CHARACTER = '\\';
     
     private static final int SHORT_UNICODE_ESCAPE_LENGTH = 4;
@@ -65,8 +69,7 @@ public final class PostgreSQLIdentifierUtils {
      * @return is Unicode quoted identifier or not
      */
     public static boolean isUnicodeQuoted(final String identifier) {
-        return identifier.length() > 3 && ('U' == identifier.charAt(0) || 'u' == identifier.charAt(0)) && '&' == identifier.charAt(1) && '"' == identifier.charAt(2)
-                && identifier.indexOf('"', 3) >= 0;
+        return (identifier.startsWith(UNICODE_QUOTE_PREFIX) || identifier.startsWith(LOWER_CASE_UNICODE_QUOTE_PREFIX)) && identifier.indexOf('"', UNICODE_QUOTE_PREFIX.length()) >= 0;
     }
     
     /**
@@ -76,8 +79,8 @@ public final class PostgreSQLIdentifierUtils {
      * @return unquoted identifier
      */
     public static String unquoteUnicode(final String identifier) {
-        int endQuoteIndex = identifier.indexOf('"', 3);
-        return decodeUnicodeEscapes(identifier.substring(3, endQuoteIndex), getUnicodeEscapeCharacter(identifier.substring(endQuoteIndex + 1)));
+        int endQuoteIndex = identifier.indexOf('"', UNICODE_QUOTE_PREFIX.length());
+        return decodeUnicodeEscapes(identifier.substring(UNICODE_QUOTE_PREFIX.length(), endQuoteIndex), getUnicodeEscapeCharacter(identifier.substring(endQuoteIndex + 1)));
     }
     
     private static char getUnicodeEscapeCharacter(final String uescapeClause) {

--- a/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractor.java
+++ b/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractor.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.binder.postgresql;
 
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.DialectProjectionIdentifierExtractor;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.FunctionSegment;
@@ -47,13 +48,20 @@ public final class PostgreSQLProjectionIdentifierExtractor implements DialectPro
         }
         ExpressionSegment innerExpressionSegment = ((ExpressionProjectionSegment) expressionSegment).getExpr();
         if (innerExpressionSegment instanceof FunctionSegment) {
-            return ((FunctionSegment) innerExpressionSegment).getFunctionName();
+            return getColumnNameFromFunctionSegment((FunctionSegment) innerExpressionSegment);
         }
         if (innerExpressionSegment instanceof AggregationProjectionSegment) {
             AggregationProjectionSegment aggregationProjectionSegment = (AggregationProjectionSegment) innerExpressionSegment;
             return getColumnNameFromFunction(aggregationProjectionSegment.getType().name(), aggregationProjectionSegment.getExpression());
         }
         return "?column?";
+    }
+    
+    private String getColumnNameFromFunctionSegment(final FunctionSegment functionSegment) {
+        IdentifierValue functionName = new IdentifierValue(functionSegment.getFunctionName());
+        return QuoteCharacter.NONE == functionName.getQuoteCharacter()
+                ? getColumnNameFromFunction(functionName.getValue(), functionSegment.getText())
+                : functionName.getValue();
     }
     
     @Override

--- a/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractor.java
+++ b/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractor.java
@@ -33,12 +33,12 @@ public final class PostgreSQLProjectionIdentifierExtractor implements DialectPro
     
     @Override
     public String getIdentifierValue(final IdentifierValue identifierValue) {
-        return identifierValue.getValue().toLowerCase();
+        return PostgreSQLIdentifierUtils.fold(identifierValue.getValue());
     }
     
     @Override
     public String getColumnNameFromFunction(final String functionName, final String functionExpression) {
-        return functionName.toLowerCase();
+        return PostgreSQLIdentifierUtils.fold(functionName);
     }
     
     @Override
@@ -58,6 +58,9 @@ public final class PostgreSQLProjectionIdentifierExtractor implements DialectPro
     }
     
     private String getColumnNameFromFunctionSegment(final FunctionSegment functionSegment) {
+        if (PostgreSQLIdentifierUtils.isUnicodeQuoted(functionSegment.getFunctionName())) {
+            return PostgreSQLIdentifierUtils.unquoteUnicode(functionSegment.getFunctionName());
+        }
         IdentifierValue functionName = new IdentifierValue(functionSegment.getFunctionName());
         return QuoteCharacter.NONE == functionName.getQuoteCharacter()
                 ? getColumnNameFromFunction(functionName.getValue(), functionSegment.getText())

--- a/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractor.java
+++ b/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractor.java
@@ -33,7 +33,9 @@ public final class PostgreSQLProjectionIdentifierExtractor implements DialectPro
     
     @Override
     public String getIdentifierValue(final IdentifierValue identifierValue) {
-        return PostgreSQLIdentifierUtils.fold(identifierValue.getValue());
+        return PostgreSQLIdentifierUtils.isUnicodeQuoted(identifierValue.getValue())
+                ? PostgreSQLIdentifierUtils.unquoteUnicode(identifierValue.getValue())
+                : PostgreSQLIdentifierUtils.fold(identifierValue.getValue());
     }
     
     @Override

--- a/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLIdentifierUtilsTest.java
+++ b/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLIdentifierUtilsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.postgresql;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostgreSQLIdentifierUtilsTest {
+    
+    @Test
+    void assertFoldAsciiLetters() {
+        assertThat(PostgreSQLIdentifierUtils.fold("AbS_1"), is("abs_1"));
+    }
+    
+    @Test
+    void assertFoldLeavesNonAsciiLettersUnchanged() {
+        assertThat(PostgreSQLIdentifierUtils.fold("ÄBC"), is("Äbc"));
+    }
+    
+    @Test
+    void assertFoldWithTurkishDefaultLocale() {
+        Locale originalLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("tr", "TR"));
+        try {
+            assertThat(PostgreSQLIdentifierUtils.fold("INITCAP"), is("initcap"));
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+    }
+    
+    @Test
+    void assertIsUnicodeQuoted() {
+        assertTrue(PostgreSQLIdentifierUtils.isUnicodeQuoted("U&\"MyFunc\""));
+        assertTrue(PostgreSQLIdentifierUtils.isUnicodeQuoted("u&\"MyFunc\""));
+        assertTrue(PostgreSQLIdentifierUtils.isUnicodeQuoted("U&\"\""));
+    }
+    
+    @Test
+    void assertIsNotUnicodeQuoted() {
+        assertFalse(PostgreSQLIdentifierUtils.isUnicodeQuoted("ABS"));
+        assertFalse(PostgreSQLIdentifierUtils.isUnicodeQuoted("\"MyFunc\""));
+        assertFalse(PostgreSQLIdentifierUtils.isUnicodeQuoted("U&\""));
+        assertFalse(PostgreSQLIdentifierUtils.isUnicodeQuoted("U?\"abc\""));
+        assertFalse(PostgreSQLIdentifierUtils.isUnicodeQuoted("U&'abc'"));
+        assertFalse(PostgreSQLIdentifierUtils.isUnicodeQuoted("U&\"abc"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithoutEscape() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"MyFunc\""), is("MyFunc"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithShortAndLongEscape() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"d\\0061t\\+000041\""), is("datA"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithSurrogatePairEscape() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"\\D83D\\DE00\""), is("😀"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithEscapedEscapeCharacter() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"a\\\\b\""), is("a\\b"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithUescapeClause() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("u&\"d!0061t\"UESCAPE'!'"), is("dat"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithSpacedAndLowerCaseUescapeClause() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"d!0061t\" uescape '!' "), is("dat"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithMalformedUescapeClauseFallsBackToDefaultEscape() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"d\\0061t\"UESCAPE'!!'"), is("dat"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithNonHexEscapeDigits() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"a\\zz12b\""), is("a\\zz12b"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithTruncatedEscape() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"ab\\00\""), is("ab\\00"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithTrailingEscapeCharacter() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"ab\\\""), is("ab\\"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithOutOfRangeCodePoint() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"a\\+FFFFFFb\""), is("a\\+FFFFFFb"));
+    }
+    
+    @Test
+    void assertUnquoteUnicodeWithEmptyContent() {
+        assertThat(PostgreSQLIdentifierUtils.unquoteUnicode("U&\"\""), is(""));
+    }
+}

--- a/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
@@ -71,7 +71,12 @@ class PostgreSQLProjectionIdentifierExtractorTest {
     
     @Test
     void assertGetColumnNameFromFunctionExpression() {
-        assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "SUM(ID)", new FunctionSegment(0, 0, "SUM", "SUM(ID)"))), is("SUM"));
+        assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "SUM(ID)", new FunctionSegment(0, 0, "SUM", "SUM(ID)"))), is("sum"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromQuotedFunctionExpression() {
+        assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "\"MyFunc\"(ID)", new FunctionSegment(0, 0, "\"MyFunc\"", "\"MyFunc\"(ID)"))), is("MyFunc"));
     }
     
     @Test

--- a/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.Windo
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -77,6 +78,41 @@ class PostgreSQLProjectionIdentifierExtractorTest {
     @Test
     void assertGetColumnNameFromQuotedFunctionExpression() {
         assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "\"MyFunc\"(ID)", new FunctionSegment(0, 0, "\"MyFunc\"", "\"MyFunc\"(ID)"))), is("MyFunc"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromUnicodeQuotedFunctionExpression() {
+        assertThat(extractor.getColumnNameFromExpression(
+                new ExpressionProjectionSegment(0, 0, "U&\"MyFunc\"(ID)", new FunctionSegment(0, 0, "U&\"MyFunc\"", "U&\"MyFunc\"(ID)"))), is("MyFunc"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromUnicodeQuotedFunctionExpressionWithDefaultEscape() {
+        assertThat(extractor.getColumnNameFromExpression(
+                new ExpressionProjectionSegment(0, 0, "U&\"d\\0061t\\+000041\"(ID)", new FunctionSegment(0, 0, "U&\"d\\0061t\\+000041\"", "U&\"d\\0061t\\+000041\"(ID)"))), is("datA"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromUnicodeQuotedFunctionExpressionWithUescapeClause() {
+        assertThat(extractor.getColumnNameFromExpression(
+                new ExpressionProjectionSegment(0, 0, "u&\"d!0061t\" UESCAPE '!'(ID)", new FunctionSegment(0, 0, "u&\"d!0061t\"UESCAPE'!'", "u&\"d!0061t\" UESCAPE '!'(ID)"))), is("dat"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromFunctionExpressionWithNonAsciiName() {
+        assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "ÄBC(ID)", new FunctionSegment(0, 0, "ÄBC", "ÄBC(ID)"))), is("Äbc"));
+    }
+    
+    @Test
+    void assertGetColumnNameFromFunctionExpressionWithTurkishDefaultLocale() {
+        Locale originalLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("tr", "TR"));
+        try {
+            assertThat(extractor.getIdentifierValue(new IdentifierValue("INITCAP", QuoteCharacter.NONE)), is("initcap"));
+            assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "INITCAP(ID)", new FunctionSegment(0, 0, "INITCAP", "INITCAP(ID)"))), is("initcap"));
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
     
     @Test

--- a/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
@@ -56,6 +56,11 @@ class PostgreSQLProjectionIdentifierExtractorTest {
     }
     
     @Test
+    void assertGetIdentifierValueWithUnicodeQuotedAlias() {
+        assertThat(extractor.getIdentifierValue(new IdentifierValue("U&\"MyAlias\"", QuoteCharacter.NONE)), is("MyAlias"));
+    }
+    
+    @Test
     void assertGetColumnNameFromFunction() {
         assertThat(extractor.getColumnNameFromFunction("Function", "FunctionExpression"), is("function"));
     }


### PR DESCRIPTION
Fixes #39392.

Changes proposed in this pull request:

- Fold unquoted PostgreSQL function names to lower case when deriving the column label of an unaliased function projection, matching PostgreSQL identifier folding.
- Strip quote characters from quoted function names and preserve their case, matching the guard `ProjectionIdentifierExtractEngine#getIdentifierValue` already applies to identifiers.
- Correct the PostgreSQL and openGauss test expectations that recorded the previous behavior, and cover the quoted case.

The function branch of `PostgreSQLProjectionIdentifierExtractor#getColumnNameFromExpression` returned the raw parsed name, while the aggregation branch below it routed through `getColumnNameFromFunction`, which lower cases. That is why `SUM` was already correct and `ABS` was not: `AggregationProjection#getColumnLabel` passes `AggregationType#name()`, which is always upper case, so that path had to fold to work at all, whereas the function branch receives the source text as typed.

The label is user visible. `QueryHeaderBuilderEngine#build` prefers `projection.getColumnLabel()` over the backend result set label.

### Verification

Built this branch, packaged ShardingSphere-Proxy, and ran it against PostgreSQL 16 with `t_order` sharded over `t_order_0` and `t_order_1`.

| Query | PostgreSQL | Proxy 5.5.3 | This branch |
|---|---|---|---|
| `SELECT ABS(user_id) FROM t_order` | `abs` | `ABS` | `abs` |
| `SELECT AbS(user_id) FROM t_order` | `abs` | `AbS` | `abs` |
| `SELECT MYABS(user_id) FROM t_order` | `myabs` | `MYABS` | `myabs` |
| `SELECT "MyFunc"(user_id) FROM t_order` | `MyFunc` | `"MyFunc"` | `MyFunc` |
| `SELECT abs(user_id) FROM t_order` | `abs` | `abs` | `abs` |
| `SELECT SUM(user_id) FROM t_order` | `sum` | `sum` | `sum` |

Checks that the change must not disturb, all unchanged on this branch:

| Query | Label |
|---|---|
| `SELECT user_id AS "MyAlias" FROM t_order` | `MyAlias` |
| `SELECT user_id AS my_alias FROM t_order` | `my_alias` |
| `SELECT user_id FROM t_order` | `user_id` |
| `SELECT PG_CATALOG.ABS(user_id) FROM t_order` | `abs` |
| `SELECT MAX(user_id), COUNT(*) FROM t_order` | `max`, `count` |
| `SELECT ABS(user_id) AS keep_me FROM t_order` | `keep_me` |

`infra/binder/dialect/postgresql` and `infra/binder/dialect/opengauss` pass with checkstyle and spotless clean.

### Notes

openGauss is included because `OpenGaussProjectionIdentifierExtractor` delegates every method to the PostgreSQL extractor and openGauss folds identifiers the same way. Its test carried the same expectation and is corrected alongside.

The `getColumnNameFromSubquery` TODO in the same class is a separate gap and is left untouched.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
