### PR TITLE
Parse SQLServer altered column nullability

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@
 1. SQL Parser: Preserve Firebird `CREATE TABLE` column nullability metadata - [#39423](https://github.com/apache/shardingsphere/pull/39423)
 1. SQL Parser: Preserve openGauss `CREATE TABLE` column nullability metadata - [#39425](https://github.com/apache/shardingsphere/pull/39425)
 1. SQL Parser: Preserve Hive `CREATE TABLE` column nullability metadata - [#39428](https://github.com/apache/shardingsphere/pull/39428)
+1. SQL Parser: Preserve SQLServer `ALTER TABLE ALTER COLUMN` nullability metadata - [#39430](https://github.com/apache/shardingsphere/pull/39430)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)

--- a/parser/sql/engine/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/engine/sqlserver/visitor/statement/type/SQLServerDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/engine/sqlserver/visitor/statement/type/SQLServerDDLStatementVisitor.java
@@ -309,7 +309,8 @@ public final class SQLServerDDLStatementVisitor extends SQLServerStatementVisito
         // TODO visit pk and table ref
         ColumnSegment column = (ColumnSegment) visit(ctx.alterColumnOperation().columnName());
         DataTypeSegment dataType = (DataTypeSegment) visit(ctx.dataType());
-        ColumnDefinitionSegment columnDefinition = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, false, false, getText(ctx));
+        boolean isNotNull = null != ctx.NOT() && null != ctx.NULL();
+        ColumnDefinitionSegment columnDefinition = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, false, isNotNull, getText(ctx));
         return new ModifyColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), columnDefinition);
     }
     

--- a/test/it/parser/src/main/resources/case/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-table.xml
@@ -1201,6 +1201,24 @@
         </modify-column>
     </alter-table>
 
+    <alter-table sql-case-id="alter_table_alter_column_not_null_sqlserver">
+        <table name="t_order" start-index="12" stop-index="18" />
+        <modify-column>
+            <column-definition type="VARCHAR" not-null="true" start-index="20" stop-index="60">
+                <column name="column4" />
+            </column-definition>
+        </modify-column>
+    </alter-table>
+
+    <alter-table sql-case-id="alter_table_alter_column_null_sqlserver">
+        <table name="t_order" start-index="12" stop-index="18" />
+        <modify-column>
+            <column-definition type="VARCHAR" not-null="false" start-index="20" stop-index="56">
+                <column name="column4" />
+            </column-definition>
+        </modify-column>
+    </alter-table>
+
     <alter-table sql-case-id="alter_table_set_schema">
         <table name="t_order" start-index="12" stop-index="18" />
     </alter-table>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
@@ -142,6 +142,8 @@
     <sql-case id="alter_table_drop_constraints_sqlserver" value="ALTER TABLE t_order DROP CONSTRAINT pk_order_id, uk_order_id, order_index" db-types="SQLServer" />
     <sql-case id="alter_table_alter_column_for_postgresql" value="ALTER TABLE t_order ALTER column4 TYPE VARCHAR(20)" db-types="PostgreSQL,openGauss" />
     <sql-case id="alter_table_alter_column_for_sqlserver" value="ALTER TABLE t_order ALTER COLUMN column4 VARCHAR(20)" db-types="SQLServer" />
+    <sql-case id="alter_table_alter_column_not_null_sqlserver" value="ALTER TABLE t_order ALTER COLUMN column4 VARCHAR(20) NOT NULL" db-types="SQLServer" />
+    <sql-case id="alter_table_alter_column_null_sqlserver" value="ALTER TABLE t_order ALTER COLUMN column4 VARCHAR(20) NULL" db-types="SQLServer" />
     <sql-case id="alter_table_set_schema" value="ALTER TABLE t_order SET SCHEMA yourschema" db-types="PostgreSQL,openGauss" />
     <sql-case id="alter_table_attach_partition" value="ALTER TABLE t_order ATTACH PARTITION measurement_y2016m07 FOR VALUES FROM ('2016-07-01') TO ('2016-08-01')" db-types="PostgreSQL,openGauss" />
     <sql-case id="alter_table_detach_partition" value="ALTER TABLE t_order DETACH PARTITION measurement_y2016m07" db-types="PostgreSQL" />


### PR DESCRIPTION
Fix SQLServer `ALTER TABLE ... ALTER COLUMN` nullability metadata.

### Problem

The SQLServer grammar accepts explicit `NOT NULL` and `NULL` on `ALTER COLUMN`, but `SQLServerDDLStatementVisitor` always constructed `ColumnDefinitionSegment` with `notNull=false`.

Microsoft documents both forms in the `ALTER TABLE` Transact-SQL syntax: https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-ver17

### Change

- Detect `NOT NULL` in the existing `modifyColumnSpecification` AST.
- Add focused SQLServer parser cases covering explicit `NOT NULL` and `NULL` behavior.
- Add the ShardingSphere 5.5.4 bug-fix release note.

### Verification

- RED: the `NOT NULL` case was the only failure among 773 SQLServer parser tests before the visitor change.
- `InternalSQLServerParserIT`: 773 tests passed.
- SQLServer parser module passed.
- Spotless passed.
- Checkstyle reported 0 violations.
- `git diff --check` passed.
