### PR TITLE
Fix statement close invalidating live result sets of other statements

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,6 +37,7 @@
 1. DistSQL: Use case-insensitive table name matching in broadcast create and drop executors - [#39200](https://github.com/apache/shardingsphere/pull/39200)
 1. JDBC: Fix stale generated values leaking into prepared statement executeBatch calls without pending batches - [#38160](https://github.com/apache/shardingsphere/pull/38160)
 1. JDBC: Fix MySQL-compatible typed string conversion for `ResultSet#getObject(index, Class<T>)` - [#38444](https://github.com/apache/shardingsphere/pull/38444)
+1. JDBC: Fix statement close invalidating live result sets of other statements on the same connection - [#39503](https://github.com/apache/shardingsphere/pull/39503)
 1. Proxy: Resolve MySQL prepared statement parameter columns for where clause - [#38382](https://github.com/apache/shardingsphere/pull/38382)
 1. Proxy: Resolve PostgreSQL prepared statement parameter types before bind - [#38384](https://github.com/apache/shardingsphere/pull/38384)
 1. Proxy: Resolve openGauss batch bind parameter types before reading values - [#38390](https://github.com/apache/shardingsphere/pull/38390)

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractStatementAdapter.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractStatementAdapter.java
@@ -83,7 +83,7 @@ public abstract class AbstractStatementAdapter extends WrapperAdapter implements
     }
     
     protected final void handleAutoCommitAfterExecution(final ShardingSphereConnection connection) throws SQLException {
-        if (connection.getAutoCommit()) {
+        if (connection.getAutoCommit() && !connection.hasRegisteredStatementManagers()) {
             connection.getDatabaseConnectionManager().clearCachedConnections();
         }
     }

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
@@ -340,4 +340,13 @@ public final class ShardingSphereConnection extends AbstractConnectionAdapter {
     public void unregisterStatementManager(final StatementManager statementManager) {
         statementManagers.remove(statementManager);
     }
+    
+    /**
+     * Judge whether any statement manager is still registered.
+     *
+     * @return whether any statement manager is still registered
+     */
+    public boolean hasRegisteredStatementManagers() {
+        return !statementManagers.isEmpty();
+    }
 }

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/ShardingSphereDriverTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/ShardingSphereDriverTest.java
@@ -17,9 +17,12 @@
 
 package org.apache.shardingsphere.driver;
 
+import com.google.common.collect.Multimap;
+import org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager;
 import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.infra.hint.HintManager;
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.sql.Connection;
 import java.sql.Driver;
@@ -148,6 +151,61 @@ class ShardingSphereDriverTest {
             assertTrue(resultSet.next());
             assertThat(resultSet.getInt(1), is(1));
         }
+    }
+    
+    @Test
+    void assertResultSetRemainsUsableAfterAnotherStatementCloses() throws SQLException {
+        try (Connection connection = DriverManager.getConnection("jdbc:shardingsphere:classpath:config/driver/driver-fixture-h2-mysql.yaml")) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("DROP TABLE IF EXISTS t_order");
+                statement.execute("CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT)");
+                statement.execute("INSERT INTO t_order (order_id, user_id) VALUES (1, 101), (2, 102)");
+            }
+            assertTrue(connection.getAutoCommit());
+            try (Statement queryStatement = connection.createStatement()) {
+                ResultSet resultSet = queryStatement.executeQuery("SELECT order_id, user_id FROM t_order ORDER BY order_id");
+                assertTrue(resultSet.next());
+                assertThat(resultSet.getInt(1), is(1));
+                executeAndCloseSecondaryStatement(connection);
+                assertThat(resultSet.getInt(2), is(101));
+                assertTrue(resultSet.next());
+                assertThat(resultSet.getInt(1), is(2));
+                assertThat(resultSet.getInt(2), is(102));
+            }
+        }
+    }
+    
+    private void executeAndCloseSecondaryStatement(final Connection connection) throws SQLException {
+        try (
+                Statement secondaryStatement = connection.createStatement();
+                ResultSet secondaryResultSet = secondaryStatement.executeQuery("SELECT COUNT(1) FROM t_order")) {
+            assertTrue(secondaryResultSet.next());
+            assertThat(secondaryResultSet.getInt(1), is(2));
+        }
+    }
+    
+    @Test
+    void assertCachedConnectionsClearedWhenLastStatementCloses() throws SQLException, ReflectiveOperationException {
+        try (Connection connection = DriverManager.getConnection("jdbc:shardingsphere:classpath:config/driver/driver-fixture-h2-mysql.yaml")) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("DROP TABLE IF EXISTS t_order");
+                statement.execute("CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT)");
+                statement.execute("INSERT INTO t_order (order_id, user_id) VALUES (1, 101), (2, 102)");
+            }
+            Statement queryStatement = connection.createStatement();
+            try (ResultSet resultSet = queryStatement.executeQuery("SELECT order_id FROM t_order")) {
+                assertTrue(resultSet.next());
+                assertFalse(getCachedConnections(connection).isEmpty());
+            }
+            queryStatement.close();
+            assertTrue(getCachedConnections(connection).isEmpty());
+        }
+    }
+    
+    private Multimap<?, ?> getCachedConnections(final Connection connection) throws ReflectiveOperationException {
+        DriverDatabaseConnectionManager databaseConnectionManager = ((ShardingSphereConnection) connection).getDatabaseConnectionManager();
+        return (Multimap<?, ?>) Plugins.getMemberAccessor().get(
+                DriverDatabaseConnectionManager.class.getDeclaredField("cachedConnections"), databaseConnectionManager);
     }
     
     @Test


### PR DESCRIPTION
Fixes #39189.

Changes proposed in this pull request:
  - Gate the auto-commit connection cleanup in `AbstractStatementAdapter#handleAutoCommitAfterExecution` on there being no other statement still registered on the logical connection, so closing one statement no longer closes physical connections that still back another statement's live `ResultSet`.
  - Add `ShardingSphereConnection#hasRegisteredStatementManagers()` to expose that state.
  - Add two regression tests: one reproducing the failure, and one asserting the connections *are* still released once the last statement closes.

### Root cause

This is a 5.5.2 -> 5.5.3 regression introduced by #35834.

`AbstractStatementAdapter#close` calls `safeCloseAndUnregisterStatementManager`, which ends in `handleAutoCommitAfterExecution` -> `DriverDatabaseConnectionManager#clearCachedConnections()`. That closes **every** connection in `cachedConnections`, and that Multimap is owned by the logical connection and shared by all of its statements. Since a `StatementManager` is created per `Statement`, closing a secondary statement closes the physical connections still backing an outer statement's open `ResultSet`.

It is not a Hibernate problem — Hibernate just produces the access pattern that triggers it. It reproduces with plain JDBC and two statements on one connection, which is what the added test does.

The `connection.getAutoCommit()` gate on that call also explains both of the reporter's observations: 5.5.2 works because the path did not exist before #35834, and `@Transactional(readOnly = true)` works because inside a transaction `autoCommit` is false, so the clear never runs.

### Fix

`unregisterStatementManager` already runs immediately before the auto-commit handling, so at that point a non-empty registry means another statement is still open:

```java
protected final void handleAutoCommitAfterExecution(final ShardingSphereConnection connection) throws SQLException {
    if (connection.getAutoCommit() && !connection.hasRegisteredStatementManagers()) {
        connection.getDatabaseConnectionManager().clearCachedConnections();
    }
}
```

This preserves #35834's timely-release goal — the last statement to close still releases everything — and only skips the clear while another statement is genuinely live.

### Verification

Run on `jdbc` against current `master`:

- `mvn -pl jdbc test` — **1216 tests, 0 failures**, including the tests added by #39437 to `StatementAdapterTest` and `DriverDatabaseConnectionManagerTest`.
- `mvn -Pcheck -pl jdbc validate` — 0 Checkstyle violations; `spotless:check` clean.
- A/B checked both ways: with the guard reverted, `assertResultSetRemainsUsableAfterAnotherStatementCloses` fails while `assertCachedConnectionsClearedWhenLastStatementCloses` still passes — so the second test is genuinely guarding the release behaviour rather than being trivially satisfied.

### Two open questions

I raised these on the issue and am happy to go either way:

1. **Test placement** — these currently live in `ShardingSphereDriverTest`. Happy to move them to a dedicated multi-statement lifecycle test class instead, as suggested in the issue.
2. **Granularity** — using open statements as the proxy for "a result set may still be live" is deliberately conservative: a statement left open without a live result set will hold its connections until it closes. Tracking open result sets directly would be tighter but considerably more invasive. Glad to go that way if preferred.

Also happy to add an E2E case if this should be covered beyond the unit level.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally (exact scope listed under Verification above).
- [ ] I have made corresponding changes to the documentation. (No documentation impact — internal resource-lifecycle fix.)
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version.
- [x] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

**AI assistance:** Claude (Claude Code) was used while investigating and implementing this change, covering `AbstractStatementAdapter`, `ShardingSphereConnection` and `ShardingSphereDriverTest`. I have reviewed and verified all of it and can explain every line.

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md

