### PR TITLE
Unify MCP workflow property masking

### DIFF
--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPCallToolResultFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPCallToolResultFactoryTest.java
@@ -36,9 +36,7 @@ import org.apache.shardingsphere.mcp.core.tool.handler.MCPToolDefinition;
 import org.apache.shardingsphere.mcp.core.tool.handler.ToolDefinitionRegistry;
 import org.apache.shardingsphere.mcp.feature.encrypt.EncryptFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.encrypt.tool.model.EncryptWorkflowRequest;
-import org.apache.shardingsphere.mcp.feature.encrypt.tool.service.EncryptAlgorithmPropertyTemplateService;
 import org.apache.shardingsphere.mcp.feature.mask.MaskFeatureDefinition;
-import org.apache.shardingsphere.mcp.feature.mask.tool.service.MaskAlgorithmPropertyTemplateService;
 import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPStatement;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConnectionException;
 import org.apache.shardingsphere.mcp.support.database.tool.result.RuntimeDatabaseValidationCheckResult;
@@ -57,6 +55,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactMaskUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowPlanPayloadBuilder;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -267,7 +266,7 @@ class MCPCallToolResultFactoryTest extends AbstractMCPToolSpecificationFactoryTe
         WorkflowContextSnapshot snapshot = createMaskSnapshot();
         Map<String, Object> payload = WorkflowPlanPayloadBuilder.buildWithArtifacts(snapshot, snapshot.getRequest());
         payload.put("masked_property_preview", Map.of("primary",
-                new MaskAlgorithmPropertyTemplateService().maskProperties(snapshot.getPropertyRequirements(), snapshot.getRequest().getPrimaryAlgorithmProperties())));
+                WorkflowArtifactMaskUtils.maskPropertyMap(snapshot.getRequest().getPrimaryAlgorithmProperties(), snapshot.getPropertyRequirements())));
         return new MCPMapPayload(payload);
     }
     
@@ -286,7 +285,7 @@ class MCPCallToolResultFactoryTest extends AbstractMCPToolSpecificationFactoryTe
         WorkflowContextSnapshot snapshot = createEncryptSnapshot();
         Map<String, Object> payload = WorkflowPlanPayloadBuilder.buildWithArtifacts(snapshot, snapshot.getRequest());
         payload.put("masked_property_preview", Map.of("primary",
-                new EncryptAlgorithmPropertyTemplateService().maskProperties(snapshot.getPropertyRequirements(), snapshot.getRequest().getPrimaryAlgorithmProperties())));
+                WorkflowArtifactMaskUtils.maskPropertyMap(snapshot.getRequest().getPrimaryAlgorithmProperties(), snapshot.getPropertyRequirements())));
         return new MCPMapPayload(payload);
     }
     

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/handler/PlanEncryptRuleToolHandler.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/handler/PlanEncryptRuleToolHandler.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyReq
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactMaskUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowPlanningArguments;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowPlanPayloadBuilder;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowRequestBinder;
@@ -82,8 +83,8 @@ public final class PlanEncryptRuleToolHandler implements MCPToolHandler<MCPFeatu
     
     private void putMaskedProperties(final Map<String, Object> target, final List<AlgorithmPropertyRequirement> requirements,
                                      final WorkflowRequest request, final String role) {
-        target.put(role, propertyTemplateService.maskProperties(
-                requirements.stream().filter(each -> role.equals(each.getAlgorithmRole())).toList(), request.getAlgorithmProperties(role)));
+        List<AlgorithmPropertyRequirement> roleRequirements = requirements.stream().filter(each -> role.equals(each.getAlgorithmRole())).toList();
+        target.put(role, WorkflowArtifactMaskUtils.maskPropertyMap(request.getAlgorithmProperties(role), roleRequirements, request, role));
     }
     
     private List<AlgorithmPropertyRequirement> createPropertyRequirements(final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmPropertyTemplateService.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmPropertyTemplateService.java
@@ -20,12 +20,8 @@ package org.apache.shardingsphere.mcp.feature.encrypt.tool.service;
 import org.apache.shardingsphere.mcp.feature.encrypt.EncryptFeatureDefinition;
 import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyRequirement;
 
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 /**
  * Algorithm property template service.
@@ -48,19 +44,4 @@ public final class EncryptAlgorithmPropertyTemplateService {
         return result;
     }
     
-    /**
-     * Mask properties for review.
-     *
-     * @param requirements requirements
-     * @param actualProperties actual properties
-     * @return masked properties
-     */
-    public Map<String, String> maskProperties(final List<AlgorithmPropertyRequirement> requirements, final Map<String, String> actualProperties) {
-        return actualProperties.entrySet().stream().collect(Collectors.toMap(Entry::getKey,
-                entry -> isSecret(requirements, entry.getKey()) ? "******" : entry.getValue(), (a, b) -> b, () -> new LinkedHashMap<>(actualProperties.size(), 1F)));
-    }
-    
-    private boolean isSecret(final List<AlgorithmPropertyRequirement> requirements, final String propertyKey) {
-        return requirements.stream().filter(each -> each.getPropertyKey().equals(propertyKey)).findFirst().map(AlgorithmPropertyRequirement::isSecret).orElse(false);
-    }
 }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/handler/PlanEncryptRuleToolHandlerTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/handler/PlanEncryptRuleToolHandlerTest.java
