### PR TITLE
Fix MySQL SHOW CREATE TABLE replacement for special characters

### DIFF
--- a/features/sharding/dialect/mysql/src/main/java/org/apache/shardingsphere/sharding/merge/mysql/type/MySQLShardingShowCreateTableMergedResult.java
+++ b/features/sharding/dialect/mysql/src/main/java/org/apache/shardingsphere/sharding/merge/mysql/type/MySQLShardingShowCreateTableMergedResult.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -59,7 +61,7 @@ public final class MySQLShardingShowCreateTableMergedResult extends MySQLShardin
     }
     
     private void replaceTables(final MemoryQueryResultRow memoryResultSetRow, final String logicTableName, final String actualTableName) {
-        memoryResultSetRow.setCell(2, memoryResultSetRow.getCell(2).toString().replaceFirst(actualTableName, logicTableName));
+        memoryResultSetRow.setCell(2, memoryResultSetRow.getCell(2).toString().replaceFirst(Pattern.quote(actualTableName), Matcher.quoteReplacement(logicTableName)));
     }
     
     private void replaceBindingTables(final MemoryQueryResultRow memoryResultSetRow, final String logicTableName, final String actualTableName, final ShardingRule rule) {
@@ -75,7 +77,7 @@ public final class MySQLShardingShowCreateTableMergedResult extends MySQLShardin
                     .putAll(rule.getLogicAndActualTablesFromBindingTable(each.getDataSourceName(), logicTableName, actualTableName, bindingTableRule.get().getAllLogicTables()));
         }
         for (Entry<String, String> entry : logicAndActualTablesFromBindingTables.entrySet()) {
-            memoryResultSetRow.setCell(2, memoryResultSetRow.getCell(2).toString().replaceFirst(entry.getValue(), entry.getKey()));
+            memoryResultSetRow.setCell(2, memoryResultSetRow.getCell(2).toString().replaceFirst(Pattern.quote(entry.getValue()), Matcher.quoteReplacement(entry.getKey())));
         }
     }
     

--- a/features/sharding/dialect/mysql/src/test/java/org/apache/shardingsphere/sharding/merge/mysql/type/MySQLShardingShowCreateTableMergedResultTest.java
+++ b/features/sharding/dialect/mysql/src/test/java/org/apache/shardingsphere/sharding/merge/mysql/type/MySQLShardingShowCreateTableMergedResultTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sharding.merge.mysql.type;
 import org.apache.groovy.util.Maps;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResult;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstanceContext;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereConstraint;
@@ -29,7 +30,9 @@ import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSp
 import org.apache.shardingsphere.infra.metadata.database.schema.util.IndexMetaDataUtils;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
+import org.apache.shardingsphere.sharding.rule.BindingTableRule;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
+import org.apache.shardingsphere.sharding.rule.ShardingTable;
 import org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +41,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -114,6 +118,45 @@ class MySQLShardingShowCreateTableMergedResultTest {
                 + "  PRIMARY KEY (`id`),\n"
                 + "  CONSTRAINT `foo_tbl_foreign_key_foo_tbl_0` FOREIGN KEY (`bar_id`) REFERENCES `bar_tbl_0` (`bar_id`) \n"
                 + ") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin");
+        return result;
+    }
+    
+    @Test
+    void assertGetValueWithDollarSignInTableNames() throws SQLException {
+        MySQLShardingShowCreateTableMergedResult actual = new MySQLShardingShowCreateTableMergedResult(
+                buildShardingRuleWithDollarSign(), mock(SQLStatementContext.class), createSchemaWithDollarSign(), Collections.singletonList(mockQueryResultWithDollarSign()));
+        assertTrue(actual.next());
+        assertThat(actual.getValue(2, String.class), is("CREATE TABLE `foo$tbl` (FOREIGN KEY (`bar_id`) REFERENCES `bar$tbl` (`bar_id`))"));
+    }
+    
+    private ShardingRule buildShardingRuleWithDollarSign() {
+        ShardingRule result = mock(ShardingRule.class);
+        ShardingTable shardingTable = mock(ShardingTable.class);
+        when(shardingTable.getLogicTable()).thenReturn("foo$tbl");
+        when(shardingTable.getActualDataNodes()).thenReturn(Collections.singletonList(new DataNode("ds.foo$tbl_0")));
+        when(result.findShardingTableByActualTable("foo$tbl_0")).thenReturn(Optional.of(shardingTable));
+        when(result.findShardingTable("foo$tbl")).thenReturn(Optional.of(shardingTable));
+        BindingTableRule bindingTableRule = mock(BindingTableRule.class);
+        when(bindingTableRule.getAllLogicTables()).thenReturn(Collections.singleton("bar$tbl"));
+        when(result.findBindingTableRule("foo$tbl")).thenReturn(Optional.of(bindingTableRule));
+        when(result.getLogicAndActualTablesFromBindingTable("ds", "foo$tbl", "foo$tbl_0", Collections.singleton("bar$tbl")))
+                .thenReturn(Collections.singletonMap("bar$tbl", "bar$tbl_0"));
+        return result;
+    }
+    
+    private ShardingSphereSchema createSchemaWithDollarSign() {
+        Collection<ShardingSphereTable> tables = new LinkedList<>();
+        tables.add(new ShardingSphereTable("foo$tbl", Collections.emptyList(), Collections.emptyList(), Collections.singleton(new ShardingSphereConstraint("foo_foreign_key", "bar$tbl"))));
+        tables.add(new ShardingSphereTable("bar$tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
+        return new ShardingSphereSchema("foo_db", mock(DatabaseType.class), tables, Collections.emptyList());
+    }
+    
+    private QueryResult mockQueryResultWithDollarSign() throws SQLException {
+        QueryResult result = mock(QueryResult.class, RETURNS_DEEP_STUBS);
+        when(result.getMetaData().getColumnCount()).thenReturn(2);
+        when(result.next()).thenReturn(true, false);
+        when(result.getValue(1, Object.class)).thenReturn("foo$tbl_0");
+        when(result.getValue(2, Object.class)).thenReturn("CREATE TABLE `foo$tbl_0` (FOREIGN KEY (`bar_id`) REFERENCES `bar$tbl_0` (`bar_id`))");
         return result;
     }
     


### PR DESCRIPTION
Changes proposed in this pull request:
- Treat actual and logic table names as literal values when rewriting MySQL `SHOW CREATE TABLE` output.
- Cover dollar signs in both sharding and binding table names with a regression test.

MySQL permits `$` in unquoted identifiers, but `String.replaceFirst` interprets its first argument as a regular expression and its second argument as a replacement template. Quoting both values preserves the existing first-occurrence behavior without treating valid identifier characters as regex syntax.

Verification:
- `./mvnw -pl features/sharding/dialect/mysql -DskipITs test`
- `./mvnw checkstyle:check -Pcheck -T1C`
- `./mvnw spotless:apply -Pcheck -T1C`

Documentation and release notes are not changed because this restores existing `SHOW CREATE TABLE` behavior without changing configuration or public APIs.
