### PR TITLE
Optimize handling of SingleRuleConfiguration in metadata persistence

### DIFF
--- a/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistService.java
+++ b/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistService.java
@@ -202,6 +202,17 @@ public final class ClusterMetaDataManagerPersistService implements MetaDataManag
             return;
         }
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaDataContextManager.getMetaDataContexts().getMetaData(), metaDataContextManager.getMetaDataContexts().getStatistics());
+        if (toBeAlteredRuleConfig instanceof SingleRuleConfiguration) {
+            alterSingleRuleConfigurationItem(database, (SingleRuleConfiguration) toBeAlteredRuleConfig, originalMetaDataContexts);
+            return;
+        }
+        metaDataPersistFacade.getDatabaseRuleService().persist(database.getName(), Collections.singleton(toBeAlteredRuleConfig));
+        MetaDataContexts reloadMetaDataContexts = getReloadedMetaDataContexts(originalMetaDataContexts);
+        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(database.getName(), rebuildDatabaseSchemaIndex(database.getName(), reloadMetaDataContexts),
+                originalMetaDataContexts.getMetaData().getDatabase(database.getName()));
+    }
+    
+    private void alterSingleRuleConfigurationItem(final ShardingSphereDatabase database, final SingleRuleConfiguration toBeAlteredRuleConfig, final MetaDataContexts originalMetaDataContexts) {
         metaDataPersistFacade.getDatabaseRuleService().persist(database.getName(), Collections.singleton(toBeAlteredRuleConfig));
         MetaDataContexts reloadMetaDataContexts = getReloadedMetaDataContexts(originalMetaDataContexts);
         metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(database.getName(), rebuildDatabaseSchemaIndex(database.getName(), reloadMetaDataContexts),
@@ -215,7 +226,7 @@ public final class ClusterMetaDataManagerPersistService implements MetaDataManag
         }
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaDataContextManager.getMetaDataContexts().getMetaData(), metaDataContextManager.getMetaDataContexts().getStatistics());
         if (toBeRemovedRuleItemConfig instanceof SingleRuleConfiguration) {
-            removeSingleRuleConfiguration(database, toBeRemovedRuleItemConfig, originalMetaDataContexts);
+            removeSingleRuleConfigurationItem(database, (SingleRuleConfiguration) toBeRemovedRuleItemConfig, originalMetaDataContexts);
             return;
         }
         Collection<String> needReloadTables = toBeRemovedRuleItemConfig.getLogicTableNames();
@@ -223,11 +234,16 @@ public final class ClusterMetaDataManagerPersistService implements MetaDataManag
         metaDataPersistFacade.getDatabaseMetaDataFacade().persistAlteredTables(database.getName(), getReloadedMetaDataContexts(originalMetaDataContexts), needReloadTables);
     }
     
+    private void removeSingleRuleConfigurationItem(final ShardingSphereDatabase database, final SingleRuleConfiguration toBeRemovedRuleItemConfig, final MetaDataContexts originalMetaDataContexts) {
+        metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
+        persistReloadDatabaseByUnloadSingleTable(database, originalMetaDataContexts);
+    }
+    
     @Override
     public void removeRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleConfig, final String ruleType) {
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaDataContextManager.getMetaDataContexts().getMetaData(), metaDataContextManager.getMetaDataContexts().getStatistics());
         if (toBeRemovedRuleConfig instanceof SingleRuleConfiguration) {
-            removeSingleRuleConfiguration(database, toBeRemovedRuleConfig, originalMetaDataContexts);
+            removeSingleRuleConfiguration(database, (SingleRuleConfiguration) toBeRemovedRuleConfig, originalMetaDataContexts);
             return;
         }
         Collection<String> needReloadTables = toBeRemovedRuleConfig.getLogicTableNames();
@@ -235,8 +251,12 @@ public final class ClusterMetaDataManagerPersistService implements MetaDataManag
         metaDataPersistFacade.getDatabaseMetaDataFacade().persistAlteredTables(database.getName(), getReloadedMetaDataContexts(originalMetaDataContexts), needReloadTables);
     }
     
