### PR TITLE
Add logical default schema lookup to ShardingSphereDatabase

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
@@ -306,6 +306,21 @@ public final class ShardingSphereDatabase {
      * @return default schema name
      */
     public String getDefaultSchemaName() {
-        return new DatabaseTypeRegistry(protocolType).getDefaultSchemaName(name);
+        String defaultSchemaIdentifier = getDefaultSchemaIdentifier();
+        return findSchema(new IdentifierValue(defaultSchemaIdentifier)).map(ShardingSphereSchema::getName).orElse(defaultSchemaIdentifier);
+    }
+    
+    private String getDefaultSchemaIdentifier() {
+        return new DatabaseTypeRegistry(protocolType).getDialectDatabaseMetaData().getSchemaOption().getDefaultSchema()
+                .orElseGet(() -> identifierContext.normalizeProtocol(IdentifierScope.SCHEMA, new IdentifierValue(name)));
+    }
+    
+    /**
+     * Find default schema.
+     *
+     * @return default schema
+     */
+    public Optional<ShardingSphereSchema> findDefaultSchema() {
+        return findSchema(new IdentifierValue(getDefaultSchemaIdentifier()));
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.infra.metadata.database;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.MetadataIdentifierCaseSensitivity;
 import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
@@ -49,7 +48,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.internal.configuration.plugins.Plugins;
 
@@ -83,7 +81,6 @@ import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -322,17 +319,45 @@ class ShardingSphereDatabaseTest {
     }
     
     @Test
-    void assertGetDefaultSchemaName() {
+    void assertGetDefaultSchemaNameWithFixedDefaultSchema() {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                "foo_db", postgreSQLDatabaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
                 new ConfigurationProperties(new Properties()));
-        try (
-                MockedConstruction<DatabaseTypeRegistry> mockedConstruction = mockConstruction(DatabaseTypeRegistry.class,
-                        (mock, context) -> when(mock.getDefaultSchemaName("foo_db")).thenReturn("foo_schema"))) {
-            assertThat(database.getDefaultSchemaName(), is("foo_schema"));
-            assertThat(mockedConstruction.constructed().size(), is(1));
-            verify(mockedConstruction.constructed().get(0)).getDefaultSchemaName("foo_db");
-        }
+        assertThat(database.getDefaultSchemaName(), is("public"));
+    }
+    
+    @Test
+    void assertGetDefaultSchemaNameWithNormalizedDatabaseName() {
+        ShardingSphereDatabase database = new ShardingSphereDatabase(
+                "foo_db", oracleDatabaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
+        assertThat(database.getDefaultSchemaName(), is("FOO_DB"));
+    }
+    
+    @Test
+    void assertGetDefaultSchemaNameWithMatchedSchema() {
+        ShardingSphereSchema schema = new ShardingSphereSchema("FOO_DB", mySQLDatabaseType);
+        ShardingSphereDatabase database = new ShardingSphereDatabase(
+                "foo_db", mySQLDatabaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
+        assertThat(database.getDefaultSchemaName(), is("FOO_DB"));
+    }
+    
+    @Test
+    void assertFindDefaultSchema() {
+        ShardingSphereSchema schema = new ShardingSphereSchema("FOO_DB", oracleDatabaseType);
+        ShardingSphereDatabase database = new ShardingSphereDatabase(
+                "foo_db", oracleDatabaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
+        assertThat(database.findDefaultSchema(), is(Optional.of(schema)));
+    }
+    
+    @Test
+    void assertFindDefaultSchemaWhenMissing() {
+        ShardingSphereDatabase database = new ShardingSphereDatabase(
+                "foo_db", oracleDatabaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
+        assertThat(database.findDefaultSchema(), is(Optional.empty()));
     }
     
     private static Stream<Arguments> containsSchemaArguments() {


### PR DESCRIPTION

Changes proposed in this pull request:
  - Add logical default schema lookup to ShardingSphereDatabase

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
