### PR TITLE
Use database APIs for protocol default schema lookup

### DIFF
--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/executor/engine/facade/DriverExecutorFacade.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/executor/engine/facade/DriverExecutorFacade.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.driver.executor.engine.facade;
 
-import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.driver.executor.callback.add.StatementAddCallback;
 import org.apache.shardingsphere.driver.executor.callback.execute.StatementExecuteCallback;
 import org.apache.shardingsphere.driver.executor.callback.execute.StatementExecuteUpdateCallback;
@@ -78,7 +77,7 @@ public final class DriverExecutorFacade implements AutoCloseable {
         this.jdbcDriverType = jdbcDriverType;
         JDBCExecutor jdbcExecutor = new JDBCExecutor(connection.getContextManager().getExecutorEngine(), connection.getDatabaseConnectionManager().getConnectionContext());
         ShardingSphereMetaData metaData = connection.getContextManager().getMetaDataContexts().getMetaData();
-        String currentSchemaName = new DatabaseTypeRegistry(currentDatabase.getProtocolType()).getDefaultSchemaName(connection.getCurrentDatabaseName());
+        String currentSchemaName = currentDatabase.getDefaultSchemaName();
         sqlFederationEngine =
                 new SQLFederationEngine(connection.getCurrentDatabaseName(), currentSchemaName, metaData, connection.getContextManager().getMetaDataContexts().getStatistics(), jdbcExecutor);
         RawExecutor rawExecutor = new RawExecutor(connection.getContextManager().getExecutorEngine(), connection.getDatabaseConnectionManager().getConnectionContext());

--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/UnloadSingleTableExecutor.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/UnloadSingleTableExecutor.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.single.distsql.handler.update;
 import com.google.common.base.Splitter;
 import lombok.Setter;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.database.exception.core.exception.syntax.table.NoSuchTableException;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.type.DatabaseRuleAlterExecutor;
 import org.apache.shardingsphere.distsql.handler.required.DistSQLExecutorCurrentRuleRequired;
@@ -37,6 +36,7 @@ import org.apache.shardingsphere.single.exception.SingleTableNotFoundException;
 import org.apache.shardingsphere.single.rule.SingleRule;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -71,8 +71,8 @@ public final class UnloadSingleTableExecutor implements DatabaseRuleAlterExecuto
     }
     
     private Collection<String> getAllTableNames(final ShardingSphereDatabase database) {
-        String defaultSchemaName = new DatabaseTypeRegistry(database.getProtocolType()).getDefaultSchemaName(database.getName());
-        return database.getSchema(defaultSchemaName).getAllTables().stream().map(ShardingSphereTable::getName).collect(Collectors.toList());
+        return database.findDefaultSchema().map(schema -> schema.getAllTables().stream().map(ShardingSphereTable::getName).collect(Collectors.toList()))
+                .orElseGet(Collections::emptyList);
     }
     
     private void checkTableExist(final Collection<String> allTables, final String tableName) {

--- a/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/update/UnloadSingleTableExecutorTest.java
+++ b/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/update/UnloadSingleTableExecutorTest.java
@@ -52,6 +52,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -113,6 +114,12 @@ class UnloadSingleTableExecutorTest {
         assertDoesNotThrow(() -> executor.checkBeforeUpdate(sqlStatement));
     }
     
+    @Test
+    void assertCheckBeforeUpdateWithMissingDefaultSchema() {
+        when(database.findDefaultSchema()).thenReturn(Optional.empty());
+        assertThrows(NoSuchTableException.class, () -> executor.checkBeforeUpdate(new UnloadSingleTableStatement(false, Collections.singletonList("foo_tbl"))));
+    }
+    
     @ParameterizedTest(name = "{0}")
     @MethodSource("assertBuildToBeAlteredRuleConfigurationArguments")
     void assertBuildToBeAlteredRuleConfiguration(final String name, final Collection<String> currentTables,
@@ -147,7 +154,7 @@ class UnloadSingleTableExecutorTest {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         when(schema.getAllTables()).thenReturn(
                 allTables.stream().map(each -> new ShardingSphereTable(each, Collections.emptyList(), Collections.emptyList(), Collections.emptyList())).collect(Collectors.toList()));
-        when(database.getSchema("foo_db")).thenReturn(schema);
+        when(database.findDefaultSchema()).thenReturn(Optional.of(schema));
         when(tableMapperRuleAttribute.getLogicTableNames()).thenReturn(singleTables);
         when(dataNodeRuleAttribute.getDataNodesByTableName(anyString())).thenAnswer(invocation -> tableDataNodes.getOrDefault(invocation.getArgument(0), Collections.emptyList()));
         when(rule.getConfiguration()).thenReturn(new SingleRuleConfiguration(new LinkedList<>(configuredTables), null));


### PR DESCRIPTION

Changes proposed in this pull request:
  - Use database APIs for protocol default schema lookup

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [ ] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
