### PR TITLE
Use payload charset for PostgreSQL binary strings

### DIFF
--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
@@ -36,7 +36,7 @@ public final class PostgreSQLStringBinaryProtocolValue implements PostgreSQLBina
     public Object read(final PostgreSQLPacketPayload payload, final int parameterValueLength) {
         byte[] result = new byte[parameterValueLength];
         payload.getByteBuf().readBytes(result);
-        return new String(result);
+        return new String(result, payload.getCharset());
     }
     
     @Override

--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValue.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValue.java
@@ -34,7 +34,7 @@ public final class PostgreSQLUnspecifiedBinaryProtocolValue implements PostgreSQ
     public Object read(final PostgreSQLPacketPayload payload, final int parameterValueLength) {
         byte[] bytes = new byte[parameterValueLength];
         payload.getByteBuf().readBytes(bytes);
-        String result = new String(bytes);
+        String result = new String(bytes, payload.getCharset());
         return new PostgreSQLTypeUnspecifiedSQLParameter(result);
     }
     

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValueTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValueTest.java
@@ -18,20 +18,17 @@
 package org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.bind.protocol;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.database.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
-
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,12 +54,10 @@ class PostgreSQLStringBinaryProtocolValueTest {
     
     @Test
     void assertRead() {
-        doAnswer((Answer<ByteBuf>) invocation -> {
-            ((byte[]) invocation.getArguments()[0])[0] = 'a';
-            return byteBuf;
-        }).when(byteBuf).readBytes(any(byte[].class));
-        PostgreSQLStringBinaryProtocolValue actual = new PostgreSQLStringBinaryProtocolValue();
-        assertThat(actual.read(payload, "a".length()), is("a"));
+        String expected = "中文";
+        byte[] bytes = expected.getBytes(StandardCharsets.UTF_16BE);
+        PostgreSQLPacketPayload readPayload = new PostgreSQLPacketPayload(Unpooled.wrappedBuffer(bytes), StandardCharsets.UTF_16BE);
+        assertThat(new PostgreSQLStringBinaryProtocolValue().read(readPayload, bytes.length), is(expected));
     }
     
     @Test

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValueTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValueTest.java
@@ -25,10 +25,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,6 +58,16 @@ class PostgreSQLStringBinaryProtocolValueTest {
     
     @Test
     void assertRead() {
+        doAnswer((Answer<ByteBuf>) invocation -> {
+            ((byte[]) invocation.getArguments()[0])[0] = 'a';
+            return byteBuf;
+        }).when(byteBuf).readBytes(any(byte[].class));
+        PostgreSQLStringBinaryProtocolValue actual = new PostgreSQLStringBinaryProtocolValue();
+        assertThat(actual.read(payload, "a".length()), is("a"));
+    }
+    
+    @Test
+    void assertReadWithMultiByteCharset() {
         String expected = "中文";
         byte[] bytes = expected.getBytes(StandardCharsets.UTF_16BE);
         PostgreSQLPacketPayload readPayload = new PostgreSQLPacketPayload(Unpooled.wrappedBuffer(bytes), StandardCharsets.UTF_16BE);

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.bind.protocol;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.shardingsphere.database.protocol.postgresql.packet.ByteBufTestUtils;
+import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.bind.PostgreSQLTypeUnspecifiedSQLParameter;
 import org.apache.shardingsphere.database.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,17 +62,14 @@ class PostgreSQLUnspecifiedBinaryProtocolValueTest {
     
     @Test
     void assertRead() {
-        String timestampStr = "2020-08-23 15:57:03+08";
-        int expectedLength = 4 + timestampStr.length();
-        ByteBuf readBuf = ByteBufTestUtils.createByteBuf(expectedLength);
-        readBuf.writeInt(timestampStr.length());
-        readBuf.writeCharSequence(timestampStr, StandardCharsets.ISO_8859_1);
-        readBuf.readInt();
-        PostgreSQLPacketPayload readPayload = new PostgreSQLPacketPayload(readBuf, StandardCharsets.UTF_8);
-        Object actual = new PostgreSQLUnspecifiedBinaryProtocolValue().read(readPayload, timestampStr.length());
+        String expected = "中文";
+        byte[] bytes = expected.getBytes(StandardCharsets.UTF_16BE);
+        ByteBuf readBuf = Unpooled.wrappedBuffer(bytes);
+        PostgreSQLPacketPayload readPayload = new PostgreSQLPacketPayload(readBuf, StandardCharsets.UTF_16BE);
+        Object actual = new PostgreSQLUnspecifiedBinaryProtocolValue().read(readPayload, bytes.length);
         assertThat(actual, isA(PostgreSQLTypeUnspecifiedSQLParameter.class));
-        assertThat(actual.toString(), is(timestampStr));
-        assertThat(readBuf.readerIndex(), is(expectedLength));
+        assertThat(actual.toString(), is(expected));
+        assertThat(readBuf.readerIndex(), is(bytes.length));
     }
     
     @Test

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.database.protocol.postgresql.packet.command.qu
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import org.apache.shardingsphere.database.protocol.postgresql.packet.ByteBufTestUtils;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.bind.PostgreSQLTypeUnspecifiedSQLParameter;
 import org.apache.shardingsphere.database.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +63,21 @@ class PostgreSQLUnspecifiedBinaryProtocolValueTest {
     
     @Test
     void assertRead() {
+        String timestampStr = "2020-08-23 15:57:03+08";
+        int expectedLength = 4 + timestampStr.length();
+        ByteBuf readBuf = ByteBufTestUtils.createByteBuf(expectedLength);
+        readBuf.writeInt(timestampStr.length());
+        readBuf.writeCharSequence(timestampStr, StandardCharsets.ISO_8859_1);
+        readBuf.readInt();
+        PostgreSQLPacketPayload readPayload = new PostgreSQLPacketPayload(readBuf, StandardCharsets.UTF_8);
+        Object actual = new PostgreSQLUnspecifiedBinaryProtocolValue().read(readPayload, timestampStr.length());
+        assertThat(actual, isA(PostgreSQLTypeUnspecifiedSQLParameter.class));
+        assertThat(actual.toString(), is(timestampStr));
+        assertThat(readBuf.readerIndex(), is(expectedLength));
+    }
+    
+    @Test
+    void assertReadWithMultiByteCharset() {
         String expected = "中文";
         byte[] bytes = expected.getBytes(StandardCharsets.UTF_16BE);
         ByteBuf readBuf = Unpooled.wrappedBuffer(bytes);


### PR DESCRIPTION
Changes proposed in this pull request:
- Decode PostgreSQL `VARCHAR`, `CHAR`, and unspecified binary bind values with the packet payload charset.
- Strengthen both read tests with non-ASCII values encoded using a non-default multibyte charset.

The PostgreSQL frontend stores its negotiated charset in `PostgreSQLPacketPayload`. The affected readers used `new String(byte[])`, which instead depends on the JVM default charset. When those charsets differ, non-ASCII binary bind values are corrupted before reaching statement execution. The write and column-length paths already use the payload charset.

Verification:
- `./mvnw -pl database/protocol/dialect/postgresql -DskipITs test` (356 tests)
- Focused tests: 8 tests
- Target-class JaCoCo CLASS/LINE/BRANCH coverage: 100%
- `./mvnw checkstyle:check -Pcheck -T1C`
- `./mvnw spotless:apply -Pcheck -T1C`

Documentation and release notes are not changed because this restores the existing payload-charset contract without changing configuration or public APIs.
