### PR TITLE
Parse openGauss column nullability constraints

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 1. SQL Parser: Preserve SQLServer `CREATE TABLE` column nullability metadata - [#39414](https://github.com/apache/shardingsphere/pull/39414)
 1. SQL Parser: Preserve MySQL `ALTER TABLE MODIFY COLUMN` nullability metadata - [#39421](https://github.com/apache/shardingsphere/pull/39421)
 1. SQL Parser: Preserve Firebird `CREATE TABLE` column nullability metadata - [#39423](https://github.com/apache/shardingsphere/pull/39423)
+1. SQL Parser: Preserve openGauss `CREATE TABLE` column nullability metadata - [#39425](https://github.com/apache/shardingsphere/pull/39425)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)

--- a/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
@@ -456,8 +456,8 @@ public final class OpenGaussDDLStatementVisitor extends OpenGaussStatementVisito
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
         DataTypeSegment dataType = (DataTypeSegment) visit(ctx.dataType());
         boolean isPrimaryKey = ctx.columnConstraint().stream().anyMatch(each -> null != each.columnConstraintOption() && null != each.columnConstraintOption().primaryKey());
-        // TODO parse not null
-        ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, false, getText(ctx));
+        boolean isNotNull = ctx.columnConstraint().stream().anyMatch(each -> null != each.columnConstraintOption().NOT() && null != each.columnConstraintOption().NULL());
+        ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, isNotNull, getText(ctx));
         for (ColumnConstraintContext each : ctx.columnConstraint()) {
             if (null != each.columnConstraintOption().tableName()) {
                 result.getReferencedTables().add((SimpleTableSegment) visit(each.columnConstraintOption().tableName()));

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -427,6 +427,16 @@
         </column-definition>
     </create-table>
 
+    <create-table sql-case-id="create_table_with_explicit_column_nullability_opengauss">
+        <table name="t_order" start-index="13" stop-index="19" />
+        <column-definition type="INT" not-null="true" start-index="22" stop-index="42">
+            <column name="order_id" />
+        </column-definition>
+        <column-definition type="INT" not-null="false" start-index="45" stop-index="60">
+            <column name="user_id" />
+        </column-definition>
+    </create-table>
+
     <create-table sql-case-id="create_table_with_explicit_column_nullability_sqlserver">
         <table name="t_order" start-index="13" stop-index="19" />
         <column-definition type="INT" not-null="true" start-index="22" stop-index="42">

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -62,6 +62,7 @@
     <sql-case id="create_temporary_table" value="CREATE TEMPORARY TABLE t_order (order_id INT, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL" />
     <sql-case id="create_table_with_column_not_null" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL,Oracle,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="create_table_with_explicit_column_nullability_postgresql" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT NULL)" db-types="PostgreSQL" />
+    <sql-case id="create_table_with_explicit_column_nullability_opengauss" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT NULL)" db-types="openGauss" />
     <sql-case id="create_table_with_explicit_column_nullability_sqlserver" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT NULL)" db-types="SQLServer" />
     <sql-case id="create_table_with_column_default" value="CREATE TABLE t_order (order_id INT DEFAULT 0, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="create_table_with_column_increment" value="CREATE TABLE t_order (order_id INT AUTO_INCREMENT, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL" />


### PR DESCRIPTION
Fix openGauss `CREATE TABLE` column nullability metadata.

### Problem

The openGauss grammar accepts column-level `NOT NULL` and `NULL`, but `OpenGaussDDLStatementVisitor` always constructed `ColumnDefinitionSegment` with `notNull=false`.

The openGauss 6.0 SQL Reference documents `NOT NULL` as disallowing null values and `NULL` as allowing them: https://docs.opengauss.org/en/docs/6.0.0/docs/SQLReference/create-table.html

### Change

- Detect `NOT NULL` in the existing `columnConstraint` AST.
- Add a focused openGauss parser case covering explicit `NOT NULL` and `NULL` behavior.
- Add the ShardingSphere 5.5.4 bug-fix release note.

### Verification

- RED: the new case was the only failure among 923 openGauss parser tests before the visitor change.
- `InternalOpenGaussParserIT`: 923 tests passed.
- openGauss parser module: 3 tests passed.
- Spotless passed.
- Checkstyle reported 0 violations.
- `git diff --check` passed.