-    private void removeSingleRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleItemConfig, final MetaDataContexts originalMetaDataContexts) {
-        metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
+    private void removeSingleRuleConfiguration(final ShardingSphereDatabase database, final SingleRuleConfiguration toBeRemovedRuleConfig, final MetaDataContexts originalMetaDataContexts) {
+        metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleConfig));
+        persistReloadDatabaseByUnloadSingleTable(database, originalMetaDataContexts);
+    }
+    
+    private void persistReloadDatabaseByUnloadSingleTable(final ShardingSphereDatabase database, final MetaDataContexts originalMetaDataContexts) {
         metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(database.getName(),
                 rebuildDatabaseSchemaIndex(database.getName(), getReloadedMetaDataContexts(originalMetaDataContexts)),
                 originalMetaDataContexts.getMetaData().getDatabase(database.getName()));

--- a/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
+++ b/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
@@ -162,7 +162,7 @@ class ClusterMetaDataManagerPersistServiceTest {
     }
     
     @Test
-    void assertAlterRuleConfiguration() {
+    void assertAlterRuleConfigurationWithSingleRule() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, Answers.RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");
         when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
@@ -172,6 +172,22 @@ class ClusterMetaDataManagerPersistServiceTest {
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
         when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
         RuleConfiguration ruleConfig = new SingleRuleConfiguration();
+        metaDataManagerPersistService.alterRuleConfiguration(database, ruleConfig);
+        verify(metaDataPersistFacade.getDatabaseRuleService()).persist("foo_db", Collections.singleton(ruleConfig));
+        verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistReloadDatabase(eq("foo_db"), any(), any());
+    }
+    
+    @Test
+    void assertAlterRuleConfiguration() {
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, Answers.RETURNS_DEEP_STUBS);
+        when(database.getName()).thenReturn("foo_db");
+        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+        ShardingSphereRule rule = mock(ShardingSphereRule.class);
+        when(rule.getAttributes()).thenReturn(new RuleAttributes());
+        when(database.getRuleMetaData().getRules()).thenReturn(Collections.singleton(rule));
+        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
+        when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
+        RuleConfiguration ruleConfig = mock(RuleConfiguration.class);
         metaDataManagerPersistService.alterRuleConfiguration(database, ruleConfig);
         verify(metaDataPersistFacade.getDatabaseRuleService()).persist("foo_db", Collections.singleton(ruleConfig));
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistReloadDatabase(eq("foo_db"), any(), any());

--- a/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
+++ b/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
@@ -219,7 +219,19 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
         if (null == toBeAlteredRuleConfig) {
             return;
         }
-        Collection<String> needReloadTables = getNeedReloadTables(database, toBeAlteredRuleConfig);
+        if (toBeAlteredRuleConfig instanceof SingleRuleConfiguration) {
+            alterSingleRuleConfigurationItem(database, (SingleRuleConfiguration) toBeAlteredRuleConfig);
+            return;
+        }
+        Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().persist(database.getName(), Collections.singleton(toBeAlteredRuleConfig));
+        alterRuleItem(database.getName(), metaDataVersions);
+        persistAndAlterSchemaTables(database, toBeAlteredRuleConfig.getLogicTableNames());
+        clearServicesCache();
+    }
+    
+    private void alterSingleRuleConfigurationItem(final ShardingSphereDatabase database, final SingleRuleConfiguration toBeAlteredRuleConfig) {
+        Collection<String> originalSingleTables = database.getRuleMetaData().getSingleRule(SingleRule.class).getConfiguration().getLogicTableNames();
+        Collection<String> needReloadTables = toBeAlteredRuleConfig.getLogicTableNames().stream().filter(each -> !originalSingleTables.contains(each)).collect(Collectors.toList());
         Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().persist(database.getName(), Collections.singleton(toBeAlteredRuleConfig));
         alterRuleItem(database.getName(), metaDataVersions);
         persistAndAlterSchemaTables(database, needReloadTables);
@@ -243,18 +255,20 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
             return;
         }
         if (toBeRemovedRuleItemConfig instanceof SingleRuleConfiguration) {
-            Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
-            removeRuleItem(database.getName(), metaDataVersions);
-            ShardingSphereDatabase reloadedDatabase = rebuildDatabaseSchemaIndex(database.getName(), metaDataContextManager.getMetaDataContexts());
-            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
-                    database.getName(), reloadedDatabase, database);
-            clearServicesCache();
+            removeSingleRuleConfigurationItem(database, (SingleRuleConfiguration) toBeRemovedRuleItemConfig);
             return;
         }
-        Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleItemConfig);
         Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
         removeRuleItem(database.getName(), metaDataVersions);
