### PR TITLE
Add PostgreSQL column nullability release note

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,7 @@
 1. SQL Parser: Preserve unary NOT as NotExpression for scalar-subquery table extraction in PostgreSQL - [#38187](https://github.com/apache/shardingsphere/pull/38187)
 1. SQL Parser: Fix wrong parameter index parse in MySQL, Doris - [#38624](https://github.com/apache/shardingsphere/pull/38624)
 1. SQL Parser: Fix reversed parameter marker order for openGauss `LIMIT offset, row-count` - [#39242](https://github.com/apache/shardingsphere/pull/39242)
+1. SQL Parser: Preserve PostgreSQL `CREATE TABLE` column nullability metadata - [#39412](https://github.com/apache/shardingsphere/pull/39412)
 1. SQL Parser: Preserve SQLServer `CREATE TABLE` column nullability metadata - [#39414](https://github.com/apache/shardingsphere/pull/39414)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)


### PR DESCRIPTION
Add the missing ShardingSphere 5.5.4 bug-fix release note for #39412.

The entry records that the PostgreSQL SQL parser now preserves `CREATE TABLE` column nullability metadata.

### Verification

- Spotless passed.
- Checkstyle reported 0 violations.
- `git diff --check` passed.