### PR TITLE
Collect table type for H2 and SQLServer meta data loaders

### DIFF
--- a/database/connector/dialect/h2/src/main/java/org/apache/shardingsphere/database/connector/h2/metadata/data/loader/H2MetaDataLoader.java
+++ b/database/connector/dialect/h2/src/main/java/org/apache/shardingsphere/database/connector/h2/metadata/data/loader/H2MetaDataLoader.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.model.Ind
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.SchemaMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.TableMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.datatype.DataTypeRegistry;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -65,18 +66,41 @@ public final class H2MetaDataLoader implements DialectMetaDataLoader {
     
     private static final String GENERATED_INFO_SQL_IN_TABLES = GENERATED_INFO_SQL + " AND UPPER(C.TABLE_NAME) IN (%s)";
     
+    private static final String VIEW_META_DATA_SQL = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES"
+            + " WHERE TABLE_CATALOG=? AND TABLE_SCHEMA=? AND TABLE_TYPE='VIEW' AND UPPER(TABLE_NAME) IN (%s)";
+    
     @Override
     public Collection<SchemaMetaData> load(final MetaDataLoaderMaterial material) throws SQLException {
         Collection<TableMetaData> tableMetaDataList = new LinkedList<>();
         try (Connection connection = material.getDataSource().getConnection()) {
             Map<String, Collection<ColumnMetaData>> columnMetaDataMap = loadColumnMetaDataMap(connection, material.getActualTableNames());
+            Collection<String> viewNames = columnMetaDataMap.isEmpty() ? Collections.emptySet() : loadViewNames(connection, columnMetaDataMap.keySet());
             Map<String, Collection<IndexMetaData>> indexMetaDataMap = columnMetaDataMap.isEmpty() ? Collections.emptyMap() : loadIndexMetaData(connection, columnMetaDataMap.keySet());
             for (Entry<String, Collection<ColumnMetaData>> entry : columnMetaDataMap.entrySet()) {
                 Collection<IndexMetaData> indexMetaDataList = indexMetaDataMap.getOrDefault(entry.getKey(), Collections.emptyList());
-                tableMetaDataList.add(new TableMetaData(entry.getKey(), entry.getValue(), indexMetaDataList, Collections.emptyList()));
+                tableMetaDataList.add(new TableMetaData(entry.getKey(), entry.getValue(), indexMetaDataList, Collections.emptyList(),
+                        viewNames.contains(entry.getKey()) ? TableType.VIEW : TableType.TABLE));
             }
         }
         return Collections.singleton(new SchemaMetaData(material.getDefaultSchemaName(), tableMetaDataList));
+    }
+    
+    private Collection<String> loadViewNames(final Connection connection, final Collection<String> tableNames) throws SQLException {
+        Collection<String> result = new LinkedList<>();
+        try (PreparedStatement preparedStatement = connection.prepareStatement(getViewMetaDataSQL(tableNames))) {
+            preparedStatement.setString(1, connection.getCatalog());
+            preparedStatement.setString(2, "PUBLIC");
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    result.add(resultSet.getString("TABLE_NAME"));
+                }
+            }
+        }
+        return result;
+    }
+    
+    private String getViewMetaDataSQL(final Collection<String> tableNames) {
+        return String.format(VIEW_META_DATA_SQL, tableNames.stream().map(each -> String.format("'%s'", each).toUpperCase()).collect(Collectors.joining(",")));
     }
     
     private Map<String, Collection<ColumnMetaData>> loadColumnMetaDataMap(final Connection connection, final Collection<String> tables) throws SQLException {

--- a/database/connector/dialect/h2/src/test/java/org/apache/shardingsphere/database/connector/h2/metadata/data/loader/H2MetaDataLoaderTest.java
+++ b/database/connector/dialect/h2/src/test/java/org/apache/shardingsphere/database/connector/h2/metadata/data/loader/H2MetaDataLoaderTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.model.Ind
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.SchemaMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.TableMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.datatype.DataTypeRegistry;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -33,9 +34,12 @@ import javax.sql.DataSource;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
@@ -101,6 +105,31 @@ class H2MetaDataLoaderTest {
     }
     
     @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
+    @Test
+    void assertLoadWithView() throws SQLException {
+        DataSource dataSource = mockDataSource();
+        ResultSet resultSet = mockTableAndViewMetaDataResultSet();
+        when(dataSource.getConnection().prepareStatement(
+                "SELECT TABLE_CATALOG, TABLE_NAME, COLUMN_NAME, DATA_TYPE, ORDINAL_POSITION, COALESCE(IS_VISIBLE, FALSE) IS_VISIBLE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS"
+                        + " WHERE TABLE_CATALOG=? AND TABLE_SCHEMA=? AND UPPER(TABLE_NAME) IN ('TBL','TBL_VIEW') ORDER BY ORDINAL_POSITION")
+                .executeQuery()).thenReturn(resultSet);
+        ResultSet viewResultSet = mockViewMetaDataResultSet();
+        when(dataSource.getConnection().prepareStatement(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_CATALOG=? AND TABLE_SCHEMA=? AND TABLE_TYPE='VIEW' AND UPPER(TABLE_NAME) IN ('TBL_VIEW','TBL')")
+                .executeQuery()).thenReturn(viewResultSet);
+        DataTypeRegistry.load(dataSource, "H2");
+        Collection<SchemaMetaData> schemaMetaDataList = getDialectTableMetaDataLoader().load(
+                new MetaDataLoaderMaterial(Arrays.asList("tbl", "tbl_view"), "foo_ds", dataSource, databaseType, "sharding_db"));
+        assertThat(schemaMetaDataList.size(), is(1));
+        Map<String, TableType> actualTableTypes = new HashMap<>();
+        for (TableMetaData each : schemaMetaDataList.iterator().next().getTables()) {
+            actualTableTypes.put(each.getName(), each.getType());
+        }
+        assertThat(actualTableTypes.get("tbl"), is(TableType.TABLE));
+        assertThat(actualTableTypes.get("tbl_view"), is(TableType.VIEW));
+    }
+    
+    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     private DataSource mockDataSource() throws SQLException {
         DataSource result = mock(DataSource.class, RETURNS_DEEP_STUBS);
         ResultSet typeInfoResultSet = mockTypeInfoResultSet();
@@ -126,6 +155,24 @@ class H2MetaDataLoaderTest {
         when(result.getInt("ORDINAL_POSITION")).thenReturn(0, 1);
         when(result.getBoolean("IS_VISIBLE")).thenReturn(true, false);
         when(result.getString("IS_NULLABLE")).thenReturn("NO", "YES");
+        return result;
+    }
+    
+    private ResultSet mockTableAndViewMetaDataResultSet() throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(true, true, false);
+        when(result.getString("TABLE_NAME")).thenReturn("tbl", "tbl_view");
+        when(result.getString("COLUMN_NAME")).thenReturn("id", "id");
+        when(result.getString("DATA_TYPE")).thenReturn("int", "int");
+        when(result.getBoolean("IS_VISIBLE")).thenReturn(true);
+        when(result.getString("IS_NULLABLE")).thenReturn("NO");
+        return result;
+    }
+    
+    private ResultSet mockViewMetaDataResultSet() throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(true, false);
+        when(result.getString("TABLE_NAME")).thenReturn("tbl_view");
         return result;
     }
     

--- a/database/connector/dialect/sqlserver/src/main/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/data/loader/SQLServerMetaDataLoader.java
+++ b/database/connector/dialect/sqlserver/src/main/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/data/loader/SQLServerMetaDataLoader.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.model.Ind
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.SchemaMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.TableMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.datatype.DataTypeRegistry;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -61,6 +62,8 @@ public final class SQLServerMetaDataLoader implements DialectMetaDataLoader {
             + " LEFT JOIN sys.columns col ON obj.object_id = col.object_id"
             + " WHERE idx.index_id NOT IN (0, 255) AND obj.name IN (%s) ORDER BY idx.index_id";
     
+    private static final String VIEW_META_DATA_SQL = "SELECT name AS TABLE_NAME FROM sys.objects WHERE type = 'V' AND name IN (%s)";
+    
     private static final int HIDDEN_COLUMN_START_MAJOR_VERSION = 15;
     
     @Override
@@ -68,13 +71,33 @@ public final class SQLServerMetaDataLoader implements DialectMetaDataLoader {
         Collection<TableMetaData> tableMetaDataList = new LinkedList<>();
         Map<String, Collection<ColumnMetaData>> columnMetaDataMap = loadColumnMetaDataMap(material.getDataSource(), material.getActualTableNames());
         if (!columnMetaDataMap.isEmpty()) {
+            Collection<String> viewNames = loadViewNames(material.getDataSource(), columnMetaDataMap.keySet());
             Map<String, Collection<IndexMetaData>> indexMetaDataMap = loadIndexMetaData(material.getDataSource(), columnMetaDataMap.keySet());
             for (Entry<String, Collection<ColumnMetaData>> entry : columnMetaDataMap.entrySet()) {
                 Collection<IndexMetaData> indexMetaDataList = indexMetaDataMap.getOrDefault(entry.getKey(), Collections.emptyList());
-                tableMetaDataList.add(new TableMetaData(entry.getKey(), entry.getValue(), indexMetaDataList, Collections.emptyList()));
+                tableMetaDataList.add(new TableMetaData(entry.getKey(), entry.getValue(), indexMetaDataList, Collections.emptyList(),
+                        viewNames.contains(entry.getKey()) ? TableType.VIEW : TableType.TABLE));
             }
         }
         return Collections.singleton(new SchemaMetaData(material.getDefaultSchemaName(), tableMetaDataList));
+    }
+    
+    private Collection<String> loadViewNames(final DataSource dataSource, final Collection<String> tableNames) throws SQLException {
+        Collection<String> result = new LinkedList<>();
+        try (
+                Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(getViewMetaDataSQL(tableNames))) {
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    result.add(resultSet.getString("TABLE_NAME"));
+                }
+            }
+        }
+        return result;
+    }
+    
+    private String getViewMetaDataSQL(final Collection<String> tableNames) {
+        return String.format(VIEW_META_DATA_SQL, tableNames.stream().map(each -> String.format("'%s'", each)).collect(Collectors.joining(",")));
     }
     
     private Map<String, Collection<ColumnMetaData>> loadColumnMetaDataMap(final DataSource dataSource, final Collection<String> tables) throws SQLException {

--- a/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/data/loader/SQLServerMetaDataLoaderTest.java
+++ b/database/connector/dialect/sqlserver/src/test/java/org/apache/shardingsphere/database/connector/sql92/sqlserver/metadata/data/loader/SQLServerMetaDataLoaderTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.model.Ind
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.SchemaMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.TableMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.datatype.DataTypeRegistry;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -40,7 +41,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,6 +74,15 @@ class SQLServerMetaDataLoaderTest {
             + " LEFT JOIN sys.objects obj ON idx.object_id = obj.object_id"
             + " LEFT JOIN sys.columns col ON obj.object_id = col.object_id"
             + " WHERE idx.index_id NOT IN (0, 255) AND obj.name IN ('tbl') ORDER BY idx.index_id";
+    
+    private static final String LOAD_COLUMN_META_DATA_WITH_VIEW = "SELECT obj.name AS TABLE_NAME, col.name AS COLUMN_NAME, t.name AS DATA_TYPE,"
+            + " col.collation_name AS COLLATION_NAME, col.column_id, is_identity AS IS_IDENTITY, col.is_nullable AS IS_NULLABLE,"
+            + "  (SELECT TOP 1 ind.is_primary_key FROM sys.index_columns ic LEFT JOIN sys.indexes ind ON ic.object_id = ind.object_id"
+            + " AND ic.index_id = ind.index_id AND ind.name LIKE 'PK_%' WHERE ic.object_id = obj.object_id AND ic.column_id = col.column_id) AS IS_PRIMARY_KEY"
+            + " FROM sys.objects obj INNER JOIN sys.columns col ON obj.object_id = col.object_id LEFT JOIN sys.types t ON t.user_type_id = col.user_type_id"
+            + " WHERE obj.name IN ('tbl','tbl_view') ORDER BY col.column_id";
+    
+    private static final String LOAD_VIEW_META_DATA = "SELECT name AS TABLE_NAME FROM sys.objects WHERE type = 'V' AND name IN ('tbl_view','tbl')";
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "SQLServer");
     
@@ -107,6 +119,27 @@ class SQLServerMetaDataLoaderTest {
         assertTableMetaData(actual, expectedSecondColumnVisible, expectedIndexColumns);
     }
     
+    @SuppressWarnings({"JDBCResourceOpenedButNotSafelyClosed", "resource"})
+    @Test
+    void assertLoadWithView() throws SQLException {
+        DataSource dataSource = mockDataSource();
+        ResultSet tableMetaDataResultSet = mockTableAndViewMetaDataResultSet();
+        when(dataSource.getConnection().prepareStatement(LOAD_COLUMN_META_DATA_WITH_VIEW).executeQuery()).thenReturn(tableMetaDataResultSet);
+        ResultSet viewMetaDataResultSet = mockViewMetaDataResultSet();
+        when(dataSource.getConnection().prepareStatement(LOAD_VIEW_META_DATA).executeQuery()).thenReturn(viewMetaDataResultSet);
+        when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(14);
+        DataTypeRegistry.load(dataSource, "SQLServer");
+        Collection<SchemaMetaData> schemaMetaDataList = dialectMetaDataLoader.load(
+                new MetaDataLoaderMaterial(Arrays.asList("tbl", "tbl_view"), "foo_ds", dataSource, databaseType, "sharding_db"));
+        assertThat(schemaMetaDataList.size(), is(1));
+        Map<String, TableType> actualTableTypes = new HashMap<>();
+        for (TableMetaData each : schemaMetaDataList.iterator().next().getTables()) {
+            actualTableTypes.put(each.getName(), each.getType());
+        }
+        assertThat(actualTableTypes.get("tbl"), is(TableType.TABLE));
+        assertThat(actualTableTypes.get("tbl_view"), is(TableType.VIEW));
+    }
+    
     @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     private DataSource mockDataSource() throws SQLException {
         DataSource result = mock(DataSource.class, RETURNS_DEEP_STUBS);
@@ -134,6 +167,22 @@ class SQLServerMetaDataLoaderTest {
         when(result.getString("IS_HIDDEN")).thenReturn("0", "1");
         when(result.getString("COLLATION_NAME")).thenReturn("SQL_Latin1_General_CP1_CS_AS", secondColumnCollationName);
         when(result.getString("IS_NULLABLE")).thenReturn("0", "1");
+        return result;
+    }
+    
+    private ResultSet mockTableAndViewMetaDataResultSet() throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(true, true, false);
+        when(result.getString("TABLE_NAME")).thenReturn("tbl", "tbl_view");
+        when(result.getString("COLUMN_NAME")).thenReturn("id", "id");
+        when(result.getString("DATA_TYPE")).thenReturn("int", "int");
+        return result;
+    }
+    
+    private ResultSet mockViewMetaDataResultSet() throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(true, false);
+        when(result.getString("TABLE_NAME")).thenReturn("tbl_view");
         return result;
     }
     

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowTablesExecutor.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowTablesExecutor.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sho
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.SystemDatabase;
 import org.apache.shardingsphere.database.exception.core.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
