### PR TITLE
Parse SQL92 create column nullability

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@
 1. SQL Parser: Preserve PostgreSQL `ALTER TABLE ALTER COLUMN` nullability metadata - [#39432](https://github.com/apache/shardingsphere/pull/39432)
 1. SQL Parser: Preserve openGauss `ALTER TABLE ALTER COLUMN` nullability metadata - [#39435](https://github.com/apache/shardingsphere/pull/39435)
 1. SQL Parser: Preserve Firebird `ALTER TABLE ALTER COLUMN` nullability metadata - [#39436](https://github.com/apache/shardingsphere/pull/39436)
+1. SQL Parser: Preserve SQL92 `CREATE TABLE` column nullability metadata - [#39439](https://github.com/apache/shardingsphere/pull/39439)
 1. SQL Parser: Fix No value specified for parameter exception when sql is 'INSERT INTO tableName ON CONFLICT  DO UPDATE set  WHERE ' - [#38668](https://github.com/apache/shardingsphere/pull/38668)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)

--- a/parser/sql/engine/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/engine/sql92/visitor/statement/type/SQL92DDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/engine/sql92/visitor/statement/type/SQL92DDLStatementVisitor.java
@@ -116,8 +116,8 @@ public final class SQL92DDLStatementVisitor extends SQL92StatementVisitor implem
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
         DataTypeSegment dataType = (DataTypeSegment) visit(ctx.dataType());
         boolean isPrimaryKey = ctx.dataTypeOption().stream().anyMatch(each -> null != each.primaryKey());
-        // TODO parse not null
-        ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, false, getText(ctx));
+        boolean isNotNull = ctx.dataTypeOption().stream().anyMatch(each -> null != each.NOT() && null != each.NULL());
+        ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, isNotNull, getText(ctx));
         for (DataTypeOptionContext each : ctx.dataTypeOption()) {
             if (null != each.referenceDefinition()) {
                 result.getReferencedTables().add((SimpleTableSegment) visit(each.referenceDefinition().tableName()));

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -447,6 +447,16 @@
         </column-definition>
     </create-table>
 
+    <create-table sql-case-id="create_table_with_explicit_column_nullability_sql92">
+        <table name="t_order" start-index="13" stop-index="19" />
+        <column-definition type="INT" not-null="true" start-index="22" stop-index="42">
+            <column name="order_id" />
+        </column-definition>
+        <column-definition type="INT" not-null="false" start-index="45" stop-index="60">
+            <column name="user_id" />
+        </column-definition>
+    </create-table>
+
     <create-table sql-case-id="create_table_with_column_default">
         <table name="t_order" start-index="13" stop-index="19" />
         <column-definition type="INT" start-index="22" stop-index="43">

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -64,6 +64,7 @@
     <sql-case id="create_table_with_explicit_column_nullability_postgresql" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT NULL)" db-types="PostgreSQL" />
     <sql-case id="create_table_with_explicit_column_nullability_opengauss" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT NULL)" db-types="openGauss" />
     <sql-case id="create_table_with_explicit_column_nullability_sqlserver" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT NULL)" db-types="SQLServer" />
+    <sql-case id="create_table_with_explicit_column_nullability_sql92" value="CREATE TABLE t_order (order_id INT NOT NULL, user_id INT NULL)" db-types="SQL92" />
     <sql-case id="create_table_with_column_default" value="CREATE TABLE t_order (order_id INT DEFAULT 0, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="create_table_with_column_increment" value="CREATE TABLE t_order (order_id INT AUTO_INCREMENT, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL" />
     <sql-case id="create_table_with_column_generated" value="CREATE TABLE t_order (order_id INT GENERATED ALWAYS AS (user_id * 2), user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="MySQL" />


### PR DESCRIPTION
Fix SQL92 `CREATE TABLE` column nullability metadata.

### Problem

The SQL92 grammar accepts column-level `NOT NULL` and `NULL` options, but `SQL92DDLStatementVisitor.visitColumnDefinition()` always constructed `ColumnDefinitionSegment` with `notNull=false`.

### Change

- Derive `notNull` from the parsed `NOT NULL` option.
- Add a focused SQL92 parser case covering `NOT NULL` and explicit `NULL`.
- Add the ShardingSphere 5.5.4 bug-fix release note.

### Verification

- Baseline: `InternalSQL92ParserIT` passed 207 tests.
- `InternalSQL92ParserIT`: 208 tests passed after the change.
- SQL92 parser module passed.
- Spotless passed.
- Checkstyle reported 0 violations.
- `git diff --check` passed.
