### PR TITLE
Deprecate getDefaultSchemaName method for DatabaseTypeRegistry

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistry.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistry.java
@@ -68,7 +68,9 @@ public final class DatabaseTypeRegistry {
      *
      * @param databaseName database name
      * @return default schema name
+     * @deprecated use {@link org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase#getDefaultSchemaName()} instead
      */
+    @Deprecated
     public String getDefaultSchemaName(final String databaseName) {
         return dialectDatabaseMetaData.getSchemaOption().getDefaultSchema()
                 .orElse(null == databaseName ? null : IdentifierNormalizeEngine.normalize(getSchemaIdentifierCasePolicy(), databaseName));


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [ ] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
