### PR TITLE
Support parsing Doris RECOVER and SHOW TRANSACTION syntax

### DIFF
--- a/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
+++ b/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
@@ -607,6 +607,14 @@ public enum SQLVisitorRule {
     
     PLAN_REPLAYER_PLAY("PlanReplayerPlay", SQLStatementType.DAL),
     
+    RECOVER_DATABASE("RecoverDatabase", SQLStatementType.DAL),
+    
+    RECOVER_TABLE("RecoverTable", SQLStatementType.DAL),
+    
+    RECOVER_PARTITION("RecoverPartition", SQLStatementType.DAL),
+    
+    SHOW_TRANSACTION("ShowTransaction", SQLStatementType.DAL),
+    
     CREATE_SQL_BLOCK_RULE("CreateSqlBlockRule", SQLStatementType.DAL),
     
     DELIMITER("Delimiter", SQLStatementType.DAL),

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
@@ -450,6 +450,12 @@ cleanAllProfile
 planReplayerPlay
     : PLAN REPLAYER PLAY DOUBLE_QUOTED_TEXT
     ;
+
+recover
+    : RECOVER DATABASE databaseName NUMBER_? (AS identifier)? #recoverDatabase
+    | RECOVER TABLE tableName NUMBER_? (AS identifier)? #recoverTable
+    | RECOVER PARTITION partitionName NUMBER_? (AS identifier)? FROM tableName (AS identifier)? #recoverPartition
+    ;
 // DORIS ADDED END
 
 dorisAlterSystem
@@ -511,6 +517,10 @@ showResourcesNameWhereCondition
 
 showResourcesResourceTypeWhereCondition
     : RESOURCETYPE EQ_ string_
+    ;
+
+showTransaction
+    : SHOW TRANSACTION fromDatabase? showWhereClause?
     ;
 // DORIS ADDED END
 
@@ -977,5 +987,6 @@ show
     | showTrash
     // DORIS ADDED BEGIN
     | showResources
+    | showTransaction
     // DORIS ADDED END
     ;

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
@@ -175,6 +175,7 @@ execute
     | cancelLoadStatement
     | cleanAllProfile
     | planReplayerPlay
+    | recover
     // TODO consider refactor following sytax to SEMI_? EOF
     ) (SEMI_ EOF? | EOF)
     | EOF

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDALStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDALStatementVisitor.java
@@ -64,6 +64,9 @@ import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.OptionV
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.OptionValueNoOptionTypeContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.PartitionListContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.PartitionNameContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RecoverDatabaseContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RecoverPartitionContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RecoverTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RepairTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RepositoryNameContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ResetOptionContext;
@@ -162,6 +165,7 @@ import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ShowSyn
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ShowDataTypesContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ShowDataContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ShowTrashContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ShowTransactionContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ShowEncryptKeysContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ShowFileContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.AlterSqlBlockRuleContext;
@@ -275,6 +279,8 @@ import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowLoadWar
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowResourcesStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowStreamLoadStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisSyncStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRecoverStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowTransactionStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.ShowResourcesNameConditionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.ShowResourcesResourceTypeConditionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.RepositoryNameSegment;
@@ -1749,6 +1755,58 @@ public final class DorisDALStatementVisitor extends DorisStatementVisitor implem
                 result.setConditionType("LABEL");
             }
             result.setConditionValue(SQLUtils.getExactlyValue(condCtx.string_().getText()));