-        persistAndAlterSchemaTables(database, needReloadTables);
+        persistAndAlterSchemaTables(database, toBeRemovedRuleItemConfig.getLogicTableNames());
+        clearServicesCache();
+    }
+    
+    private void removeSingleRuleConfigurationItem(final ShardingSphereDatabase database, final SingleRuleConfiguration toBeRemovedRuleItemConfig) {
+        Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
+        removeRuleItem(database.getName(), metaDataVersions);
+        ShardingSphereDatabase reloadedDatabase = rebuildDatabaseSchemaIndex(database.getName(), metaDataContextManager.getMetaDataContexts());
+        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(database.getName(), reloadedDatabase, database);
         clearServicesCache();
     }
     
@@ -264,14 +278,6 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
             ruleItemChangedNodePathBuilder.build(databaseName, NodePathGenerator.toPath(each.getNodePath()), Type.DELETED)
                     .ifPresent(optional -> metaDataContextManager.getDatabaseRuleItemManager().drop(optional));
         }
-    }
-    
-    private Collection<String> getNeedReloadTables(final ShardingSphereDatabase originalDatabase, final RuleConfiguration toBeAlteredRuleConfig) {
-        if (toBeAlteredRuleConfig instanceof SingleRuleConfiguration) {
-            Collection<String> originalSingleTables = originalDatabase.getRuleMetaData().getSingleRule(SingleRule.class).getConfiguration().getLogicTableNames();
-            return toBeAlteredRuleConfig.getLogicTableNames().stream().filter(each -> !originalSingleTables.contains(each)).collect(Collectors.toList());
-        }
-        return toBeAlteredRuleConfig.getLogicTableNames();
     }
     
     private void alterSchemaTables(final ShardingSphereDatabase database, final Map<String, Collection<ShardingSphereTable>> schemaAndTablesMap) {
@@ -285,18 +291,20 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
     @Override
     public void removeRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleConfig, final String ruleType) {
         if (toBeRemovedRuleConfig instanceof SingleRuleConfiguration) {
-            metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
-            metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));
-            ShardingSphereDatabase reloadedDatabase = rebuildDatabaseSchemaIndex(database.getName(), metaDataContextManager.getMetaDataContexts());
-            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
-                    database.getName(), reloadedDatabase, database);
-            clearServicesCache();
+            removeSingleRuleConfiguration(database, ruleType);
             return;
         }
-        Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleConfig);
         metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
         metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));
-        persistAndAlterSchemaTables(database, needReloadTables);
+        persistAndAlterSchemaTables(database, toBeRemovedRuleConfig.getLogicTableNames());
+        clearServicesCache();
+    }
+    
+    private void removeSingleRuleConfiguration(final ShardingSphereDatabase database, final String ruleType) {
+        metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
+        metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));
+        ShardingSphereDatabase reloadedDatabase = rebuildDatabaseSchemaIndex(database.getName(), metaDataContextManager.getMetaDataContexts());
+        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(database.getName(), reloadedDatabase, database);
         clearServicesCache();
     }
     

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -178,6 +178,23 @@ class StandaloneMetaDataManagerPersistServiceTest {
     }
     
     @Test
+    void assertAlterRuleConfigurationWithSingleRule() {
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getName()).thenReturn("foo_db");
+        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+        SingleRule singleRule = mock(SingleRule.class);
+        when(singleRule.getConfiguration()).thenReturn(new SingleRuleConfiguration(Collections.singleton("foo_ds.foo_tbl"), null));
+        when(singleRule.getAttributes()).thenReturn(new RuleAttributes());
+        when(database.getRuleMetaData()).thenReturn(new RuleMetaData(Collections.singleton(singleRule)));
+        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
+        when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
+        SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Arrays.asList("foo_ds.foo_tbl", "foo_ds.bar_tbl"), null);
+        metaDataManagerPersistService.alterRuleConfiguration(database, ruleConfig);
+        verify(metaDataPersistFacade.getDatabaseRuleService()).persist("foo_db", Collections.singleton(ruleConfig));
+        verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistAlteredTables(eq("foo_db"), any(), eq(Collections.singletonList("bar_tbl")));
+    }
+    
+    @Test
     void assertRemoveNullRuleConfigurationItem() {
         metaDataManagerPersistService.removeRuleConfigurationItem(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
                 null);


### PR DESCRIPTION

Changes proposed in this pull request:
  - Optimize handling of SingleRuleConfiguration in metadata persistence

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
