### PR TITLE
Support for the CREATE WORKLOAD GROUP statement and the ANALYZE TABLE statement for Doris

### DIFF
--- a/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
+++ b/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
@@ -621,6 +621,8 @@ public enum SQLVisitorRule {
     
     CREATE_SQL_BLOCK_RULE("CreateSqlBlockRule", SQLStatementType.DAL),
     
+    CREATE_WORKLOAD_GROUP("CreateWorkloadGroup", SQLStatementType.DAL),
+    
     DELIMITER("Delimiter", SQLStatementType.DAL),
     
     CALL("Call", SQLStatementType.DML),

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
@@ -403,6 +403,9 @@ identifierKeywordsUnambiguous
     | PASSWORD_LOCK_TIME
     | PATH
     | PAUSE
+    // DORIS ADDED BEGIN
+    | PERCENT
+    // DORIS ADDED END
     | PHASE
     // DORIS ADDED BEGIN
     | PLAN
@@ -479,6 +482,9 @@ identifierKeywordsUnambiguous
     | ROW_COUNT
     | ROW_FORMAT
     | RTREE
+    // DORIS ADDED BEGIN
+    | SAMPLE
+    // DORIS ADDED END
     | SCHEDULE
     | SCHEMA_NAME
     | SECONDARY_ENGINE
@@ -579,6 +585,9 @@ identifierKeywordsUnambiguous
     | WEIGHT_STRING
     | WITHOUT
     | WORK
+    // DORIS ADDED BEGIN
+    | WORKLOAD
+    // DORIS ADDED END
     | WRAPPER
     | X509
     | XID

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
@@ -380,9 +380,18 @@ uninstallPlugin
     : UNINSTALL PLUGIN pluginName
     ;
 
+// DORIS CHANGED BEGIN
 analyzeTable
-    : ANALYZE (NO_WRITE_TO_BINLOG | LOCAL)? tableOrTables tableList histogram?
+    : ANALYZE (NO_WRITE_TO_BINLOG | LOCAL)? tableOrTables tableList (LP_ columnNames RP_)? analyzeOption* histogram?
     ;
+// DORIS CHANGED END
+
+// DORIS ADDED BEGIN
+analyzeOption
+    : WITH SYNC
+    | WITH SAMPLE (PERCENT | ROWS) numberLiterals
+    ;
+// DORIS ADDED END
 
 histogram
     : UPDATE HISTOGRAM ON columnNames (WITH NUMBER_ BUCKETS | USING DATA string_)?
@@ -597,6 +606,12 @@ createResourceGroup
     : CREATE RESOURCE GROUP groupName TYPE EQ_ (SYSTEM | USER) (VCPU EQ_? vcpuSpec (COMMA_ vcpuSpec)*)?
     (THREAD_PRIORITY EQ_? numberLiterals)? (ENABLE | DISABLE)?
     ;
+
+// DORIS ADDED BEGIN
+createWorkloadGroup
+    : CREATE WORKLOAD GROUP ifNotExists? groupName propertiesClause
+    ;
+// DORIS ADDED END
 
 dropResourceGroup
     : DROP RESOURCE GROUP groupName FORCE?

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DorisKeyword.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DorisKeyword.g4
@@ -2010,6 +2010,10 @@ PAUSE
     : P A U S E
     ;
 
+PERCENT
+    : P E R C E N T
+    ;
+
 PERCENT_RANK
     : P E R C E N T UL_ R A N K
     ;
@@ -2484,6 +2488,10 @@ ROW_NUMBER
 
 RTREE
     : R T R E E
+    ;
+
+SAMPLE
+    : S A M P L E
     ;
 
 SAVEPOINT
@@ -3318,6 +3326,10 @@ WITHOUT
 
 WORK
     : W O R K
+    ;
+
+WORKLOAD
+    : W O R K L O A D
     ;
 
 WRAPPER

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
@@ -55,6 +55,7 @@ execute
     | alterResourceGroup
     | alterResource
     | createResourceGroup
+    | createWorkloadGroup
     | dropResourceGroup
     | prepare
     | executeStmt

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDALStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDALStatementVisitor.java
@@ -158,6 +158,7 @@ import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.AdminCo
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.AdminCheckTabletContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.AdminSetPartitionVersionContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CreateSqlBlockRuleContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CreateWorkloadGroupContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.PropertiesClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.PropertyContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.DorisAlterSystemActionContext;
@@ -257,6 +258,7 @@ import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisBackupState
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCancelBackupStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCancelLoadStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCreateSqlBlockRuleStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCreateWorkloadGroupStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCreateRepositoryStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisSwitchStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAlterSqlBlockRuleStatement;
@@ -1371,6 +1373,14 @@ public final class DorisDALStatementVisitor extends DorisStatementVisitor implem
     public ASTNode visitCreateSqlBlockRule(final CreateSqlBlockRuleContext ctx) {
         DorisCreateSqlBlockRuleStatement result = new DorisCreateSqlBlockRuleStatement(getDatabaseType());
         result.setRuleName(((IdentifierValue) visit(ctx.ruleName())).getValue());
+        result.setProperties(extractPropertiesSegment(ctx.propertiesClause()));
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitCreateWorkloadGroup(final CreateWorkloadGroupContext ctx) {
+        DorisCreateWorkloadGroupStatement result = new DorisCreateWorkloadGroupStatement(getDatabaseType());
+        result.setGroupName(((IdentifierValue) visit(ctx.groupName())).getValue());
         result.setProperties(extractPropertiesSegment(ctx.propertiesClause()));
         return result;
     }

--- a/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisCreateWorkloadGroupStatement.java
+++ b/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisCreateWorkloadGroupStatement.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.dal;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.property.PropertiesSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.DALStatement;
+
+/**
+ * Create workload group statement for Doris.
+ */
+@Getter
+@Setter
+public final class DorisCreateWorkloadGroupStatement extends DALStatement {
+    
+    private String groupName;
+    
+    private PropertiesSegment properties;
+    
+    public DorisCreateWorkloadGroupStatement(final DatabaseType databaseType) {
+        super(databaseType);
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/DorisDALStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/DorisDALStatementAssert.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisBackupState
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCancelBackupStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCancelLoadStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCreateSqlBlockRuleStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCreateWorkloadGroupStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCreateRepositoryStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisDescFunctionStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisDropRepositoryStatement;
@@ -75,6 +76,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.d
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisCancelBackupStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisCancelLoadStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisCreateSqlBlockRuleStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisCreateWorkloadGroupStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisCreateRepositoryStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisDescFunctionStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisDropRepositoryStatementAssert;
@@ -115,6 +117,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCancelBackupStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCancelLoadStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCreateSqlBlockRuleStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCreateWorkloadGroupStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCreateRepositoryStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisDescFunctionStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisDropRepositoryStatementTestCase;
@@ -160,6 +163,8 @@ public final class DorisDALStatementAssert {
             DorisAlterSystemStatementAssert.assertIs(assertContext, (DorisAlterSystemStatement) actual, (DorisAlterSystemStatementTestCase) expected);
         } else if (actual instanceof DorisCreateSqlBlockRuleStatement) {
             DorisCreateSqlBlockRuleStatementAssert.assertIs(assertContext, (DorisCreateSqlBlockRuleStatement) actual, (DorisCreateSqlBlockRuleStatementTestCase) expected);
+        } else if (actual instanceof DorisCreateWorkloadGroupStatement) {
+            DorisCreateWorkloadGroupStatementAssert.assertIs(assertContext, (DorisCreateWorkloadGroupStatement) actual, (DorisCreateWorkloadGroupStatementTestCase) expected);
         } else if (actual instanceof DorisShowQueryStatsStatement) {
             DorisShowQueryStatsStatementAssert.assertIs(assertContext, (DorisShowQueryStatsStatement) actual, (DorisShowQueryStatsStatementTestCase) expected);
         } else if (actual instanceof DorisSwitchStatement) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisCreateWorkloadGroupStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisCreateWorkloadGroupStatementAssert.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.property.PropertySegment;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCreateWorkloadGroupStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCreateWorkloadGroupStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.PropertyTestCase;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Create workload group statement assert for Doris.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DorisCreateWorkloadGroupStatementAssert {
+    
+    /**
+     * Assert create workload group statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual create workload group statement
+     * @param expected expected create workload group statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DorisCreateWorkloadGroupStatement actual, final DorisCreateWorkloadGroupStatementTestCase expected) {
+        if (null != expected.getGroupName()) {
+            assertThat(assertContext.getText("Group name does not match: "), actual.getGroupName(), is(expected.getGroupName()));
+        }
+        assertNotNull(actual.getProperties(), assertContext.getText("Properties should not be null"));
+        if (!expected.getProperties().isEmpty()) {
+            assertThat(assertContext.getText("Properties size does not match: "), actual.getProperties().getProperties().size(), is(expected.getProperties().size()));
+            for (int i = 0; i < expected.getProperties().size(); i++) {
+                assertProperty(assertContext, actual.getProperties().getProperties().get(i), expected.getProperties().get(i));
+            }
+        }
+    }
+    
+    private static void assertProperty(final SQLCaseAssertContext assertContext, final PropertySegment actual, final PropertyTestCase expected) {
+        assertThat(assertContext.getText(String.format("Property key '%s' assertion error: ", expected.getKey())), actual.getKey(), is(expected.getKey()));
+        assertThat(assertContext.getText(String.format("Property value for key '%s' assertion error: ", expected.getKey())), actual.getValue(), is(expected.getValue()));
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -40,6 +40,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCleanAllProfileStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCreateRepositoryStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCreateSqlBlockRuleStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCreateWorkloadGroupStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisDescFunctionStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisDropRepositoryStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisDropSqlBlockRuleStatementTestCase;
@@ -850,6 +851,9 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "create-sql-block-rule")
     private final List<DorisCreateSqlBlockRuleStatementTestCase> createSqlBlockRuleTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "create-workload-group")
+    private final List<DorisCreateWorkloadGroupStatementTestCase> createWorkloadGroupTestCases = new LinkedList<>();
     
     @XmlElement(name = "set-default-role")
     private final List<MySQLSetDefaultRoleStatementTestCase> setDefaultRoleTestCases = new LinkedList<>();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisCreateWorkloadGroupStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisCreateWorkloadGroupStatementTestCase.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Create workload group statement test case for Doris.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+public final class DorisCreateWorkloadGroupStatementTestCase extends SQLParserTestCase {
+    
+    @XmlElement(name = "group-name")
+    private String groupName;
+    
+    @XmlElement(name = "property")
+    private final List<PropertyTestCase> properties = new LinkedList<>();
+}

--- a/test/it/parser/src/main/resources/case/dal/analyze-table.xml
+++ b/test/it/parser/src/main/resources/case/dal/analyze-table.xml
@@ -18,4 +18,6 @@
 
 <sql-parser-test-cases>
     <common sql-case-id="analyze_table_doris" />
+    <common sql-case-id="analyze_table_with_sample_percent" />
+    <common sql-case-id="analyze_table_with_sample_rows" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dal/create.xml
+++ b/test/it/parser/src/main/resources/case/dal/create.xml
@@ -71,4 +71,8 @@
         <property key="max_cpu_percent" value="10%" start-index="50" stop-index="72" />
         <property key="max_memory_percent" value="30%" start-index="74" stop-index="99" />
     </create-workload-group>
+    <create-workload-group sql-case-id="create_workload_group_with_keyword_group_name">
+        <group-name start-index="22" stop-index="27">sample</group-name>
+        <property key="max_cpu_percent" value="10%" start-index="40" stop-index="62" />
+    </create-workload-group>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dal/create.xml
+++ b/test/it/parser/src/main/resources/case/dal/create.xml
@@ -61,4 +61,14 @@
         <repository-name name="backup_repo" start-index="28" stop-index="38" />
         <property key="hadoop.username" value="user" start-index="106" stop-index="129" />
     </create-repository>
+    <create-workload-group sql-case-id="create_workload_group">
+        <group-name start-index="22" stop-index="23">g1</group-name>
+        <property key="max_cpu_percent" value="10%" start-index="36" stop-index="58" />
+        <property key="max_memory_percent" value="30%" start-index="60" stop-index="85" />
+    </create-workload-group>
+    <create-workload-group sql-case-id="create_workload_group_if_not_exists">
+        <group-name start-index="36" stop-index="37">g1</group-name>
+        <property key="max_cpu_percent" value="10%" start-index="50" stop-index="72" />
+        <property key="max_memory_percent" value="30%" start-index="74" stop-index="99" />
+    </create-workload-group>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/analyze-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/analyze-table.xml
@@ -18,4 +18,6 @@
 
 <sql-cases>
     <sql-case id="analyze_table_doris" value="ANALYZE TABLE t_order" db-types="Doris" />
+    <sql-case id="analyze_table_with_sample_percent" value="ANALYZE TABLE lineitem WITH SAMPLE PERCENT 10" db-types="Doris" />
+    <sql-case id="analyze_table_with_sample_rows" value="ANALYZE TABLE lineitem WITH SAMPLE ROWS 100000" db-types="Doris" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/create.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/create.xml
@@ -26,4 +26,6 @@
     <sql-case id="create_sql_block_rule_mixed_properties" value="CREATE SQL_BLOCK_RULE complex_rule PROPERTIES(&quot;sql&quot;=&quot;\\s*select\\s*\\*\\s*from order_\\w*\\s*&quot;,&quot;global&quot;=&quot;false&quot;,&quot;enable&quot;=&quot;true&quot;)" db-types="Doris" />
     <sql-case id="create_repository" value="CREATE REPOSITORY `s3_repo` WITH S3 ON LOCATION &quot;s3://s3-repo&quot; PROPERTIES(&quot;s3.endpoint&quot;=&quot;http://s3-REGION.amazonaws.com&quot;,&quot;s3.access_key&quot;=&quot;AWS_ACCESS_KEY&quot;,&quot;s3.secret_key&quot;=&quot;AWS_SECRET_KEY&quot;,&quot;s3.region&quot;=&quot;REGION&quot;)" db-types="Doris" />
     <sql-case id="create_repository_readonly" value="CREATE READ ONLY REPOSITORY backup_repo WITH HDFS ON LOCATION &quot;hdfs://hdfs-server:9000/backup&quot; PROPERTIES(&quot;hadoop.username&quot;=&quot;user&quot;)" db-types="Doris" />
+    <sql-case id="create_workload_group" value="CREATE WORKLOAD GROUP g1 PROPERTIES(&quot;max_cpu_percent&quot;=&quot;10%&quot;,&quot;max_memory_percent&quot;=&quot;30%&quot;)" db-types="Doris" />
+    <sql-case id="create_workload_group_if_not_exists" value="CREATE WORKLOAD GROUP IF NOT EXISTS g1 PROPERTIES(&quot;max_cpu_percent&quot;=&quot;10%&quot;,&quot;max_memory_percent&quot;=&quot;30%&quot;)" db-types="Doris" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/create.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/create.xml
@@ -28,4 +28,5 @@
     <sql-case id="create_repository_readonly" value="CREATE READ ONLY REPOSITORY backup_repo WITH HDFS ON LOCATION &quot;hdfs://hdfs-server:9000/backup&quot; PROPERTIES(&quot;hadoop.username&quot;=&quot;user&quot;)" db-types="Doris" />
     <sql-case id="create_workload_group" value="CREATE WORKLOAD GROUP g1 PROPERTIES(&quot;max_cpu_percent&quot;=&quot;10%&quot;,&quot;max_memory_percent&quot;=&quot;30%&quot;)" db-types="Doris" />
     <sql-case id="create_workload_group_if_not_exists" value="CREATE WORKLOAD GROUP IF NOT EXISTS g1 PROPERTIES(&quot;max_cpu_percent&quot;=&quot;10%&quot;,&quot;max_memory_percent&quot;=&quot;30%&quot;)" db-types="Doris" />
+    <sql-case id="create_workload_group_with_keyword_group_name" value="CREATE WORKLOAD GROUP sample PROPERTIES(&quot;max_cpu_percent&quot;=&quot;10%&quot;)" db-types="Doris" />
 </sql-cases>


### PR DESCRIPTION
- Add CREATE WORKLOAD GROUP [IF NOT EXISTS] grammar with a new DorisCreateWorkloadGroupStatement carrying group name and properties
- Extend Doris ANALYZE TABLE with an optional column list and WITH SYNC / WITH SAMPLE PERCENT|ROWS analyze options
- Add InternalSQLParserIT cases with expected parser assertions for both statements

Fixes #31486