### PR TITLE
Add Doris SQL parser test cases for CANCEL ALTER TABLE with qualified table name (#31474)

### DIFF
--- a/test/it/parser/src/main/resources/case/ddl/cancel-alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/cancel-alter-table.xml
@@ -67,4 +67,30 @@
         </table>
         <job-id>40001</job-id>
     </cancel-alter-table>
+
+    <cancel-alter-table sql-case-id="cancel_alter_table_column_db_table" alter-type="COLUMN">
+        <table>
+            <simple-table name="my_table" start-index="31" stop-index="49">
+                <owner name="example_db" start-index="31" stop-index="40" />
+            </simple-table>
+        </table>
+    </cancel-alter-table>
+
+    <cancel-alter-table sql-case-id="cancel_alter_table_rollup_db_table_without_jobs" alter-type="ROLLUP">
+        <table>
+            <simple-table name="my_table" start-index="31" stop-index="49">
+                <owner name="example_db" start-index="31" stop-index="40" />
+            </simple-table>
+        </table>
+    </cancel-alter-table>
+
+    <cancel-alter-table sql-case-id="cancel_alter_table_rollup_db_table_with_jobs" alter-type="ROLLUP">
+        <table>
+            <simple-table name="my_table" start-index="31" stop-index="49">
+                <owner name="example_db" start-index="31" stop-index="40" />
+            </simple-table>
+        </table>
+        <job-id>12801</job-id>
+        <job-id>12802</job-id>
+    </cancel-alter-table>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/cancel-alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/cancel-alter-table.xml
@@ -24,4 +24,7 @@
     <sql-case id="cancel_alter_table_materialized_view_without_jobs" value="CANCEL ALTER TABLE MATERIALIZED VIEW FROM table_name" db-types="Doris" />
     <sql-case id="cancel_alter_table_materialized_view_with_jobs" value="CANCEL ALTER TABLE MATERIALIZED VIEW FROM table_name (30001)" db-types="Doris" />
     <sql-case id="cancel_alter_table_rollup_db_table" value="CANCEL ALTER TABLE ROLLUP FROM db_name.table_name (40001);" db-types="Doris" />
+    <sql-case id="cancel_alter_table_column_db_table" value="CANCEL ALTER TABLE COLUMN FROM example_db.my_table" db-types="Doris" />
+    <sql-case id="cancel_alter_table_rollup_db_table_without_jobs" value="CANCEL ALTER TABLE ROLLUP FROM example_db.my_table" db-types="Doris" />
+    <sql-case id="cancel_alter_table_rollup_db_table_with_jobs" value="CANCEL ALTER TABLE ROLLUP FROM example_db.my_table (12801,12802)" db-types="Doris" />
 </sql-cases>


### PR DESCRIPTION
Fixes #31474.

This PR verifies the remaining unchecked cases in #31474 on current master and adds test cases for the missing variants:

- Added SQL parser test cases for CANCEL ALTER TABLE with qualified table name:
  - `CANCEL ALTER TABLE COLUMN FROM example_db.my_table`
  - `CANCEL ALTER TABLE ROLLUP FROM example_db.my_table`
  - `CANCEL ALTER TABLE ROLLUP FROM example_db.my_table (12801,12802)`
- DROP REPOSITORY already has test coverage (`drop_repository` case), no change needed.
- The keyword items (CANCEL, ALTER, TABLE, CANCEL ALTER) are keyword lists from the Doris docs page rather than SQL statements, so they are ignored.

Changes:
- test/it/parser/src/main/resources/sql/supported/ddl/cancel-alter-table.xml
- test/it/parser/src/main/resources/case/ddl/cancel-alter-table.xml

Verified by `mvn test -Dtest=InternalDorisParserIT`: 1266 tests run, 0 failures.
