### PR TITLE
Parse Firebird column NOT NULL constraints

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 1. SQL Parser: Preserve PostgreSQL `CREATE TABLE` column nullability metadata - [#39412](https://github.com/apache/shardingsphere/pull/39412)
 1. SQL Parser: Preserve SQLServer `CREATE TABLE` column nullability metadata - [#39414](https://github.com/apache/shardingsphere/pull/39414)
 1. SQL Parser: Preserve MySQL `ALTER TABLE MODIFY COLUMN` nullability metadata - [#39421](https://github.com/apache/shardingsphere/pull/39421)
+1. SQL Parser: Preserve Firebird `CREATE TABLE` column nullability metadata - [#39423](https://github.com/apache/shardingsphere/pull/39423)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)

--- a/parser/sql/engine/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/engine/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/engine/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
@@ -144,7 +144,8 @@ public final class FirebirdDDLStatementVisitor extends FirebirdStatementVisitor 
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
         DataTypeSegment dataType = null == ctx.dataType() ? null : (DataTypeSegment) visit(ctx.dataType());
         boolean isPrimaryKey = ctx.dataTypeOption().stream().anyMatch(each -> null != each.primaryKey());
-        ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, false, getText(ctx));
+        boolean isNotNull = ctx.dataTypeOption().stream().anyMatch(each -> null != each.NOT() && null != each.NULL());
+        ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, isNotNull, getText(ctx));
         for (DataTypeOptionContext each : ctx.dataTypeOption()) {
             if (null != each.referenceDefinition()) {
                 result.getReferencedTables().add((SimpleTableSegment) visit(each.referenceDefinition().tableName()));

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -4301,6 +4301,16 @@
         </constraint-definition>
     </create-table>
 
+    <create-table sql-case-id="create_table_with_column_not_null_firebird">
+        <table name="t_order" start-index="13" stop-index="19" />
+        <column-definition type="INT" not-null="true" start-index="22" stop-index="42">
+            <column name="order_id" />
+        </column-definition>
+        <column-definition type="INT" not-null="false" start-index="45" stop-index="55">
+            <column name="user_id" />
+        </column-definition>
+    </create-table>
+
     <create-table sql-case-id="create_table_with_ref_column_oracle">
         <table name="ref_table" start-index="13" stop-index="21" />
         <column-definition type="person_t" start-index="24" stop-index="43">

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -545,6 +545,7 @@
     <sql-case id="create_table_with_blob_segment_size" value="CREATE TABLE t_blob_segment (payload BLOB SUB_TYPE 0 SEGMENT SIZE 80)" db-types="Firebird" />
     <sql-case id="create_table_firebird_len" value="CREATE TABLE t_firebird_len (id INT PRIMARY KEY, amount DECIMAL(10,2), code CHAR(5))" db-types="Firebird" />
     <sql-case id="create_table_firebird_constraint" value="CREATE TABLE t_firebird_constraint (id INT, CONSTRAINT pk_t PRIMARY KEY (id), CONSTRAINT fk_t FOREIGN KEY (id) REFERENCES t_firebird_len(id))" db-types="Firebird" />
+    <sql-case id="create_table_with_column_not_null_firebird" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT)" db-types="Firebird" />
     <sql-case id="create_table_with_ref_column_oracle" value="CREATE TABLE ref_table (ref_col REF person_t)" db-types="Oracle" />
     <sql-case id="create_table_with_varchar2_char_length_oracle" value="CREATE TABLE dt_len (c VARCHAR2(10 CHAR))" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fix Firebird `CREATE TABLE` column nullability metadata.

### Problem

The Firebird grammar accepts column-level `NOT NULL`, but `FirebirdDDLStatementVisitor` always constructed `ColumnDefinitionSegment` with `notNull=false`.

Firebird 5.0 documents `NOT NULL` as a column constraint: https://firebirdsql.org/file/documentation/chunk/en/refdocs/fblangref50/fblangref50-ddl-table.html

### Change

- Detect `NOT NULL` in the existing `dataTypeOption` AST.
- Add a focused Firebird parser case covering `NOT NULL` and default nullable behavior.
- Add the ShardingSphere 5.5.4 bug-fix release note.

### Verification

- RED: the new case was the only failure among 234 Firebird parser tests before the visitor change.
- `InternalFirebirdParserIT`: 234 tests passed.
- Firebird parser module passed.
- Spotless passed.
- Checkstyle reported 0 violations.
- `git diff --check` passed.
