### PR TITLE
Confirm error severity for PostgreSQL and openGauss codecs

### DIFF
--- a/database/protocol/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/protocol/opengauss/codec/OpenGaussPacketCodecEngine.java
+++ b/database/protocol/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/protocol/opengauss/codec/OpenGaussPacketCodecEngine.java
@@ -118,7 +118,6 @@ public final class OpenGaussPacketCodecEngine implements DatabasePacketCodecEngi
         } catch (final RuntimeException ex) {
             // CHECKSTYLE:ON
             payload.getByteBuf().resetWriterIndex();
-            // TODO consider what severity to use
             OpenGaussErrorResponsePacket errorResponsePacket = new OpenGaussErrorResponsePacket(
                     PostgreSQLMessageSeverityLevel.ERROR, PostgreSQLVendorError.SYSTEM_ERROR.getSqlState().getValue(), ex.getMessage());
             isIdentifierPacket = true;

--- a/database/protocol/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/protocol/opengauss/codec/OpenGaussPacketCodecEngineTest.java
+++ b/database/protocol/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/protocol/opengauss/codec/OpenGaussPacketCodecEngineTest.java
@@ -132,7 +132,7 @@ class OpenGaussPacketCodecEngineTest {
         OpenGaussPacketCodecEngine codecEngine = new OpenGaussPacketCodecEngine();
         DatabasePacket message = createPacket(identifierPacket);
         if (writeException) {
-            doThrow(new RuntimeException("Error")).when(message).write(any(PostgreSQLPacketPayload.class));
+            doThrow(new RuntimeException("foo_error")).when(message).write(any(PostgreSQLPacketPayload.class));
         }
         ByteBuf out = Unpooled.buffer();
         codecEngine.encode(context, message, out);
@@ -141,6 +141,11 @@ class OpenGaussPacketCodecEngineTest {
         if (expectedHeader) {
             assertThat((char) out.getByte(0), is(expectedIdentifier));
             assertThat(out.getInt(1), is(out.readableBytes() - 1));
+        }
+        if (writeException) {
+            String expectedPayload = "SERROR\0C58000\0Mfoo_error\0c0\0\0";
+            String actualPayload = out.toString(Byte.BYTES + Integer.BYTES, out.readableBytes() - Byte.BYTES - Integer.BYTES, StandardCharsets.UTF_8);
+            assertThat(actualPayload, is(expectedPayload));
         }
     }
     

--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/codec/PostgreSQLPacketCodecEngine.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/codec/PostgreSQLPacketCodecEngine.java
@@ -116,7 +116,6 @@ public final class PostgreSQLPacketCodecEngine implements DatabasePacketCodecEng
         } catch (final RuntimeException ex) {
             // CHECKSTYLE:ON
             payload.getByteBuf().resetWriterIndex();
-            // TODO consider what severity to use
             PostgreSQLErrorResponsePacket errorResponsePacket = PostgreSQLErrorResponsePacket.newBuilder(
                     PostgreSQLMessageSeverityLevel.ERROR, PostgreSQLVendorError.SYSTEM_ERROR, ex.getMessage()).build();
             isIdentifierPacket = true;

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/codec/PostgreSQLPacketCodecEngineTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/codec/PostgreSQLPacketCodecEngineTest.java
@@ -133,7 +133,7 @@ class PostgreSQLPacketCodecEngineTest {
         PostgreSQLPacketCodecEngine codecEngine = new PostgreSQLPacketCodecEngine();
         DatabasePacket message = createPacket(identifierPacket);
         if (writeException) {
-            doThrow(new RuntimeException("Error")).when(message).write(any(PostgreSQLPacketPayload.class));
+            doThrow(new RuntimeException("foo_error")).when(message).write(any(PostgreSQLPacketPayload.class));
         }
         ByteBuf out = Unpooled.buffer();
         codecEngine.encode(context, message, out);
@@ -142,6 +142,11 @@ class PostgreSQLPacketCodecEngineTest {
         if (expectedHeader) {
             assertThat((char) out.getByte(0), is(expectedIdentifier));
             assertThat(out.getInt(1), is(out.readableBytes() - 1));
+        }
+        if (writeException) {
+            String expectedPayload = "SERROR\0VERROR\0C58000\0Mfoo_error\0\0";
+            String actualPayload = out.toString(Byte.BYTES + Integer.BYTES, out.readableBytes() - Byte.BYTES - Integer.BYTES, StandardCharsets.UTF_8);
+            assertThat(actualPayload, is(expectedPayload));
         }
     }
     


### PR DESCRIPTION
Keep ERROR for packet encoding failures because the fallback does not close the current session. Remove the resolved TODOs and verify the complete ErrorResponse payloads.