@@ -109,6 +110,8 @@ public final class MySQLShowTablesExecutor implements DatabaseAdminQueryExecutor
     }
     
     private LocalDataQueryResultRow getQueryResultRow(final ShardingSphereTable table) {
-        return sqlStatement.isContainsFull() ? new LocalDataQueryResultRow(table.getName(), table.getType()) : new LocalDataQueryResultRow(table.getName());
+        return sqlStatement.isContainsFull()
+                ? new LocalDataQueryResultRow(table.getName(), TableType.VIEW == table.getType() ? "VIEW" : "BASE TABLE")
+                : new LocalDataQueryResultRow(table.getName());
     }
 }

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowTablesExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowTablesExecutorTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.show;
 
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResultMetaData;
@@ -85,8 +86,18 @@ class MySQLShowTablesExecutorTest {
     void assertShowTablesExecutorWithFull() throws SQLException {
         MySQLShowTablesStatement sqlStatement = new MySQLShowTablesStatement(databaseType, null, mock(), true);
         MySQLShowTablesExecutor executor = new MySQLShowTablesExecutor(sqlStatement);
-        executor.execute(mockConnectionSession(), mockMetaData(mockDatabases()));
+        Collection<ShardingSphereTable> tables = new LinkedList<>();
+        tables.add(new ShardingSphereTable("t_account", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
+        tables.add(new ShardingSphereTable("v_account", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), TableType.VIEW));
+        executor.execute(mockConnectionSession(), mockMetaData(mockDatabases(tables)));
         assertThat(executor.getQueryResultMetaData().getColumnCount(), is(2));
+        executor.getMergedResult().next();
+        assertThat(executor.getMergedResult().getValue(1, Object.class), is("t_account"));
+        assertThat(executor.getMergedResult().getValue(2, Object.class), is("BASE TABLE"));
+        executor.getMergedResult().next();
+        assertThat(executor.getMergedResult().getValue(1, Object.class), is("v_account"));
+        assertThat(executor.getMergedResult().getValue(2, Object.class), is("VIEW"));
+        assertFalse(executor.getMergedResult().next());
     }
     
     @Test
@@ -167,6 +178,10 @@ class MySQLShowTablesExecutorTest {
         tables.add(new ShardingSphereTable("t_account_bak", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
         tables.add(new ShardingSphereTable("t_account_detail", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
         tables.add(new ShardingSphereTable("T_TEST", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
+        return mockDatabases(tables);
+    }
+    
+    private Collection<ShardingSphereDatabase> mockDatabases(final Collection<ShardingSphereTable> tables) {
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_db", databaseType, tables, Collections.emptyList());
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn(String.format(DATABASE_PATTERN, 0));


### PR DESCRIPTION
- Load view names in H2MetaDataLoader from INFORMATION_SCHEMA.TABLES and mark views with TableType.VIEW
- Load view names in SQLServerMetaDataLoader from sys.objects and mark views with TableType.VIEW
- Map TableType.TABLE to BASE TABLE in MySQLShowTablesExecutor to align SHOW FULL TABLES output with native MySQL

Fixes #29816.