@@ -115,13 +115,22 @@ class PlanEncryptRuleToolHandlerTest {
         try (MockedConstruction<EncryptWorkflowPlanningService> mockedConstruction = mockConstruction(EncryptWorkflowPlanningService.class)) {
             PlanEncryptRuleToolHandler handler = new PlanEncryptRuleToolHandler();
             EncryptWorkflowPlanningService planningService = mockedConstruction.constructed().getFirst();
-            when(planningService.plan(any(), any(), any(), any())).thenReturn(createSnapshot("plan-1", "planned"));
+            WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "planned");
+            when(planningService.plan(any(), any(), any(), any())).thenAnswer(invocation -> {
+                snapshot.setRequest(invocation.getArgument(3));
+                return snapshot;
+            });
             WorkflowContextFixture fixture = createWorkflowContextFixture();
-            handler.handle(fixture.requestContext, Map.of(
+            Map<String, Object> actualPayload = handler.handle(fixture.requestContext, Map.of(
                     "database", "logic_db",
                     "primary_algorithm_properties", Map.of("aes-key-value", Map.of("secret_ref", "placeholder://secret-value-1")),
                     "assisted_query_algorithm_properties", Map.of("salt", Map.of("secret_ref", "placeholder://secret-value-2")),
-                    "like_query_algorithm_properties", Map.of("token", Map.of("secret_ref", "placeholder://secret-value-3"))));
+                    "like_query_algorithm_properties", Map.of("token", Map.of("secret_ref", "placeholder://secret-value-3")))).toPayload();
+            Map<?, ?> actualMaskedPropertyPreview = (Map<?, ?>) actualPayload.get("masked_property_preview");
+            assertThat(((Map<?, ?>) actualMaskedPropertyPreview.get("primary")).get("aes-key-value"), is("******"));
+            assertThat(((Map<?, ?>) actualMaskedPropertyPreview.get("assisted_query")).get("salt"), is("******"));
+            assertThat(((Map<?, ?>) actualMaskedPropertyPreview.get("like_query")).get("token"), is("******"));
+            assertFalse(String.valueOf(actualPayload).contains("secret_reference:"));
             ArgumentCaptor<EncryptWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(EncryptWorkflowRequest.class);
             verify(planningService).plan(eq(fixture.workflowSessionContext), eq(fixture.metadataQueryFacade), eq(fixture.queryFacade), requestCaptor.capture());
             EncryptWorkflowRequest actualRequest = requestCaptor.getValue();

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmPropertyTemplateServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmPropertyTemplateServiceTest.java
@@ -21,7 +21,6 @@ import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyReq
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -47,13 +46,4 @@ class EncryptAlgorithmPropertyTemplateServiceTest {
         assertTrue(actual.isEmpty());
     }
     
-    @Test
-    void assertMaskProperties() {
-        List<AlgorithmPropertyRequirement> requirements = List.of(
-                new AlgorithmPropertyRequirement("primary", "aes-key-value", true, true, "key", ""),
-                new AlgorithmPropertyRequirement("primary", "digest-algorithm-name", false, false, "digest", "SHA-1"));
-        Map<String, String> actual = service.maskProperties(requirements, Map.of("aes-key-value", "secret", "digest-algorithm-name", "SHA-256"));
-        assertThat(actual.get("aes-key-value"), is("******"));
-        assertThat(actual.get("digest-algorithm-name"), is("SHA-256"));
-    }
 }

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/handler/PlanMaskRuleToolHandler.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/handler/PlanMaskRuleToolHandler.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyReq
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactMaskUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowPlanningArguments;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowPlanPayloadBuilder;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowRequestBinder;
@@ -65,8 +66,9 @@ public final class PlanMaskRuleToolHandler implements MCPToolHandler<MCPFeatureR
     private Map<String, Object> buildPlanResponse(final WorkflowContextSnapshot snapshot) {
         WorkflowRequest request = snapshot.getRequest();
         Map<String, Object> result = WorkflowPlanPayloadBuilder.buildWithArtifacts(snapshot, request);
-        result.put("masked_property_preview", Map.of(
-                "primary", propertyTemplateService.maskProperties(createPropertyRequirements(snapshot, request), request.getAlgorithmProperties("primary"))));
+        Map<String, String> maskedProperties = WorkflowArtifactMaskUtils.maskPropertyMap(
+                request.getAlgorithmProperties("primary"), createPropertyRequirements(snapshot, request), request, "primary");
+        result.put("masked_property_preview", Map.of("primary", maskedProperties));
         return result;
     }
     

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskAlgorithmPropertyTemplateService.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskAlgorithmPropertyTemplateService.java
@@ -24,7 +24,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 
 /**
@@ -50,25 +49,6 @@ public final class MaskAlgorithmPropertyTemplateService {
             result.add(new AlgorithmPropertyRequirement("primary", each.getPropertyKey(), each.isRequired(), each.isSecret(), each.getDescription(), each.getDefaultValue()));
         }
         return result;
-    }
-    
-    /**
-     * Mask properties for review.
-     *
-     * @param requirements requirements
-     * @param actualProperties actual properties
-     * @return masked properties
-     */
-    public Map<String, String> maskProperties(final List<AlgorithmPropertyRequirement> requirements, final Map<String, String> actualProperties) {
-        Map<String, String> result = new LinkedHashMap<>(actualProperties.size(), 1F);
-        for (Entry<String, String> entry : actualProperties.entrySet()) {
-            result.put(entry.getKey(), isSecret(requirements, entry.getKey()) ? "******" : entry.getValue());
-        }
-        return result;
-    }
-    
-    private boolean isSecret(final List<AlgorithmPropertyRequirement> requirements, final String propertyKey) {
-        return requirements.stream().filter(each -> each.getPropertyKey().equals(propertyKey)).findFirst().map(AlgorithmPropertyRequirement::isSecret).orElse(false);
     }
     
     private static Map<String, List<AlgorithmPropertyRequirement>> createMaskTemplates() {

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/handler/PlanMaskRuleToolHandlerTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/handler/PlanMaskRuleToolHandlerTest.java
@@ -107,11 +107,18 @@ class PlanMaskRuleToolHandlerTest {
         try (MockedConstruction<MaskWorkflowPlanningService> mockedConstruction = mockConstruction(MaskWorkflowPlanningService.class)) {
             PlanMaskRuleToolHandler handler = new PlanMaskRuleToolHandler();
             MaskWorkflowPlanningService planningService = mockedConstruction.constructed().getFirst();
-            when(planningService.plan(any(), any(), any(), any())).thenReturn(createSnapshot("plan-1", "planned"));
+            WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "planned");
+            when(planningService.plan(any(), any(), any(), any())).thenAnswer(invocation -> {
+                snapshot.setRequest(invocation.getArgument(3));
+                return snapshot;
+            });
             WorkflowContextFixture fixture = createWorkflowContextFixture();
-            handler.handle(fixture.requestContext, Map.of(
+            Map<String, Object> actualPayload = handler.handle(fixture.requestContext, Map.of(
                     "database", "logic_db",
-                    "primary_algorithm_properties", Map.of("replace-char", Map.of("secret_ref", "placeholder://secret-value-1"))));
+                    "primary_algorithm_properties", Map.of("replace-char", Map.of("secret_ref", "placeholder://secret-value-1")))).toPayload();
+            Map<?, ?> actualMaskedPropertyPreview = (Map<?, ?>) actualPayload.get("masked_property_preview");
+            assertThat(((Map<?, ?>) actualMaskedPropertyPreview.get("primary")).get("replace-char"), is("******"));
+            assertFalse(String.valueOf(actualPayload).contains("secret_reference:"));
             ArgumentCaptor<WorkflowRequest> requestCaptor = ArgumentCaptor.forClass(WorkflowRequest.class);
             verify(planningService).plan(eq(fixture.workflowSessionContext), eq(fixture.metadataQueryFacade), eq(fixture.queryFacade), requestCaptor.capture());
             WorkflowRequest actualRequest = requestCaptor.getValue();

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskAlgorithmPropertyTemplateServiceTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskAlgorithmPropertyTemplateServiceTest.java
@@ -21,7 +21,6 @@ import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyReq
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -52,13 +51,4 @@ class MaskAlgorithmPropertyTemplateServiceTest {
         assertTrue(actual.isEmpty());
     }
     
-    @Test
-    void assertMaskProperties() {
-        List<AlgorithmPropertyRequirement> requirements = List.of(
-                new AlgorithmPropertyRequirement("primary", "special-chars", true, false, "anchor", ""),
-                new AlgorithmPropertyRequirement("primary", "secret-key", true, true, "secret", ""));
-        Map<String, String> actual = service.maskProperties(requirements, Map.of("special-chars", "@", "secret-key", "abc"));
-        assertThat(actual.get("special-chars"), is("@"));
-        assertThat(actual.get("secret-key"), is("******"));
-    }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/SecretReferenceValue.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/SecretReferenceValue.java
@@ -32,6 +32,8 @@ import java.util.Map;
 @Getter
 public final class SecretReferenceValue {
     
+    private static final String PLACEHOLDER_PREFIX = "secret_reference:";
+    
     private final boolean malformed;
     
     /**
@@ -60,7 +62,17 @@ public final class SecretReferenceValue {
      * @return SQL placeholder
      */
     public static String createPlaceholder(final String algorithmRole, final String propertyKey) {
-        return String.format("secret_reference:%s.%s", normalize(algorithmRole), normalize(propertyKey));
+        return PLACEHOLDER_PREFIX + normalize(algorithmRole) + "." + normalize(propertyKey);
+    }
+    
+    /**
+     * Judge whether the value is a secret reference placeholder.
+     *
+     * @param value value to be judged
+     * @return whether the value is a secret reference placeholder
+     */
+    public static boolean isPlaceholder(final String value) {
+        return value.startsWith(PLACEHOLDER_PREFIX);
     }
     
     /**

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowAlgorithmUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowAlgorithmUtils.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.exception.external.ShardingSphereExternal
 import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPI;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.mcp.support.workflow.model.SecretReferenceValue;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -38,8 +39,6 @@ import java.util.Properties;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowAlgorithmUtils {
-    
-    private static final String SECRET_REFERENCE_PREFIX = "secret_reference:";
     
     private static final String ALGORITHM_TYPE_KEY = "type";
     
@@ -160,7 +159,7 @@ public final class WorkflowAlgorithmUtils {
     }
     
     private static boolean hasSecretReference(final Map<String, String> properties) {
-        return properties.values().stream().anyMatch(each -> Objects.toString(each, "").startsWith(SECRET_REFERENCE_PREFIX));
+        return properties.values().stream().anyMatch(each -> SecretReferenceValue.isPlaceholder(Objects.toString(each, "")));
     }
     
     private static Map<String, String> parsePropertyString(final String value) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactMaskUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactMaskUtils.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -37,6 +38,8 @@ import java.util.Set;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowArtifactMaskUtils {
+    
+    private static final String MASKED_VALUE = "******";
     
     /**
      * Create masked rule artifact map.
@@ -69,8 +72,8 @@ public final class WorkflowArtifactMaskUtils {
             if (each.isEmpty()) {
                 continue;
             }
-            result = result.replace(each, "******");
-            result = result.replace(WorkflowSQLUtils.escapeLiteral(each), "******");
+            result = result.replace(each, MASKED_VALUE);
+            result = result.replace(WorkflowSQLUtils.escapeLiteral(each), MASKED_VALUE);
         }
         return result;
     }
@@ -83,9 +86,7 @@ public final class WorkflowArtifactMaskUtils {
      * @return masked property values
      */
     public static Map<String, String> maskPropertyMap(final Map<String, String> properties, final List<AlgorithmPropertyRequirement> propertyRequirements) {
-        Map<String, String> result = new LinkedHashMap<>(properties.size(), 1F);
-        properties.forEach((key, value) -> result.put(key, isSecretProperty(propertyRequirements, key) || isSecretReferencePlaceholder(value) ? "******" : value));
-        return result;
+        return maskPropertyMap(properties, propertyRequirements, Set.of());
     }
     
     /**
@@ -99,9 +100,14 @@ public final class WorkflowArtifactMaskUtils {
      */
     public static Map<String, String> maskPropertyMap(final Map<String, String> properties, final List<AlgorithmPropertyRequirement> propertyRequirements,
                                                       final WorkflowRequest request, final String algorithmRole) {
+        return maskPropertyMap(properties, propertyRequirements, null == request ? Set.of() : request.getSecretReferences(algorithmRole).keySet());
+    }
+    
+    private static Map<String, String> maskPropertyMap(final Map<String, String> properties, final List<AlgorithmPropertyRequirement> propertyRequirements,
+                                                       final Set<String> secretReferencePropertyKeys) {
         Map<String, String> result = new LinkedHashMap<>(properties.size(), 1F);
-        properties.forEach((key, value) -> result.put(key, isSecretProperty(propertyRequirements, key) || isSecretReferenceProperty(request, algorithmRole, key)
-                || isSecretReferencePlaceholder(value) ? "******" : value));
+        properties.forEach((key, value) -> result.put(key, isSecretProperty(propertyRequirements, key) || secretReferencePropertyKeys.contains(key)
+                || SecretReferenceValue.isPlaceholder(Objects.toString(value, "")) ? MASKED_VALUE : value));
         return result;
     }
     
@@ -125,7 +131,7 @@ public final class WorkflowArtifactMaskUtils {
         List<String> redactedProperties = collectSecretPropertyNames(request, propertyRequirements).stream().toList();
         Map<String, Object> result = new LinkedHashMap<>(5, 1F);
         result.put("applied", !redactedProperties.isEmpty());
-        result.put("marker", "******");
+        result.put("marker", MASKED_VALUE);
         result.put("redacted_properties", redactedProperties);
         result.put("redacted_count", redactedProperties.size());
         result.put("categories", redactedProperties.stream().map(WorkflowArtifactMaskUtils::createRedactedCategory).distinct().toList());
@@ -185,11 +191,4 @@ public final class WorkflowArtifactMaskUtils {
                 || actualPropertyKey.contains("_key") || actualPropertyKey.contains("key_");
     }
     
-    private static boolean isSecretReferencePlaceholder(final String value) {
-        return null != value && value.startsWith("secret_reference:");
-    }
-    
-    private static boolean isSecretReferenceProperty(final WorkflowRequest request, final String algorithmRole, final String propertyKey) {
-        return null != request && request.getSecretReferences(algorithmRole).containsKey(propertyKey);
-    }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/model/SecretReferenceValueTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/model/SecretReferenceValueTest.java
@@ -46,6 +46,16 @@ class SecretReferenceValueTest {
     }
     
     @Test
+    void assertIsPlaceholder() {
+        assertTrue(SecretReferenceValue.isPlaceholder("secret_reference:primary.aes-key-value"));
+    }
+    
+    @Test
+    void assertIsPlaceholderWithOrdinaryValue() {
+        assertFalse(SecretReferenceValue.isPlaceholder("foo_value"));
+    }
+    
+    @Test
     void assertCreateManualPlaceholder() {
         assertThat(SecretReferenceValue.createManualPlaceholder("primary", "aes-key-value"), is("<SECRET_VALUE_PRIMARY_AES_KEY_VALUE>"));
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/functionality/HttpProxySecretReferenceWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/functionality/HttpProxySecretReferenceWorkflowE2ETest.java
@@ -84,6 +84,8 @@ class HttpProxySecretReferenceWorkflowE2ETest extends AbstractHttpProxyWorkflowE
         assertThat(String.valueOf(secretReference.get("property_key")), is("aes-key-value"));
         assertThat(String.valueOf(secretReference.get("label")), is("secret_placeholder:primary.aes-key-value"));
         assertThat(String.valueOf(secretReference.get("manual_placeholder")), is("<SECRET_VALUE_PRIMARY_AES_KEY_VALUE>"));
+        Map<String, Object> maskedPropertyPreview = getObjectOrEmpty(planResponse.get("masked_property_preview"));
+        assertThat(String.valueOf(getObjectOrEmpty(maskedPropertyPreview.get("primary")).get("aes-key-value")), is("******"));
         assertSecretReferenceRedacted(planResponse);
     }
     
@@ -101,5 +103,6 @@ class HttpProxySecretReferenceWorkflowE2ETest extends AbstractHttpProxyWorkflowE
         String actual = String.valueOf(payload);
         assertFalse(actual.contains(SECRET_REF));
         assertFalse(actual.contains(INPUT_LABEL));
+        assertFalse(actual.contains("secret_reference:"));
     }
 }


### PR DESCRIPTION
Centralize property masking and secret reference detection in MCP support. Remove duplicate Encrypt and Mask masking implementations and strengthen secret reference preview coverage.
