### PR TITLE
Fix incorrect AVG(DISTINCT) merge result

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/aggregation/DistinctAverageAggregationUnit.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/aggregation/DistinctAverageAggregationUnit.java
@@ -21,9 +21,9 @@ import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Distinct average aggregation unit.
@@ -35,30 +35,28 @@ public final class DistinctAverageAggregationUnit implements AggregationUnit {
     
     private BigDecimal sum;
     
-    private final Collection<Comparable<?>> countValues = new LinkedHashSet<>();
-    
-    private final Collection<Comparable<?>> sumValues = new LinkedHashSet<>();
+    private final Set<Comparable<?>> distinctValues = new LinkedHashSet<>();
     
     @Override
     public void merge(final List<Comparable<?>> values) {
         if (null == values || null == values.get(0) || null == values.get(1)) {
             return;
         }
-        if (countValues.add(values.get(0)) && sumValues.add(values.get(0))) {
+        if (distinctValues.add(values.get(0))) {
             if (null == count) {
                 count = BigDecimal.ZERO;
             }
             if (null == sum) {
                 sum = BigDecimal.ZERO;
             }
-            count = count.add(new BigDecimal(values.get(0).toString()));
+            count = count.add(BigDecimal.ONE);
             sum = sum.add(new BigDecimal(values.get(1).toString()));
         }
     }
     
     @Override
     public Comparable<?> getResult() {
-        if (null == count || BigDecimal.ZERO.compareTo(count) == 0) {
+        if (null == count) {
             return count;
         }
         // TODO use metadata to fetch float number precise for database field

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/aggregation/DistinctAverageAggregationUnitTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/aggregation/DistinctAverageAggregationUnitTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.merge.dql.groupby.aggregation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DistinctAverageAggregationUnitTest {
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getNullValues")
+    void assertMergeWithNullValue(final String name, final List<Comparable<?>> values) {
+        DistinctAverageAggregationUnit unit = new DistinctAverageAggregationUnit();
+        unit.merge(values);
+        assertNull(unit.getResult());
+    }
+    
+    private static Stream<Arguments> getNullValues() {
+        return Stream.of(
+                Arguments.of("Null values", null),
+                Arguments.of("Null distinct value", Arrays.asList(null, 1)),
+                Arguments.of("Null sum value", Arrays.asList(1, null)));
+    }
+    
+    @Test
+    void assertGetResultWithDistinctValues() {
+        DistinctAverageAggregationUnit unit = new DistinctAverageAggregationUnit();
+        unit.merge(Arrays.asList(1, 1));
+        unit.merge(Arrays.asList(2, 2));
+        unit.merge(Arrays.asList(1, 1));
+        assertThat(unit.getResult(), is(new BigDecimal("1.5000")));
+    }
+    
+    @Test
+    void assertGetResultWithoutMergedValues() {
+        assertNull(new DistinctAverageAggregationUnit().getResult());
+    }
+}


### PR DESCRIPTION
Related to #14432.

Changes proposed in this pull request:
  - Increment the `AVG(DISTINCT)` count by one for each newly accepted distinct value instead of adding the value itself.
  - Keep a single `Set` for distinct-value tracking and remove the unreachable zero-count guard.
  - Add focused unit tests for null inputs, cross-shard duplicate values, and the empty merge result.

Root cause:
The sharding rewrite path emits the raw distinct expression for the derived COUNT and SUM projections of `AVG(DISTINCT)`. The merge unit therefore receives the distinct value in both positions. Adding the first value to `count` produces incorrect results such as `(1 + 2) / (1 + 2) = 1.0000` instead of `1.5000`.

Verification:
- `DistinctAverageAggregationUnitTest`: 5 tests passed.
- JaCoCo target coverage: class 100%, line 100%, branch 100%.
- `./mvnw spotless:apply -Pcheck -T1C`
- `./mvnw checkstyle:check -Pcheck -T1C`
- `./mvnw -pl features/sharding/core -Pcheck spotless:check -DskipTests`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally: `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/).