### PR TITLE
Parse SQLServer column NOT NULL constraints

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,7 @@
 1. SQL Parser: Preserve unary NOT as NotExpression for scalar-subquery table extraction in PostgreSQL - [#38187](https://github.com/apache/shardingsphere/pull/38187)
 1. SQL Parser: Fix wrong parameter index parse in MySQL, Doris - [#38624](https://github.com/apache/shardingsphere/pull/38624)
 1. SQL Parser: Fix reversed parameter marker order for openGauss `LIMIT offset, row-count` - [#39242](https://github.com/apache/shardingsphere/pull/39242)
+1. SQL Parser: Preserve SQLServer `CREATE TABLE` column nullability metadata - [#39414](https://github.com/apache/shardingsphere/pull/39414)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)

--- a/parser/sql/engine/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/engine/sqlserver/visitor/statement/type/SQLServerDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/engine/sqlserver/visitor/statement/type/SQLServerDDLStatementVisitor.java
@@ -184,8 +184,8 @@ public final class SQLServerDDLStatementVisitor extends SQLServerStatementVisito
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
         DataTypeSegment dataType = (DataTypeSegment) visit(ctx.dataType());
         boolean isPrimaryKey = isPrimaryKey(ctx);
-        // TODO parse not null
-        ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, false, getText(ctx));
+        boolean isNotNull = ctx.columnDefinitionOption().stream().anyMatch(each -> null != each.NOT() && null != each.NULL());
+        ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, isNotNull, getText(ctx));
         for (ColumnDefinitionOptionContext each : ctx.columnDefinitionOption()) {
             for (ColumnConstraintContext columnConstraint : each.columnConstraint()) {
                 if (null != columnConstraint.columnForeignKeyConstraint()) {

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -427,6 +427,16 @@
         </column-definition>
     </create-table>
 
+    <create-table sql-case-id="create_table_with_explicit_column_nullability_sqlserver">
+        <table name="t_order" start-index="13" stop-index="19" />
+        <column-definition type="INT" not-null="true" start-index="22" stop-index="42">
+            <column name="order_id" />
+        </column-definition>
+        <column-definition type="INT" not-null="false" start-index="45" stop-index="60">
+            <column name="user_id" />
+        </column-definition>
+    </create-table>
+
     <create-table sql-case-id="create_table_with_column_default">
         <table name="t_order" start-index="13" stop-index="19" />
         <column-definition type="INT" start-index="22" stop-index="43">

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -62,6 +62,7 @@
     <sql-case id="create_temporary_table" value="CREATE TEMPORARY TABLE t_order (order_id INT, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL" />
     <sql-case id="create_table_with_column_not_null" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL,Oracle,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="create_table_with_explicit_column_nullability_postgresql" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT NULL)" db-types="PostgreSQL" />
+    <sql-case id="create_table_with_explicit_column_nullability_sqlserver" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT NULL)" db-types="SQLServer" />
     <sql-case id="create_table_with_column_default" value="CREATE TABLE t_order (order_id INT DEFAULT 0, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="create_table_with_column_increment" value="CREATE TABLE t_order (order_id INT AUTO_INCREMENT, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL" />
     <sql-case id="create_table_with_column_generated" value="CREATE TABLE t_order (order_id INT GENERATED ALWAYS AS (user_id * 2), user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL" />


### PR DESCRIPTION
Fixes SQLServer `CREATE TABLE` column nullability metadata.

### Problem

The SQLServer grammar accepts column-level `NULL` and `NOT NULL`, but `SQLServerDDLStatementVisitor` always constructed `ColumnDefinitionSegment` with `notNull=false`.

Microsoft documents `{ NULL | NOT NULL }` as part of a SQLServer column definition: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql

### Change

- Detect a SQLServer column option containing both `NOT` and `NULL`.
- Preserve `notNull=false` for an explicit `NULL` option.
- Add one focused parser case that asserts both boundaries.

### Verification

- RED: the new SQLServer parser case was the only failure among 771 tests before the visitor change (`expected true, actual false`).
- `InternalSQLServerParserIT`: 771 tests passed.
- SQLServer parser module: passed.
- Spotless: passed.
- Checkstyle: 0 violations.