### PR TITLE
Throw instead of returning partial results when ExecutorEngine is interrupted

### DIFF
--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/kernel/ExecutorEngine.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/kernel/ExecutorEngine.java
@@ -118,6 +118,7 @@ public final class ExecutorEngine implements AutoCloseable {
                 result.addAll(each.get());
             } catch (final InterruptedException ex) {
                 Thread.currentThread().interrupt();
+                return throwException(ex);
             } catch (final ExecutionException ex) {
                 return throwException(ex);
             }

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/kernel/ExecutorEngineTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/kernel/ExecutorEngineTest.java
@@ -25,14 +25,20 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.shardingsphere.infra.executor.kernel.model.ExecutorCallback;
+import org.apache.shardingsphere.infra.exception.generic.UnknownSQLException;
+
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 class ExecutorEngineTest {
@@ -87,5 +93,35 @@ class ExecutorEngineTest {
         List<String> actual = executorEngine.execute(executionGroupContext, firstCallback, callback, true);
         latch.await();
         assertThat(actual.size(), is(4));
+    }
+    
+    @Test
+    void assertParallelExecuteThrowsWhenInterrupted() throws InterruptedException {
+        CountDownLatch neverReleased = new CountDownLatch(1);
+        CountDownLatch asyncStarted = new CountDownLatch(1);
+        // The trunk thread interrupts itself while the async group is still running, so the
+        // Future.get() that follows throws InterruptedException. A future that has already
+        // completed hands back its value even with the flag set, hence the block.
+        ExecutorCallback<Object, String> interruptingFirstCallback = (inputs, isTrunkThread, processId) -> {
+            Thread.currentThread().interrupt();
+            return Collections.singletonList("succeed");
+        };
+        ExecutorCallback<Object, String> blockingCallback = (inputs, isTrunkThread, processId) -> {
+            asyncStarted.countDown();
+            try {
+                neverReleased.await(30L, TimeUnit.SECONDS);
+            } catch (final InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            return Collections.singletonList("succeed");
+        };
+        try {
+            assertThrows(UnknownSQLException.class,
+                    () -> executorEngine.execute(executionGroupContext, interruptingFirstCallback, blockingCallback, false));
+        } finally {
+            Thread.interrupted();
+            neverReleased.countDown();
+            asyncStarted.await(30L, TimeUnit.SECONDS);
+        }
     }
 }


### PR DESCRIPTION
## Changes

`ExecutorEngine.getGroupResults` restored the interrupt flag and then **fell through**, so the loop kept going, every remaining `Future.get()` threw immediately, and the method returned a result list silently missing one entry per interrupted group — reported to the caller as success.

The two handlers sitting next to each other were asymmetric:

```java
} catch (final InterruptedException ex) {
    Thread.currentThread().interrupt();     // restores the flag, falls through
} catch (final ExecutionException ex) {
    return throwException(ex);              // terminates
}
```

This adds the missing `return throwException(ex)` to the interrupt branch. One line.

## Why this is a regression, not a design choice

Before 551478707 (#25627) the handler was combined and rethrew for both:

```diff
-            } catch (final InterruptedException | ExecutionException ex) {
+            } catch (final InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            } catch (final ExecutionException ex) {
                 return throwException(ex);
             }
```

That was an 18-file sweep for the Sonar rule *"Either re-interrupt this method or rethrow the InterruptedException that can be caught here"*. Splitting the catch added the re-interrupt and, as a side effect, dropped the rethrow from that branch.

The rule is satisfied by re-interrupting **or** rethrowing, so doing both — which is what this PR restores — still satisfies it. Nothing about the original sweep's intent is undone.

## Why the short list matters downstream

`BatchPreparedStatementExecutor.accumulate` (`:163-173`) walks every execution unit and indexes the result list positionally:

```java
for (JDBCExecutionUnit eachUnit : each.getInputs()) {
    accumulate(executeResults.get(count), result, eachUnit);
    count++;
}
```

A missing entry surfaces as an `IndexOutOfBoundsException` a long way from the cause. Silently succeeding with fewer results than execution units is the worse of the two outcomes.

## Testing

`ExecutorEngineTest.assertParallelExecuteThrowsWhenInterrupted`: a first callback that interrupts the trunk thread before returning, and an async callback that blocks so the pending `Future.get()` actually observes the interrupt. On `master`:

```
ExecutorEngineTest.assertParallelExecuteThrowsWhenInterrupted:119
  Expected org.apache.shardingsphere.infra.exception.generic.UnknownSQLException
  to be thrown, but nothing was thrown.
```

The blocking async side is required, not incidental: a `FutureTask` that has already completed returns its value even with the interrupt flag set, so a non-blocking fixture would pass for the wrong reason.

- `ExecutorEngineTest` — fails before, 3/3 after
- `infra/executor` with `-am` — 2984 tests, 0 failures, 0 errors
- `checkstyle:check -Pcheck` and `spotless:check -Pcheck` — both clean

## One thing I left alone

`MetaDataLoader` has the same swallow from the same sweep and returns a partial metadata map. It looked like a separate fix, and open PR #39157 already touches that file, so I did not bundle it. Happy to follow up once that lands.

Fixes #39399

## Type
- [x] Bugfix