+        }
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitShowTransaction(final ShowTransactionContext ctx) {
+        DorisShowTransactionStatement result = new DorisShowTransactionStatement(getDatabaseType());
+        if (null != ctx.fromDatabase()) {
+            result.setFromDatabase(((FromDatabaseSegment) visit(ctx.fromDatabase())).getDatabase());
+        }
+        if (null != ctx.showWhereClause()) {
+            result.setWhere((WhereSegment) visit(ctx.showWhereClause()));
+        }
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitRecoverDatabase(final RecoverDatabaseContext ctx) {
+        DorisRecoverStatement result = new DorisRecoverStatement(getDatabaseType());
+        result.setDatabase((DatabaseSegment) visit(ctx.databaseName()));
+        if (null != ctx.NUMBER_()) {
+            result.setObjectId(Long.valueOf(ctx.NUMBER_().getText()));
+        }
+        if (null != ctx.identifier()) {
+            result.setNewName(((IdentifierValue) visit(ctx.identifier())).getValue());
+        }
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitRecoverTable(final RecoverTableContext ctx) {
+        DorisRecoverStatement result = new DorisRecoverStatement(getDatabaseType());
+        result.setTable((SimpleTableSegment) visit(ctx.tableName()));
+        if (null != ctx.NUMBER_()) {
+            result.setObjectId(Long.valueOf(ctx.NUMBER_().getText()));
+        }
+        if (null != ctx.identifier()) {
+            result.setNewName(((IdentifierValue) visit(ctx.identifier())).getValue());
+        }
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitRecoverPartition(final RecoverPartitionContext ctx) {
+        DorisRecoverStatement result = new DorisRecoverStatement(getDatabaseType());
+        result.setPartitionName(((IdentifierValue) visit(ctx.partitionName().identifier())).getValue());
+        result.setTable((SimpleTableSegment) visit(ctx.tableName()));
+        if (null != ctx.NUMBER_()) {
+            result.setObjectId(Long.valueOf(ctx.NUMBER_().getText()));
+        }
+        if (!ctx.identifier().isEmpty()) {
+            result.setNewName(((IdentifierValue) visit(ctx.identifier().get(0))).getValue());
         }
         return result;
     }

--- a/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverStatement.java
+++ b/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverStatement.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.dal;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.DatabaseSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.DALStatement;
+
+/**
+ * Recover statement for Doris.
+ */
+@Getter
+@Setter
+public final class DorisRecoverStatement extends DALStatement {
+    
+    private DatabaseSegment database;
+    
+    private SimpleTableSegment table;
+    
+    private String partitionName;
+    
+    private Long objectId;
+    
+    private String newName;
+    
+    public DorisRecoverStatement(final DatabaseType databaseType) {
+        super(databaseType);
+    }
+}

--- a/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisShowTransactionStatement.java
+++ b/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisShowTransactionStatement.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.dal;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.DatabaseSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.DALStatement;
+
+import java.util.Optional;
+
+/**
+ * Show transaction statement for Doris.
+ */
+@Getter
+@Setter
+public final class DorisShowTransactionStatement extends DALStatement {
+    
+    private DatabaseSegment fromDatabase;
+    
+    private WhereSegment where;
+    
+    public DorisShowTransactionStatement(final DatabaseType databaseType) {
+        super(databaseType);
+    }
+    
+    /**
+     * Get from database segment.
+     *
+     * @return from database segment
+     */
+    public Optional<DatabaseSegment> getFromDatabase() {
+        return Optional.ofNullable(fromDatabase);
+    }
+    
+    /**
+     * Get where segment.
+     *
+     * @return where segment
+     */
+    public Optional<WhereSegment> getWhere() {
+        return Optional.ofNullable(where);
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/DorisDALStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/DorisDALStatementAssert.java
@@ -49,6 +49,8 @@ import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowResourc
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowStreamLoadStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowProcStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowTrashStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRecoverStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowTransactionStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowCreateRoutineLoadStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowEncryptKeysStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowFileStatement;
@@ -83,6 +85,8 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.d
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisShowLoadStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisShowLoadWarningsStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisShowResourcesStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisRecoverStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisShowTransactionStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisShowStreamLoadStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisShowCreateRoutineLoadStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisShowQueryStatsStatementAssert;
@@ -119,6 +123,8 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowLoadStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowLoadWarningsStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowResourcesStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisRecoverStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowTransactionStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowStreamLoadStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowCreateRoutineLoadStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowEncryptKeysStatementTestCase;
@@ -212,6 +218,10 @@ public final class DorisDALStatementAssert {
             DorisPlanReplayerPlayStatementAssert.assertIs(assertContext, (DorisPlanReplayerPlayStatement) actual, (DorisPlanReplayerPlayStatementTestCase) expected);
         } else if (actual instanceof DorisShowResourcesStatement) {
             DorisShowResourcesStatementAssert.assertIs(assertContext, (DorisShowResourcesStatement) actual, (DorisShowResourcesStatementTestCase) expected);
+        } else if (actual instanceof DorisRecoverStatement) {
+            DorisRecoverStatementAssert.assertIs(assertContext, (DorisRecoverStatement) actual, (DorisRecoverStatementTestCase) expected);
+        } else if (actual instanceof DorisShowTransactionStatement) {
+            DorisShowTransactionStatementAssert.assertIs(assertContext, (DorisShowTransactionStatement) actual, (DorisShowTransactionStatementTestCase) expected);
         }
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisRecoverStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisRecoverStatementAssert.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRecoverStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.database.DatabaseAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisRecoverStatementTestCase;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Recover statement assert for Doris.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DorisRecoverStatementAssert {
+    
+    /**
+     * Assert recover statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual recover statement
+     * @param expected expected recover statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DorisRecoverStatement actual, final DorisRecoverStatementTestCase expected) {
+        assertDatabase(assertContext, actual, expected);
+        assertTable(assertContext, actual, expected);
+        assertPartitionName(assertContext, actual, expected);
+        assertObjectId(assertContext, actual, expected);
+        assertNewName(assertContext, actual, expected);
+    }
+    
+    private static void assertDatabase(final SQLCaseAssertContext assertContext, final DorisRecoverStatement actual, final DorisRecoverStatementTestCase expected) {
+        if (null != expected.getDatabase()) {
+            assertNotNull(actual.getDatabase(), assertContext.getText("Actual database should exist."));
+            DatabaseAssert.assertIs(assertContext, actual.getDatabase(), expected.getDatabase());
+        } else {
+            assertNull(actual.getDatabase(), assertContext.getText("Actual database should not exist."));
+        }
+    }
+    
+    private static void assertTable(final SQLCaseAssertContext assertContext, final DorisRecoverStatement actual, final DorisRecoverStatementTestCase expected) {
+        if (null != expected.getTable()) {
+            assertNotNull(actual.getTable(), assertContext.getText("Actual table should exist."));
+            TableAssert.assertIs(assertContext, actual.getTable(), expected.getTable());
+        } else {
+            assertNull(actual.getTable(), assertContext.getText("Actual table should not exist."));
+        }
+    }
+    
+    private static void assertPartitionName(final SQLCaseAssertContext assertContext, final DorisRecoverStatement actual, final DorisRecoverStatementTestCase expected) {
+        if (null != expected.getPartitionName()) {
+            assertThat(assertContext.getText("Partition name does not match: "), actual.getPartitionName(), is(expected.getPartitionName()));
+        } else {
+            assertNull(actual.getPartitionName(), assertContext.getText("Actual partition name should not exist."));
+        }
+    }
+    
+    private static void assertObjectId(final SQLCaseAssertContext assertContext, final DorisRecoverStatement actual, final DorisRecoverStatementTestCase expected) {
+        if (null != expected.getObjectId()) {
+            assertThat(assertContext.getText("Object id does not match: "), actual.getObjectId(), is(expected.getObjectId()));
+        } else {
+            assertNull(actual.getObjectId(), assertContext.getText("Actual object id should not exist."));
+        }
+    }
+    
+    private static void assertNewName(final SQLCaseAssertContext assertContext, final DorisRecoverStatement actual, final DorisRecoverStatementTestCase expected) {
+        if (null != expected.getNewName()) {
+            assertThat(assertContext.getText("New name does not match: "), actual.getNewName(), is(expected.getNewName()));
+        } else {
+            assertNull(actual.getNewName(), assertContext.getText("Actual new name should not exist."));
+        }
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisShowTransactionStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisShowTransactionStatementAssert.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisShowTransactionStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.database.DatabaseAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.where.WhereClauseAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowTransactionStatementTestCase;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Show transaction statement assert for Doris.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DorisShowTransactionStatementAssert {
+    
+    /**
+     * Assert show transaction statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual show transaction statement
+     * @param expected expected show transaction statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DorisShowTransactionStatement actual, final DorisShowTransactionStatementTestCase expected) {
+        assertDatabase(assertContext, actual, expected);
+        assertWhere(assertContext, actual, expected);
+    }
+    
+    private static void assertDatabase(final SQLCaseAssertContext assertContext, final DorisShowTransactionStatement actual, final DorisShowTransactionStatementTestCase expected) {
+        if (null != expected.getFromDatabase()) {
+            assertNotNull(actual.getFromDatabase().orElse(null), assertContext.getText("Actual database should exist."));
+            DatabaseAssert.assertIs(assertContext, actual.getFromDatabase().get(), expected.getFromDatabase());
+        } else {
+            assertNull(actual.getFromDatabase().orElse(null), assertContext.getText("Actual database should not exist."));
+        }
+    }
+    
+    private static void assertWhere(final SQLCaseAssertContext assertContext, final DorisShowTransactionStatement actual, final DorisShowTransactionStatementTestCase expected) {
+        if (null != expected.getWhere()) {
+            assertNotNull(actual.getWhere().orElse(null), assertContext.getText("Actual where segment should exist."));
+            WhereClauseAssert.assertIs(assertContext, actual.getWhere().get(), expected.getWhere());
+        } else {
+            assertNull(actual.getWhere().orElse(null), assertContext.getText("Actual where segment should not exist."));
+        }
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -61,6 +61,8 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowSyncJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowTableStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowTrashStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisRecoverStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisShowTransactionStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisSwitchStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisSyncStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisUnsetVariableStatementTestCase;
@@ -822,6 +824,12 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "show-trash")
     private final List<DorisShowTrashStatementTestCase> showTrashTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "recover")
+    private final List<DorisRecoverStatementTestCase> recoverTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "show-transaction")
+    private final List<DorisShowTransactionStatementTestCase> showTransactionTestCases = new LinkedList<>();
     
     @XmlElement(name = "admin-set-replica-status")
     private final List<DorisAdminSetReplicaStatusStatementTestCase> adminSetReplicaStatusTestCases = new LinkedList<>();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisRecoverStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisRecoverStatementTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.database.ExpectedDatabase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSimpleTable;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * Recover statement test case for Doris.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+public final class DorisRecoverStatementTestCase extends SQLParserTestCase {
+    
+    @XmlElement
+    private ExpectedDatabase database;
+    
+    @XmlElement(name = "table")
+    private ExpectedSimpleTable table;
+    
+    @XmlAttribute(name = "partition-name")
+    private String partitionName;
+    
+    @XmlAttribute(name = "object-id")
+    private Long objectId;
+    
+    @XmlAttribute(name = "new-name")
+    private String newName;
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisShowTransactionStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisShowTransactionStatementTestCase.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.database.ExpectedDatabase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.where.ExpectedWhereClause;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * Show transaction statement test case for Doris.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+public final class DorisShowTransactionStatementTestCase extends SQLParserTestCase {
+    
+    @XmlElement(name = "database")
+    private ExpectedDatabase fromDatabase;
+    
+    @XmlElement(name = "where")
+    private ExpectedWhereClause where;
+}

--- a/test/it/parser/src/main/resources/case/dal/recover.xml
+++ b/test/it/parser/src/main/resources/case/dal/recover.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <recover sql-case-id="recover_database">
+        <database name="example_db" start-index="17" stop-index="26" />
+    </recover>
+
+    <recover sql-case-id="recover_database_with_id" object-id="10000">
+        <database name="example_db" start-index="17" stop-index="26" />
+    </recover>
+
+    <recover sql-case-id="recover_database_with_id_and_new_name" object-id="10000" new-name="new_example_db">
+        <database name="example_db" start-index="17" stop-index="26" />
+    </recover>
+
+    <recover sql-case-id="recover_table">
+        <table name="example_tbl" start-index="14" stop-index="35">
+            <owner name="example_db" start-index="14" stop-index="23" />
+        </table>
+    </recover>
+
+    <recover sql-case-id="recover_table_with_id" object-id="20000">
+        <table name="example_tbl" start-index="14" stop-index="35">
+            <owner name="example_db" start-index="14" stop-index="23" />
+        </table>
+    </recover>
+
+    <recover sql-case-id="recover_table_with_new_name" new-name="new_example_tbl">
+        <table name="example_tbl" start-index="14" stop-index="35">
+            <owner name="example_db" start-index="14" stop-index="23" />
+        </table>
+    </recover>
+
+    <recover sql-case-id="recover_partition" partition-name="p1">
+        <table name="example_tbl" start-index="26" stop-index="36" />
+    </recover>
+
+    <recover sql-case-id="recover_partition_with_id" partition-name="p1" object-id="300">
+        <table name="example_tbl" start-index="30" stop-index="40" />
+    </recover>
+
+    <recover sql-case-id="recover_partition_with_id_and_new_name" partition-name="p1" object-id="300" new-name="new_p1">
+        <table name="example_tbl" start-index="40" stop-index="50" />
+    </recover>
+
+    <recover sql-case-id="recover_partition_with_new_name_after_from" partition-name="p1" object-id="300" new-name="new_p1">
+        <table name="example_tbl" start-index="30" stop-index="40" />
+    </recover>
+</sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dal/show-transaction.xml
+++ b/test/it/parser/src/main/resources/case/dal/show-transaction.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <show-transaction sql-case-id="show_transaction_where_id">
+        <where start-index="17" stop-index="31">
+            <expr>
+                <binary-operation-expression start-index="23" stop-index="31">
+                    <left>
+                        <column name="ID" start-index="23" stop-index="24" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="4005" start-index="28" stop-index="31" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </show-transaction>
+
+    <show-transaction sql-case-id="show_transaction_from_database_where_id">
+        <database name="example_db" start-index="22" stop-index="31" />
+        <where start-index="33" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="39" stop-index="47">
+                    <left>
+                        <column name="ID" start-index="39" stop-index="40" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="4005" start-index="44" stop-index="47" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </show-transaction>
+
+    <show-transaction sql-case-id="show_transaction_where_label">
+        <where start-index="17" stop-index="42">
+            <expr>
+                <binary-operation-expression start-index="23" stop-index="42">
+                    <left>
+                        <column name="LABEL" start-index="23" stop-index="27" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="label_name" start-delimiter="'" end-delimiter="'" start-index="31" stop-index="42" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </show-transaction>
+</sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/recover.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/recover.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="recover_database" value="RECOVER DATABASE example_db" db-types="Doris" />
+    <sql-case id="recover_database_with_id" value="RECOVER DATABASE example_db 10000" db-types="Doris" />
+    <sql-case id="recover_database_with_id_and_new_name" value="RECOVER DATABASE example_db 10000 AS new_example_db" db-types="Doris" />
+    <sql-case id="recover_table" value="RECOVER TABLE example_db.example_tbl" db-types="Doris" />
+    <sql-case id="recover_table_with_id" value="RECOVER TABLE example_db.example_tbl 20000" db-types="Doris" />
+    <sql-case id="recover_table_with_new_name" value="RECOVER TABLE example_db.example_tbl AS new_example_tbl" db-types="Doris" />
+    <sql-case id="recover_partition" value="RECOVER PARTITION p1 FROM example_tbl" db-types="Doris" />
+    <sql-case id="recover_partition_with_id" value="RECOVER PARTITION p1 300 FROM example_tbl" db-types="Doris" />
+    <sql-case id="recover_partition_with_id_and_new_name" value="RECOVER PARTITION p1 300 AS new_p1 FROM example_tbl" db-types="Doris" />
+    <sql-case id="recover_partition_with_new_name_after_from" value="RECOVER PARTITION p1 300 FROM example_tbl AS new_p1" db-types="Doris" />
+</sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/show-transaction.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/show-transaction.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="show_transaction_where_id" value="SHOW TRANSACTION WHERE ID = 4005" db-types="Doris" />
+    <sql-case id="show_transaction_from_database_where_id" value="SHOW TRANSACTION FROM example_db WHERE ID = 4005" db-types="Doris" />
+    <sql-case id="show_transaction_where_label" value="SHOW TRANSACTION WHERE LABEL = 'label_name'" db-types="Doris" />
+</sql-cases>


### PR DESCRIPTION
Add Doris RECOVER DATABASE/TABLE/PARTITION and SHOW TRANSACTION grammar rules, statement models, DAL visitor methods and visitor rule registration, with parser IT cases covering all official documentation examples.

Fix issue #31505.
