### PR TITLE
Parse Hive column NOT NULL constraints

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 1. SQL Parser: Preserve MySQL `ALTER TABLE MODIFY COLUMN` nullability metadata - [#39421](https://github.com/apache/shardingsphere/pull/39421)
 1. SQL Parser: Preserve Firebird `CREATE TABLE` column nullability metadata - [#39423](https://github.com/apache/shardingsphere/pull/39423)
 1. SQL Parser: Preserve openGauss `CREATE TABLE` column nullability metadata - [#39425](https://github.com/apache/shardingsphere/pull/39425)
+1. SQL Parser: Preserve Hive `CREATE TABLE` column nullability metadata - [#39428](https://github.com/apache/shardingsphere/pull/39428)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)

--- a/parser/sql/engine/dialect/hive/src/main/java/org/apache/shardingsphere/sql/parser/engine/hive/visitor/statement/type/HiveDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/hive/src/main/java/org/apache/shardingsphere/sql/parser/engine/hive/visitor/statement/type/HiveDDLStatementVisitor.java
@@ -250,7 +250,8 @@ public final class HiveDDLStatementVisitor extends HiveStatementVisitor implemen
         ColumnSegment column = new ColumnSegment(ctx.columnName().getStart().getStartIndex(), ctx.columnName().getStop().getStopIndex(),
                 new IdentifierValue(ctx.columnName().getText()));
         DataTypeSegment dataType = (DataTypeSegment) visit(ctx.dataTypeClause());
-        return new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, false, false, getText(ctx));
+        boolean isNotNull = ctx.columnConstraintSpecification().stream().anyMatch(each -> null != each.notNullConstraint());
+        return new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, false, isNotNull, getText(ctx));
     }
     
     @Override

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -3601,7 +3601,7 @@
 
     <create-table sql-case-id="create_table_with_col_not_null_basic">
         <table name="test_col_not_null" start-index="13" stop-index="29" />
-        <column-definition type="STRING" not-null="false" start-index="32" stop-index="51">
+        <column-definition type="STRING" not-null="true" start-index="32" stop-index="51">
             <column name="name" />
         </column-definition>
     </create-table>
@@ -4087,7 +4087,7 @@
         <column-definition type="INT" primary-key="false" start-index="89" stop-index="125">
             <column name="id" />
         </column-definition>
-        <column-definition type="STRING" not-null="false" comment="User name" start-index="140" stop-index="179">
+        <column-definition type="STRING" not-null="true" comment="User name" start-index="140" stop-index="179">
             <column name="name" />
         </column-definition>
         <column-definition type="INT" check-constraint="age&gt;0 AND age&lt;150" start-index="194" stop-index="253">


### PR DESCRIPTION
Fix Hive `CREATE TABLE` column nullability metadata.

### Problem

The Hive grammar accepts column-level `NOT NULL`, but `HiveDDLStatementVisitor` always constructed `ColumnDefinitionSegment` with `notNull=false`. Existing Hive parser expectations therefore encoded the wrong metadata.

Apache Hive documents enforced `NOT NULL` constraints since Hive 3.0.0: https://hive.apache.org/docs/latest/language/languagemanual-ddl/

### Change

- Detect `notNullConstraint` in the existing `columnConstraintSpecification` AST.
- Correct the existing Hive parser expectations for both focused and combined `NOT NULL` cases.
- Add the ShardingSphere 5.5.4 bug-fix release note.

### Verification

- RED: correcting the focused expected result produced the only failure among 775 Hive parser tests before the visitor change.
- `InternalHiveParserIT`: 775 tests passed after correcting both affected expectations.
- Hive parser module: 13 tests passed.
- Spotless passed.
- Checkstyle reported 0 violations.
- `git diff --check` passed.
