### PR TITLE
Implement MySQLPacketPayload.writeInt6()

### DIFF
--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/payload/MySQLPacketPayload.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/payload/MySQLPacketPayload.java
@@ -129,7 +129,8 @@ public final class MySQLPacketPayload implements PacketPayload {
      * @param value 6 byte fixed length integer
      */
     public void writeInt6(final long value) {
-        // TODO
+        byteBuf.writeIntLE((int) value);
+        byteBuf.writeShortLE((int) (value >>> 32));
     }
     
     /**

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/payload/MySQLPacketPayloadTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/payload/MySQLPacketPayloadTest.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.database.protocol.mysql.payload;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -95,7 +97,18 @@ class MySQLPacketPayloadTest {
     
     @Test
     void assertWriteInt6() {
-        assertDoesNotThrow(() -> new MySQLPacketPayload(byteBuf, StandardCharsets.UTF_8).writeInt6(1L));
+        byte[] expected = {0x54, 0x76, (byte) 0x98, (byte) 0xba, (byte) 0xdc, (byte) 0xfe};
+        ByteBuf actual = Unpooled.wrappedBuffer(new byte[6]).writerIndex(0);
+        new MySQLPacketPayload(actual, StandardCharsets.UTF_8).writeInt6(0xfedcba987654L);
+        assertThat(ByteBufUtil.getBytes(actual), is(expected));
+    }
+    
+    @Test
+    void assertWriteInt6WithMaximumValue() {
+        byte[] expected = {(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff};
+        ByteBuf actual = Unpooled.wrappedBuffer(new byte[6]).writerIndex(0);
+        new MySQLPacketPayload(actual, StandardCharsets.UTF_8).writeInt6(0xffffffffffffL);
+        assertThat(ByteBufUtil.getBytes(actual), is(expected));
     }
     
     @Test


### PR DESCRIPTION
Write six-byte fixed-length integers in little-endian order and add wire-format coverage for high-bit and maximum values.
