### PR TITLE
Refactor MCP descriptor YAML parsing through YamlEngine

### DIFF
--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorYamlKeyValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorYamlKeyValidator.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.mcp.support.descriptor;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
-import org.yaml.snakeyaml.Yaml;
+import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -65,7 +65,7 @@ final class MCPDescriptorYamlKeyValidator {
         if (yamlContent.isBlank()) {
             return;
         }
-        Map<?, ?> root = asMap(resourceName, "$", new Yaml().load(yamlContent));
+        Map<?, ?> root = asMap(resourceName, "$", YamlEngine.unmarshal(yamlContent, Object.class));
         validateKeys(resourceName, "$", root, ROOT_KEYS);
         validateResources(resourceName, root.get("resources"));
         validateResourceTemplates(resourceName, root.get("resourceTemplates"));

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorYamlKeyValidatorTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorYamlKeyValidatorTest.java
@@ -101,6 +101,11 @@ class MCPDescriptorYamlKeyValidatorTest {
                 """;
         assertDoesNotThrow(() -> MCPDescriptorYamlKeyValidator.validate("test.yaml", toBytes(yamlContent)));
     }
+
+    @Test
+    void assertValidateNullRoot() {
+        assertValidationError("null", "MCP descriptor resource `test.yaml` expects map at `$`.");
+    }
     
     @Test
     void assertValidateUnknownRootKey() {


### PR DESCRIPTION
Simple refactor, do not need refactor