### PR TITLE
Normalize default schema names without deprecated identifier formatting

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistry.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistry.java
@@ -20,6 +20,9 @@ package org.apache.shardingsphere.database.connector.core.type;
 import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyFactory;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierNormalizeEngine;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
 
@@ -30,6 +33,15 @@ import java.util.stream.Collectors;
  * Database type registry.
  */
 public final class DatabaseTypeRegistry {
+    
+    private static final IdentifierCasePolicy UPPER_CASE_SCHEMA_IDENTIFIER_POLICY =
+            IdentifierCasePolicyFactory.newUpperCasePolicySet().getPolicy(IdentifierScope.SCHEMA);
+    
+    private static final IdentifierCasePolicy LOWER_CASE_SCHEMA_IDENTIFIER_POLICY =
+            IdentifierCasePolicyFactory.newLowerCasePolicySet().getPolicy(IdentifierScope.SCHEMA);
+    
+    private static final IdentifierCasePolicy KEEP_ORIGIN_SCHEMA_IDENTIFIER_POLICY =
+            IdentifierCasePolicyFactory.newCasePreservingInsensitivePolicySet().getPolicy(IdentifierScope.SCHEMA);
     
     private final DatabaseType databaseType;
     
@@ -58,7 +70,20 @@ public final class DatabaseTypeRegistry {
      * @return default schema name
      */
     public String getDefaultSchemaName(final String databaseName) {
-        return dialectDatabaseMetaData.getSchemaOption().getDefaultSchema().orElse(null == databaseName ? null : formatIdentifierPattern(databaseName));
+        return dialectDatabaseMetaData.getSchemaOption().getDefaultSchema()
+                .orElse(null == databaseName ? null : IdentifierNormalizeEngine.normalize(getSchemaIdentifierCasePolicy(), databaseName));
+    }
+    
+    private IdentifierCasePolicy getSchemaIdentifierCasePolicy() {
+        switch (dialectDatabaseMetaData.getIdentifierPatternType()) {
+            case UPPER_CASE:
+                return UPPER_CASE_SCHEMA_IDENTIFIER_POLICY;
+            case LOWER_CASE:
+                return LOWER_CASE_SCHEMA_IDENTIFIER_POLICY;
+            case KEEP_ORIGIN:
+            default:
+                return KEEP_ORIGIN_SCHEMA_IDENTIFIER_POLICY;
+        }
     }
     
     /**

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistryTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistryTest.java
@@ -62,8 +62,8 @@ class DatabaseTypeRegistryTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("getDefaultSchemaNameWithIdentifierPatternArguments")
     void assertGetDefaultSchemaNameWithIdentifierPattern(final String name, final IdentifierPatternType identifierPatternType,
-                                                         final String databaseName, final String expectedSchemaName) throws ReflectiveOperationException {
-        DatabaseTypeRegistry databaseTypeRegistry = createDatabaseTypeRegistry(identifierPatternType, null);
+                                                         final String defaultSchema, final String databaseName, final String expectedSchemaName) throws ReflectiveOperationException {
+        DatabaseTypeRegistry databaseTypeRegistry = createDatabaseTypeRegistry(identifierPatternType, defaultSchema);
         assertThat(databaseTypeRegistry.getDefaultSchemaName(databaseName), is(expectedSchemaName));
     }
     
@@ -83,10 +83,11 @@ class DatabaseTypeRegistryTest {
     
     private static Stream<Arguments> getDefaultSchemaNameWithIdentifierPatternArguments() {
         return Stream.of(
-                Arguments.of("upper case identifier pattern formats default schema", IdentifierPatternType.UPPER_CASE, "foo_db", "FOO_DB"),
-                Arguments.of("lower case identifier pattern formats default schema", IdentifierPatternType.LOWER_CASE, "FOO_DB", "foo_db"),
-                Arguments.of("keep origin identifier pattern keeps default schema", IdentifierPatternType.KEEP_ORIGIN, "Foo_Db", "Foo_Db"),
-                Arguments.of("null database name keeps null default schema", IdentifierPatternType.UPPER_CASE, null, null));
+                Arguments.of("fixed default schema remains unchanged", IdentifierPatternType.UPPER_CASE, "Foo_Schema", "foo_db", "Foo_Schema"),
+                Arguments.of("upper case identifier pattern formats default schema", IdentifierPatternType.UPPER_CASE, null, "foo_db", "FOO_DB"),
+                Arguments.of("lower case identifier pattern formats default schema", IdentifierPatternType.LOWER_CASE, null, "FOO_DB", "foo_db"),
+                Arguments.of("keep origin identifier pattern keeps default schema", IdentifierPatternType.KEEP_ORIGIN, null, "Foo_Db", "Foo_Db"),
+                Arguments.of("null database name keeps null default schema", IdentifierPatternType.UPPER_CASE, null, null, null));
     }
     
     private static Stream<Arguments> formatIdentifierPatternArguments() {


### PR DESCRIPTION

Changes proposed in this pull request:
  - Normalize default schema names without deprecated identifier formatting

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
