### PR TITLE
Parse PostgreSQL altered column nullability

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@
 1. SQL Parser: Preserve openGauss `CREATE TABLE` column nullability metadata - [#39425](https://github.com/apache/shardingsphere/pull/39425)
 1. SQL Parser: Preserve Hive `CREATE TABLE` column nullability metadata - [#39428](https://github.com/apache/shardingsphere/pull/39428)
 1. SQL Parser: Preserve SQLServer `ALTER TABLE ALTER COLUMN` nullability metadata - [#39430](https://github.com/apache/shardingsphere/pull/39430)
+1. SQL Parser: Preserve PostgreSQL `ALTER TABLE ALTER COLUMN` nullability metadata - [#39432](https://github.com/apache/shardingsphere/pull/39432)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)

--- a/parser/sql/engine/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/type/PostgreSQLDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/type/PostgreSQLDDLStatementVisitor.java
@@ -620,7 +620,8 @@ public final class PostgreSQLDDLStatementVisitor extends PostgreSQLStatementVisi
         // TODO visit pk and table ref
         ColumnSegment column = (ColumnSegment) visit(ctx.modifyColumn().columnName());
         DataTypeSegment dataType = null == ctx.dataType() ? null : (DataTypeSegment) visit(ctx.dataType());
-        ColumnDefinitionSegment columnDefinition = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, false, false, getText(ctx));
+        boolean isNotNull = null != ctx.SET() && null != ctx.NOT() && null != ctx.NULL();
+        ColumnDefinitionSegment columnDefinition = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, false, isNotNull, getText(ctx));
         return new ModifyColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), columnDefinition);
     }
     

--- a/test/it/parser/src/main/resources/case/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-table.xml
@@ -1192,6 +1192,24 @@
         </modify-column>
     </alter-table>
     
+    <alter-table sql-case-id="alter_table_alter_column_set_not_null_postgresql">
+        <table name="t_order" start-index="12" stop-index="18" />
+        <modify-column>
+            <column-definition not-null="true" start-index="20" stop-index="52">
+                <column name="column4" />
+            </column-definition>
+        </modify-column>
+    </alter-table>
+
+    <alter-table sql-case-id="alter_table_alter_column_drop_not_null_postgresql">
+        <table name="t_order" start-index="12" stop-index="18" />
+        <modify-column>
+            <column-definition not-null="false" start-index="20" stop-index="53">
+                <column name="column4" />
+            </column-definition>
+        </modify-column>
+    </alter-table>
+
     <alter-table sql-case-id="alter_table_alter_column_for_sqlserver">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
@@ -141,6 +141,8 @@
     <sql-case id="alter_table_add_constraints_sqlserver" value="ALTER TABLE t_order_item ADD PRIMARY KEY (order_id), UNIQUE (order_id), CHECK (order_id > 0), FOREIGN KEY (order_id) REFERENCES t_order (order_id) ON UPDATE CASCADE ON DELETE CASCADE" db-types="SQLServer" />
     <sql-case id="alter_table_drop_constraints_sqlserver" value="ALTER TABLE t_order DROP CONSTRAINT pk_order_id, uk_order_id, order_index" db-types="SQLServer" />
     <sql-case id="alter_table_alter_column_for_postgresql" value="ALTER TABLE t_order ALTER column4 TYPE VARCHAR(20)" db-types="PostgreSQL,openGauss" />
+    <sql-case id="alter_table_alter_column_set_not_null_postgresql" value="ALTER TABLE t_order ALTER COLUMN column4 SET NOT NULL" db-types="PostgreSQL" />
+    <sql-case id="alter_table_alter_column_drop_not_null_postgresql" value="ALTER TABLE t_order ALTER COLUMN column4 DROP NOT NULL" db-types="PostgreSQL" />
     <sql-case id="alter_table_alter_column_for_sqlserver" value="ALTER TABLE t_order ALTER COLUMN column4 VARCHAR(20)" db-types="SQLServer" />
     <sql-case id="alter_table_alter_column_not_null_sqlserver" value="ALTER TABLE t_order ALTER COLUMN column4 VARCHAR(20) NOT NULL" db-types="SQLServer" />
     <sql-case id="alter_table_alter_column_null_sqlserver" value="ALTER TABLE t_order ALTER COLUMN column4 VARCHAR(20) NULL" db-types="SQLServer" />


### PR DESCRIPTION
Fix PostgreSQL `ALTER TABLE ... ALTER COLUMN` nullability metadata.

### Problem

The PostgreSQL grammar accepts `SET NOT NULL` and `DROP NOT NULL`, but `PostgreSQLDDLStatementVisitor` always constructed `ColumnDefinitionSegment` with `notNull=false`.

PostgreSQL documents both forms in the official `ALTER TABLE` syntax: https://www.postgresql.org/docs/current/sql-altertable.html

### Change

- Detect `SET NOT NULL` in the existing `modifyColumnSpecification` AST.
- Add focused PostgreSQL parser cases covering `SET NOT NULL` and `DROP NOT NULL`.
- Add the ShardingSphere 5.5.4 bug-fix release note.

### Verification

- RED: the `SET NOT NULL` case was the only failure among 1,154 PostgreSQL parser tests before the visitor change.
- `InternalPostgreSQLParserIT`: 1,154 tests passed.
- PostgreSQL parser module: 5 tests passed.
- Spotless passed.
- Checkstyle reported 0 violations.
- `git diff --check` passed.
