### PR TITLE
Parse MySQL modified column NOT NULL constraints

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,7 @@
 1. SQL Parser: Fix reversed parameter marker order for openGauss `LIMIT offset, row-count` - [#39242](https://github.com/apache/shardingsphere/pull/39242)
 1. SQL Parser: Preserve PostgreSQL `CREATE TABLE` column nullability metadata - [#39412](https://github.com/apache/shardingsphere/pull/39412)
 1. SQL Parser: Preserve SQLServer `CREATE TABLE` column nullability metadata - [#39414](https://github.com/apache/shardingsphere/pull/39414)
+1. SQL Parser: Preserve MySQL `ALTER TABLE MODIFY COLUMN` nullability metadata - [#39421](https://github.com/apache/shardingsphere/pull/39421)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)

--- a/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/type/MySQLDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/type/MySQLDDLStatementVisitor.java
@@ -385,8 +385,8 @@ public final class MySQLDDLStatementVisitor extends MySQLStatementVisitor implem
         DataTypeSegment dataTypeSegment = (DataTypeSegment) visit(ctx.dataType());
         boolean isPrimaryKey = ctx.columnAttribute().stream().anyMatch(each -> null != each.KEY() && null == each.UNIQUE());
         boolean isAutoIncrement = ctx.columnAttribute().stream().anyMatch(each -> null != each.AUTO_INCREMENT());
-        // TODO parse not null
-        ColumnDefinitionSegment result = new ColumnDefinitionSegment(column.getStartIndex(), ctx.getStop().getStopIndex(), column, dataTypeSegment, isPrimaryKey, false, getText(ctx));
+        boolean isNotNull = ctx.columnAttribute().stream().anyMatch(each -> null != each.NOT() && null != each.NULL());
+        ColumnDefinitionSegment result = new ColumnDefinitionSegment(column.getStartIndex(), ctx.getStop().getStopIndex(), column, dataTypeSegment, isPrimaryKey, isNotNull, getText(ctx));
         result.setAutoIncrement(isAutoIncrement);
         return result;
     }

--- a/test/it/parser/src/main/resources/case/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-table.xml
@@ -851,7 +851,7 @@
     <alter-table sql-case-id="alter_table_modify_unsigned_not_null">
         <table name="t1" start-index="12" stop-index="13" />
         <modify-column>
-            <column-definition type="real" start-index="22" stop-index="46">
+            <column-definition type="real" not-null="true" start-index="22" stop-index="46">
                 <column name="c1" />
             </column-definition>
         </modify-column>
@@ -860,7 +860,16 @@
     <alter-table sql-case-id="alter_table_modify_unsigned_zerofill_not_null">
         <table name="t1" start-index="12" stop-index="13" />
         <modify-column>
-            <column-definition type="real" start-index="22" stop-index="55">
+            <column-definition type="real" not-null="true" start-index="22" stop-index="55">
+                <column name="c1" />
+            </column-definition>
+        </modify-column>
+    </alter-table>
+
+    <alter-table sql-case-id="alter_table_modify_explicit_null">
+        <table name="t1" start-index="12" stop-index="13" />
+        <modify-column>
+            <column-definition type="real" not-null="false" start-index="22" stop-index="33">
                 <column name="c1" />
             </column-definition>
         </modify-column>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
@@ -54,6 +54,7 @@
     <sql-case id="alter_table_change_unsigned_not_null" value="alter table t1 change c1 c2 real unsigned not null" db-types="MySQL" />
     <sql-case id="alter_table_modify_unsigned_not_null" value="alter table t1 modify c1 real unsigned not null" db-types="MySQL" />
     <sql-case id="alter_table_modify_unsigned_zerofill_not_null" value="alter table t1 modify c1 real unsigned zerofill not null" db-types="MySQL" />
+    <sql-case id="alter_table_modify_explicit_null" value="alter table t1 modify c1 real null" db-types="MySQL" />
     <sql-case id="alter_table_change_unsigned_zerofill_not_null" value="alter table t1 change c1 c2 real unsigned zerofill not null" db-types="MySQL" />
     <sql-case id="alter_table_add_partition" value="alter table t1 add partition partitions 10" db-types="MySQL" />
     <sql-case id="alter_table_add_partition_nested_table_col_properties" value="ALTER TABLE print_media_part ADD PARTITION p4 VALUES LESS THAN (400) LOB(ad_photo, ad_composite) STORE AS (TABLESPACE omf_ts1) LOB(ad_sourcetext, ad_finaltext) STORE AS (TABLESPACE omf_ts1) NESTED TABLE ad_textdocs_ntab STORE AS nt_p3" db-types="Oracle" />


### PR DESCRIPTION
Fix MySQL `ALTER TABLE ... MODIFY COLUMN` nullability metadata.

### Problem

The MySQL grammar accepts `NULL` and `NOT NULL` in a modified column definition, but the MODIFY visitor always constructed `ColumnDefinitionSegment` with `notNull=false`.

MySQL documents `MODIFY [COLUMN] col_name column_definition` in `ALTER TABLE`: https://dev.mysql.com/doc/refman/8.4/en/alter-table.html

### Change

- Detect `NOT NULL` in the MODIFY column's existing `columnAttribute` AST.
- Assert both existing `UNSIGNED [ZEROFILL] NOT NULL` parser cases.
- Add an explicit `NULL` counter-boundary.
- Add the ShardingSphere 5.5.4 bug-fix release note.

### Verification

- RED: the two existing MODIFY NOT NULL cases were the only failures among 1,898 MySQL parser tests before the visitor change.
- `InternalMySQLParserIT`: 1,898 tests passed.
- MySQL parser module: 7 tests passed.
- Spotless passed.
- Checkstyle reported 0 violations.
- `git diff --check` passed.
