### PR TITLE
Preserve actual table identifier case in metadata loading

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNodes.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNodes.java
@@ -61,6 +61,22 @@ public final class DataNodes {
         return result;
     }
     
+    /**
+     * Whether data node table names are loaded from storage metadata.
+     *
+     * @param tableName table name
+     * @return whether data node table names are loaded from storage metadata
+     */
+    public boolean isDataNodeTableNameLoadedFromStorage(final String tableName) {
+        for (ShardingSphereRule each : rules) {
+            Optional<DataNodeRuleAttribute> attribute = each.getAttributes().findAttribute(DataNodeRuleAttribute.class);
+            if (attribute.isPresent() && !attribute.get().getDataNodesByTableName(tableName).isEmpty()) {
+                return attribute.get().isDataNodeTableNameLoadedFromStorage();
+            }
+        }
+        return false;
+    }
+    
     private Collection<DataNode> getDataNodesByTableName(final String tableName) {
         for (ShardingSphereRule each : rules) {
             Collection<DataNode> dataNodes = getDataNodesByTableName(each, tableName);

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtils.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtils.java
@@ -32,7 +32,6 @@ import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.datanode.UnsupportedActualDataNodeStructureException;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilderMaterial;
-import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 import javax.sql.DataSource;
@@ -68,10 +67,11 @@ public final class SchemaMetaDataUtils {
         boolean checkMetaDataEnable = material.getProps().getValue(ConfigurationPropertyKey.CHECK_TABLE_METADATA_ENABLED);
         for (String each : tableNames) {
             checkDataSourceTypeIncludeInstanceAndSetDatabaseTableMap(unsupportedThreeTierStorageStructureDatabaseTypes, dataNodes, each);
+            boolean tableNameLoadedFromStorage = dataNodes.isDataNodeTableNameLoadedFromStorage(each);
             if (checkMetaDataEnable) {
-                addAllActualTableDataNode(material, dataSourceTableGroups, dataNodes, each);
+                addAllActualTableDataNode(material, dataSourceTableGroups, dataNodes, each, protocolType, tableNameLoadedFromStorage);
             } else {
-                addOneActualTableDataNode(material, dataSourceTableGroups, dataNodes, each);
+                addOneActualTableDataNode(material, dataSourceTableGroups, dataNodes, each, protocolType, tableNameLoadedFromStorage);
             }
         }
         Collection<MetaDataLoaderMaterial> result = new LinkedList<>();
@@ -79,25 +79,20 @@ public final class SchemaMetaDataUtils {
         for (Entry<String, Collection<String>> entry : dataSourceTableGroups.entrySet()) {
             DatabaseType storageType = material.getStorageUnits().get(entry.getKey()).getStorageType();
             String defaultSchemaName = new DatabaseTypeRegistry(storageType).getDefaultSchemaName(material.getDefaultSchemaName());
-            result.addAll(buildMaterials(material, entry.getKey(), entry.getValue(), protocolType, storageType, defaultSchemaName, loadTableMetadataBatchSize));
+            result.addAll(buildMaterials(material, entry.getKey(), entry.getValue(), storageType, defaultSchemaName, loadTableMetadataBatchSize));
         }
         return result;
     }
     
     private static Collection<MetaDataLoaderMaterial> buildMaterials(final GenericSchemaBuilderMaterial material, final String dataSourceName, final Collection<String> actualTableNames,
-                                                                     final DatabaseType protocolType, final DatabaseType storageType, final String defaultSchemaName,
+                                                                     final DatabaseType storageType, final String defaultSchemaName,
                                                                      final int loadTableMetadataBatchSize) {
         Collection<MetaDataLoaderMaterial> result = new LinkedList<>();
         DataSource dataSource = getDataSource(material, dataSourceName);
         for (List<String> each : Lists.partition(new ArrayList<>(actualTableNames), loadTableMetadataBatchSize)) {
-            Collection<String> tableNames = protocolType.equals(storageType) ? each : normalize(each, material.getIdentifierContext());
-            result.add(new MetaDataLoaderMaterial(tableNames, dataSourceName, dataSource, storageType, defaultSchemaName));
+            result.add(new MetaDataLoaderMaterial(each, dataSourceName, dataSource, storageType, defaultSchemaName));
         }
         return result;
-    }
-    
-    private static Collection<String> normalize(final Collection<String> tableNames, final DatabaseIdentifierContext identifierContext) {
-        return tableNames.stream().map(each -> identifierContext.normalizeStorage(IdentifierScope.TABLE, new IdentifierValue(each))).collect(Collectors.toList());
     }
     
     private static DataSource getDataSource(final GenericSchemaBuilderMaterial material, final String dataSourceName) {
@@ -123,13 +118,15 @@ public final class SchemaMetaDataUtils {
     }
     
     private static void addOneActualTableDataNode(final GenericSchemaBuilderMaterial material,
-                                                  final Map<String, Collection<String>> dataSourceTableGroups, final DataNodes dataNodes, final String table) {
+                                                  final Map<String, Collection<String>> dataSourceTableGroups, final DataNodes dataNodes, final String table,
+                                                  final DatabaseType protocolType, final boolean tableNameLoadedFromStorage) {
         Optional<DataNode> dataNode = dataNodes.getDataNodes(table).stream().filter(each -> isSameDataSourceNameSchemaName(material, each)).findFirst();
         if (!dataNode.isPresent() && !material.getStorageUnits().keySet().iterator().hasNext()) {
             return;
         }
         String dataSourceName = dataNode.map(DataNode::getDataSourceName).orElseGet(() -> material.getStorageUnits().keySet().iterator().next());
-        String tableName = dataNode.map(DataNode::getTableName).orElse(table);
+        String tableName = dataNode.map(optional -> getTableName(material, protocolType, optional, tableNameLoadedFromStorage))
+                .orElseGet(() -> normalizeTableName(material, protocolType, dataSourceName, table));
         addDataSourceTableGroups(dataSourceName, tableName, dataSourceTableGroups);
     }
     
@@ -139,13 +136,25 @@ public final class SchemaMetaDataUtils {
     }
     
     private static void addAllActualTableDataNode(final GenericSchemaBuilderMaterial material,
-                                                  final Map<String, Collection<String>> dataSourceTableGroups, final DataNodes dataNodes, final String table) {
+                                                  final Map<String, Collection<String>> dataSourceTableGroups, final DataNodes dataNodes, final String table,
+                                                  final DatabaseType protocolType, final boolean tableNameLoadedFromStorage) {
         Collection<DataNode> tableDataNodes = dataNodes.getDataNodes(table);
         if (tableDataNodes.isEmpty() && !material.getStorageUnits().isEmpty()) {
-            addDataSourceTableGroups(material.getStorageUnits().keySet().iterator().next(), table, dataSourceTableGroups);
+            String dataSourceName = material.getStorageUnits().keySet().iterator().next();
+            addDataSourceTableGroups(dataSourceName, normalizeTableName(material, protocolType, dataSourceName, table), dataSourceTableGroups);
         } else {
-            tableDataNodes.forEach(each -> addDataSourceTableGroups(each.getDataSourceName(), each.getTableName(), dataSourceTableGroups));
+            tableDataNodes.forEach(each -> addDataSourceTableGroups(each.getDataSourceName(), getTableName(material, protocolType, each, tableNameLoadedFromStorage), dataSourceTableGroups));
         }
+    }
+    
+    private static String getTableName(final GenericSchemaBuilderMaterial material, final DatabaseType protocolType, final DataNode dataNode,
+                                       final boolean tableNameLoadedFromStorage) {
+        return tableNameLoadedFromStorage ? dataNode.getTableName() : normalizeTableName(material, protocolType, dataNode.getDataSourceName(), dataNode.getTableName());
+    }
+    
+    private static String normalizeTableName(final GenericSchemaBuilderMaterial material, final DatabaseType protocolType, final String dataSourceName, final String tableName) {
+        DatabaseType storageType = material.getStorageUnits().get(dataSourceName).getStorageType();
+        return protocolType.equals(storageType) ? tableName : material.getIdentifierContext().normalizeStorage(IdentifierScope.TABLE, new IdentifierValue(tableName));
     }
     
     private static void addDataSourceTableGroups(final String dataSourceName, final String tableName, final Map<String, Collection<String>> dataSourceTableGroups) {

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/rule/attribute/datanode/DataNodeRuleAttribute.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/rule/attribute/datanode/DataNodeRuleAttribute.java
@@ -45,6 +45,15 @@ public interface DataNodeRuleAttribute extends RuleAttribute {
     Collection<DataNode> getDataNodesByTableName(String tableName);
     
     /**
+     * Whether data node table names are loaded from storage metadata.
+     *
+     * @return whether data node table names are loaded from storage metadata
+     */
+    default boolean isDataNodeTableNameLoadedFromStorage() {
+        return false;
+    }
+    
+    /**
      * Find first actual table name.
      *
      * @param logicTable logic table name

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodesTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodesTest.java
@@ -34,6 +34,8 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -128,6 +130,16 @@ class DataNodesTest {
         assertThat(thirdDataNode.getTableName(), is("t_single"));
     }
     
+    @Test
+    void assertDataNodeTableNameLoadedFromStorage() {
+        assertTrue(new DataNodes(mockDataNodeRules()).isDataNodeTableNameLoadedFromStorage("t_single"));
+    }
+    
+    @Test
+    void assertDataNodeTableNameNotLoadedFromStorage() {
+        assertFalse(new DataNodes(mockDataNodeRules()).isDataNodeTableNameLoadedFromStorage("t_order"));
+    }
+    
     private Collection<ShardingSphereRule> mockShardingSphereRules() {
         Collection<ShardingSphereRule> result = new LinkedList<>();
         result.add(mockDataSourceMapperRule());
@@ -153,6 +165,7 @@ class DataNodesTest {
     private ShardingSphereRule mockSingleRule() {
         DataNodeRuleAttribute ruleAttribute = mock(DataNodeRuleAttribute.class);
         when(ruleAttribute.getDataNodesByTableName("t_single")).thenReturn(Collections.singleton(new DataNode("readwrite_ds", (String) null, "t_single")));
+        when(ruleAttribute.isDataNodeTableNameLoadedFromStorage()).thenReturn(true);
         ShardingSphereRule result = mock(ShardingSphereRule.class);
         when(result.getAttributes()).thenReturn(new RuleAttributes(ruleAttribute));
         return result;

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -140,12 +141,12 @@ class SchemaMetaDataUtilsTest {
         assertThat(new ArrayList<>(actual.get(1).getActualTableNames()), is(Collections.singletonList("foo_tbl_2")));
     }
     
-    @Test
-    void assertGetMetaDataLoaderMaterialsPreservesActualTableNameFromDataNode() {
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {true, false})
+    void assertGetMetaDataLoaderMaterialsPreservesActualTableNameFromDataNode(final boolean checkMetaDataEnabled) {
         Map<String, StorageUnit> storageUnits = new LinkedHashMap<>(1, 1F);
         storageUnits.put("ds_0", mockStorageUnit(ORACLE_DATABASE_TYPE, mock(DataSource.class)));
-        ConfigurationProperties props = new ConfigurationProperties(PropertiesBuilder.build(new Property(
-                TemporaryConfigurationPropertyKey.METADATA_IDENTIFIER_CASE_SENSITIVITY.getKey(), MetadataIdentifierCaseSensitivity.INSENSITIVE.name())));
+        ConfigurationProperties props = createIdentifierCaseProperties(checkMetaDataEnabled);
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
                 Collections.singleton(mockStorageLoadedDataNodeRule(Collections.singleton(new DataNode("ds_0.t_user")))), props, "foo_db",
                 DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
@@ -154,10 +155,11 @@ class SchemaMetaDataUtilsTest {
         assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Collections.singletonList("t_user")));
     }
     
-    @Test
-    void assertGetMetaDataLoaderMaterialsNormalizesConfiguredDataNodeTableName() {
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {true, false})
+    void assertGetMetaDataLoaderMaterialsNormalizesConfiguredDataNodeTableName(final boolean checkMetaDataEnabled) {
         Map<String, StorageUnit> storageUnits = Collections.singletonMap("ds_0", mockStorageUnit(ORACLE_DATABASE_TYPE, mock(DataSource.class)));
-        ConfigurationProperties props = createProperties(Boolean.TRUE, null);
+        ConfigurationProperties props = createIdentifierCaseProperties(checkMetaDataEnabled);
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
                 Collections.singleton(mockDataNodeRule(Collections.singleton(new DataNode("ds_0.t_user")))), props, "foo_db",
                 DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
@@ -258,6 +260,12 @@ class SchemaMetaDataUtilsTest {
         return new ConfigurationProperties(PropertiesBuilder.build(
                 new Property(ConfigurationPropertyKey.CHECK_TABLE_METADATA_ENABLED.getKey(), null == checkMetaDataEnabled ? null : checkMetaDataEnabled.toString()),
                 new Property(ConfigurationPropertyKey.LOAD_TABLE_METADATA_BATCH_SIZE.getKey(), null == loadTableMetadataBatchSize ? null : loadTableMetadataBatchSize.toString())));
+    }
+    
+    private static ConfigurationProperties createIdentifierCaseProperties(final boolean checkMetaDataEnabled) {
+        return new ConfigurationProperties(PropertiesBuilder.build(
+                new Property(ConfigurationPropertyKey.CHECK_TABLE_METADATA_ENABLED.getKey(), Boolean.toString(checkMetaDataEnabled)),
+                new Property(TemporaryConfigurationPropertyKey.METADATA_IDENTIFIER_CASE_SENSITIVITY.getKey(), MetadataIdentifierCaseSensitivity.INSENSITIVE.name())));
     }
     
     private static Map<String, StorageUnit> mockStorageUnits(final String... dataSourceNames) {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
@@ -141,17 +141,41 @@ class SchemaMetaDataUtilsTest {
     }
     
     @Test
-    void assertGetMetaDataLoaderMaterialsNormalizeActualTableNamesByTableScope() {
+    void assertGetMetaDataLoaderMaterialsPreservesActualTableNameFromDataNode() {
         Map<String, StorageUnit> storageUnits = new LinkedHashMap<>(1, 1F);
         storageUnits.put("ds_0", mockStorageUnit(ORACLE_DATABASE_TYPE, mock(DataSource.class)));
         ConfigurationProperties props = new ConfigurationProperties(PropertiesBuilder.build(new Property(
                 TemporaryConfigurationPropertyKey.METADATA_IDENTIFIER_CASE_SENSITIVITY.getKey(), MetadataIdentifierCaseSensitivity.INSENSITIVE.name())));
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
+                Collections.singleton(mockStorageLoadedDataNodeRule(Collections.singleton(new DataNode("ds_0.t_user")))), props, "foo_db",
+                DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
+        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), MYSQL_DATABASE_TYPE, material));
+        assertThat(actual.size(), is(1));
+        assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Collections.singletonList("t_user")));
+    }
+    
+    @Test
+    void assertGetMetaDataLoaderMaterialsNormalizesConfiguredDataNodeTableName() {
+        Map<String, StorageUnit> storageUnits = Collections.singletonMap("ds_0", mockStorageUnit(ORACLE_DATABASE_TYPE, mock(DataSource.class)));
+        ConfigurationProperties props = createProperties(Boolean.TRUE, null);
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
                 Collections.singleton(mockDataNodeRule(Collections.singleton(new DataNode("ds_0.t_user")))), props, "foo_db",
                 DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
         List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), MYSQL_DATABASE_TYPE, material));
         assertThat(actual.size(), is(1));
         assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Collections.singletonList("T_USER")));
+    }
+    
+    @Test
+    void assertGetMetaDataLoaderMaterialsNormalizesFallbackTableName() {
+        Map<String, StorageUnit> storageUnits = Collections.singletonMap("ds_0", mockStorageUnit(ORACLE_DATABASE_TYPE, mock(DataSource.class)));
+        ConfigurationProperties props = createProperties(Boolean.TRUE, null);
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
+                Collections.singleton(mockDataNodeRule(Collections.emptyList())), props, "foo_db",
+                DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
+        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), MYSQL_DATABASE_TYPE, material));
+        assertThat(actual.size(), is(1));
+        assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Collections.singletonList("FOO_TBL")));
     }
     
     @Test
@@ -168,13 +192,13 @@ class SchemaMetaDataUtilsTest {
     }
     
     @Test
-    void assertGetMetaDataLoaderMaterialsNormalizeActualTableNamesByStorageTypeWithMixedStorageUnits() throws SQLException {
+    void assertGetMetaDataLoaderMaterialsPreservesActualTableNamesWithMixedStorageUnits() throws SQLException {
         Map<String, StorageUnit> storageUnits = new LinkedHashMap<>(2, 1F);
         storageUnits.put("ds_mysql", mockStorageUnit(MYSQL_DATABASE_TYPE, mockMySQLDataSource(1)));
         storageUnits.put("ds_oracle", mockStorageUnit(ORACLE_DATABASE_TYPE, mock(DataSource.class)));
         ConfigurationProperties props = createProperties(Boolean.TRUE, null);
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(
-                mockDataNodeRule(Arrays.asList(new DataNode("ds_mysql.t_order"), new DataNode("ds_oracle.t_user")))), props, "foo_db",
+                mockStorageLoadedDataNodeRule(Arrays.asList(new DataNode("ds_mysql.t_order"), new DataNode("ds_oracle.t_user")))), props, "foo_db",
                 DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
         List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), MYSQL_DATABASE_TYPE, material));
         assertThat(actual.size(), is(2));
@@ -189,6 +213,12 @@ class SchemaMetaDataUtilsTest {
         DataNodeRuleAttribute ruleAttribute = mock(DataNodeRuleAttribute.class);
         when(ruleAttribute.getDataNodesByTableName("foo_tbl")).thenReturn(dataNodes);
         when(result.getAttributes()).thenReturn(new RuleAttributes(ruleAttribute));
+        return result;
+    }
+    
+    private ShardingSphereRule mockStorageLoadedDataNodeRule(final Collection<DataNode> dataNodes) {
+        ShardingSphereRule result = mockDataNodeRule(dataNodes);
+        when(result.getAttributes().getAttribute(DataNodeRuleAttribute.class).isDataNodeTableNameLoadedFromStorage()).thenReturn(true);
         return result;
     }
     

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/attribute/SingleDataNodeRuleAttribute.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/attribute/SingleDataNodeRuleAttribute.java
@@ -54,6 +54,11 @@ public final class SingleDataNodeRuleAttribute implements DataNodeRuleAttribute 
     }
     
     @Override
+    public boolean isDataNodeTableNameLoadedFromStorage() {
+        return true;
+    }
+    
+    @Override
     public Optional<String> findFirstActualTable(final String logicTable) {
         return Optional.empty();
     }

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/attribute/SingleDataNodeRuleAttributeTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/attribute/SingleDataNodeRuleAttributeTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SingleDataNodeRuleAttributeTest {
     
@@ -50,6 +51,11 @@ class SingleDataNodeRuleAttributeTest {
     @MethodSource("getDataNodesByTableNameArguments")
     void assertGetDataNodesByTableName(final String name, final String tableName, final Collection<DataNode> expectedDataNodes) {
         assertThat(ruleAttribute.getDataNodesByTableName(tableName), is(expectedDataNodes));
+    }
+    
+    @Test
+    void assertIsDataNodeTableNameLoadedFromStorage() {
+        assertTrue(ruleAttribute.isDataNodeTableNameLoadedFromStorage());
     }
     
     @Test


### PR DESCRIPTION
What: Distinguish storage-discovered data node table names from configuration-derived names before building metadata loader materials.

Why: Preserve quoted identifiers exactly while normalizing configured names for the storage database.

Changes proposed in this pull request:
  - Preserve actual table identifier case in metadata loading

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [ ] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
