### PR TITLE
fix: add SYSTEM_USER to PostgreSQL unparenthesized function names [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/option/PostgreSQLFunctionOption.java
+++ b/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/option/PostgreSQLFunctionOption.java
@@ -30,7 +30,7 @@ public final class PostgreSQLFunctionOption implements DialectFunctionOption {
     
     private static final Collection<String> UNPARENTHESIZED_FUNCTION_NAMES = new CaseInsensitiveSet<>(Arrays.asList(
             "CURRENT_CATALOG", "CURRENT_DATE", "CURRENT_ROLE", "CURRENT_SCHEMA", "CURRENT_TIME",
-            "CURRENT_TIMESTAMP", "CURRENT_USER", "LOCALTIME", "LOCALTIMESTAMP", "SESSION_USER", "USER"));
+            "CURRENT_TIMESTAMP", "CURRENT_USER", "LOCALTIME", "LOCALTIMESTAMP", "SESSION_USER", "SYSTEM_USER", "USER"));
     
     @Override
     public Collection<String> getUnparenthesizedFunctionNames() {

--- a/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/option/PostgreSQLFunctionOptionTest.java
+++ b/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/option/PostgreSQLFunctionOptionTest.java
@@ -37,6 +37,7 @@ class PostgreSQLFunctionOptionTest {
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("LOCALTIME"));
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("LOCALTIMESTAMP"));
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("SESSION_USER"));
+        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("SYSTEM_USER"));
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("USER"));
     }
 }


### PR DESCRIPTION
Fixes #39384

## Changes

Added `SYSTEM_USER` to `PostgreSQLFunctionOption.UNPARENTHESIZED_FUNCTION_NAMES` so that the PostgreSQL dialect correctly binds the niladic function `SYSTEM_USER` instead of misclassifying it as a column reference.

## Root Cause

`PostgreSQLFunctionOption` (line 31-33) lists 11 unparenthesized function names and omits `SYSTEM_USER`. `ColumnSegmentBinder.isUnparenthesizedFunction()` reads this set via `.contains()` to decide function vs column. When the lookup fails, `bind()` throws `ColumnNotFoundException`.

`MySQLFunctionOption` and `SQLServerFunctionOption` already include `SYSTEM_USER`.

## Verification

- `SELECT SYSTEM_USER` against a PostgreSQL-typed schema now correctly binds as a niladic function
- No grammar change required (SYSTEM_USER already lexes as an identifier in PostgreSQL)
- openGauss inherits this change via `OpenGaussDatabaseMetaData` which returns `new PostgreSQLFunctionOption()`

Signed-off-by: waterWang <waterWang@users.noreply.github.com>