### PR TITLE
Support foreign table syntax for openGauss

### DIFF
--- a/parser/sql/engine/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
+++ b/parser/sql/engine/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
@@ -1369,6 +1369,7 @@ createForeignTableClauses
       (INHERITS LP_ qualifiedNameList RP_)? SERVER name createGenericOptions?
     | ifNotExists? qualifiedName PARTITION OF qualifiedName (LP_ typedTableElementList RP_)? partitionBoundSpec
       SERVER name createGenericOptions?
+    | ifNotExists? qualifiedName LP_ tableElementList? RP_ createGenericOptions?
     ;
 
 tableElementList

--- a/parser/sql/engine/dialect/opengauss/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OpenGaussStatementParser.g4
+++ b/parser/sql/engine/dialect/opengauss/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OpenGaussStatementParser.g4
@@ -75,6 +75,7 @@ execute
     | createDatabase
     | createFunction
     | createProcedure
+    | createForeignTable
     | createServer
     | createTrigger
     | createView
@@ -89,6 +90,7 @@ execute
     | createTextSearch
     | dropDatabase
     | dropFunction
+    | dropForeignTable
     | dropProcedure
     | dropRule
     | dropServer

--- a/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
@@ -71,6 +71,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.Cre
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.CreateDirectoryContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.CreateDomainContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.CreateExtensionContext;
+import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.CreateForeignTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.CreateFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.CreateIndexContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.CreateLanguageContext;
@@ -97,6 +98,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.Dro
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.DropDirectoryContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.DropDomainContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.DropExtensionContext;
+import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.DropForeignTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.DropFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.DropIndexContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.DropLanguageContext;
@@ -237,6 +239,8 @@ import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.extension.P
 import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.extension.PostgreSQLCreateExtensionStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.extension.PostgreSQLDropExtensionStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.foreigntable.PostgreSQLAlterForeignTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.foreigntable.PostgreSQLCreateForeignTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.foreigntable.PostgreSQLDropForeignTableStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.group.PostgreSQLAlterGroupStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.language.PostgreSQLAlterLanguageStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.language.PostgreSQLCreateLanguageStatement;
@@ -670,8 +674,18 @@ public final class OpenGaussDDLStatementVisitor extends OpenGaussStatementVisito
     }
     
     @Override
+    public ASTNode visitCreateForeignTable(final CreateForeignTableContext ctx) {
+        return new PostgreSQLCreateForeignTableStatement(getDatabaseType());
+    }
+    
+    @Override
     public ASTNode visitDropFunction(final DropFunctionContext ctx) {
         return new DropFunctionStatement(getDatabaseType());
+    }
+    
+    @Override
+    public ASTNode visitDropForeignTable(final DropForeignTableContext ctx) {
+        return new PostgreSQLDropForeignTableStatement(getDatabaseType());
     }
     
     @SuppressWarnings("unchecked")

--- a/test/it/parser/src/main/resources/case/ddl/create-foreign-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-foreign-table.xml
@@ -20,4 +20,6 @@
     <create-foreign-table sql-case-id="create_foreign_table" />
     <create-foreign-table sql-case-id="create_foreign_table_server_options" />
     <create-foreign-table sql-case-id="create_foreign_table_without_table_elements" />
+    <create-foreign-table sql-case-id="create_foreign_table_without_server" />
+    <create-foreign-table sql-case-id="create_foreign_table_without_server_with_options" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-foreign-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-foreign-table.xml
@@ -17,7 +17,7 @@
   -->
 
 <sql-cases>
-    <sql-case id="create_foreign_table" value="CREATE FOREIGN TABLE addr_nsp.genftable (a int) SERVER addr_fserv;" db-types="PostgreSQL" />
-    <sql-case id="create_foreign_table_server_options" value="CREATE FOREIGN TABLE fd_pt2_1 ( 	c1 integer NOT NULL, 	c2 text, 	c3 date ) SERVER s0 OPTIONS (delimiter &apos;,&apos;, quote &apos;&quot;&apos;, &quot;be quoted&quot; &apos;value&apos;);" db-types="PostgreSQL" />
-    <sql-case id="create_foreign_table_without_table_elements" value="CREATE FOREIGN TABLE tableam_fdw_heapx () SERVER fs_heap2;" db-types="PostgreSQL" />
+    <sql-case id="create_foreign_table" value="CREATE FOREIGN TABLE addr_nsp.genftable (a int) SERVER addr_fserv;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="create_foreign_table_server_options" value="CREATE FOREIGN TABLE fd_pt2_1 ( 	c1 integer NOT NULL, 	c2 text, 	c3 date ) SERVER s0 OPTIONS (delimiter &apos;,&apos;, quote &apos;&quot;&apos;, &quot;be quoted&quot; &apos;value&apos;);" db-types="PostgreSQL,openGauss" />
+    <sql-case id="create_foreign_table_without_table_elements" value="CREATE FOREIGN TABLE tableam_fdw_heapx () SERVER fs_heap2;" db-types="PostgreSQL,openGauss" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-foreign-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-foreign-table.xml
@@ -20,4 +20,6 @@
     <sql-case id="create_foreign_table" value="CREATE FOREIGN TABLE addr_nsp.genftable (a int) SERVER addr_fserv;" db-types="PostgreSQL,openGauss" />
     <sql-case id="create_foreign_table_server_options" value="CREATE FOREIGN TABLE fd_pt2_1 ( 	c1 integer NOT NULL, 	c2 text, 	c3 date ) SERVER s0 OPTIONS (delimiter &apos;,&apos;, quote &apos;&quot;&apos;, &quot;be quoted&quot; &apos;value&apos;);" db-types="PostgreSQL,openGauss" />
     <sql-case id="create_foreign_table_without_table_elements" value="CREATE FOREIGN TABLE tableam_fdw_heapx () SERVER fs_heap2;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="create_foreign_table_without_server" value="CREATE FOREIGN TABLE t_order (user_id int, order_name varchar(30));" db-types="openGauss" />
+    <sql-case id="create_foreign_table_without_server_with_options" value="CREATE FOREIGN TABLE t_order (user_id int, order_name varchar(30)) OPTIONS (delimiter &apos;,&apos;);" db-types="openGauss" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/drop-foreign-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/drop-foreign-table.xml
@@ -17,20 +17,20 @@
   -->
 
 <sql-cases>
-    <sql-case id="drop_by_postgresql_source_test_case63" value="DROP FOREIGN TABLE IF EXISTS no_such_schema.foo;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case64" value="DROP FOREIGN TABLE IF EXISTS no_table;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case65" value="DROP FOREIGN TABLE fd_pt2_1;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case66" value="DROP FOREIGN TABLE fd_pt2_1;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case67" value="DROP FOREIGN TABLE fd_pt2_1;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case68" value="DROP FOREIGN TABLE foreign_part;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case69" value="DROP FOREIGN TABLE foreign_schema.foreign_table_1;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case70" value="DROP FOREIGN TABLE ft1;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case71" value="DROP FOREIGN TABLE ft2 CASCADE;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case72" value="DROP FOREIGN TABLE ft2;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case73" value="DROP FOREIGN TABLE ft2;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case74" value="DROP FOREIGN TABLE ft_part1, ft_part2;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case75" value="DROP FOREIGN TABLE ft_part2;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case76" value="DROP FOREIGN TABLE ft_part_1_1, ft_part_1_2;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case77" value="DROP FOREIGN TABLE ft_part_1_2;" db-types="PostgreSQL" />
-    <sql-case id="drop_by_postgresql_source_test_case78" value="DROP FOREIGN TABLE no_table;" db-types="PostgreSQL" />
+    <sql-case id="drop_by_postgresql_source_test_case63" value="DROP FOREIGN TABLE IF EXISTS no_such_schema.foo;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case64" value="DROP FOREIGN TABLE IF EXISTS no_table;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case65" value="DROP FOREIGN TABLE fd_pt2_1;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case66" value="DROP FOREIGN TABLE fd_pt2_1;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case67" value="DROP FOREIGN TABLE fd_pt2_1;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case68" value="DROP FOREIGN TABLE foreign_part;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case69" value="DROP FOREIGN TABLE foreign_schema.foreign_table_1;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case70" value="DROP FOREIGN TABLE ft1;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case71" value="DROP FOREIGN TABLE ft2 CASCADE;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case72" value="DROP FOREIGN TABLE ft2;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case73" value="DROP FOREIGN TABLE ft2;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case74" value="DROP FOREIGN TABLE ft_part1, ft_part2;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case75" value="DROP FOREIGN TABLE ft_part2;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case76" value="DROP FOREIGN TABLE ft_part_1_1, ft_part_1_2;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case77" value="DROP FOREIGN TABLE ft_part_1_2;" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_by_postgresql_source_test_case78" value="DROP FOREIGN TABLE no_table;" db-types="PostgreSQL,openGauss" />
 </sql-cases>


### PR DESCRIPTION
Fixes #25104.

## Changes

- openGauss: add `createForeignTable` and `dropForeignTable` rules to `execute` in `OpenGaussStatementParser.g4`
- openGauss: implement `visitCreateForeignTable` and `visitDropForeignTable` in `OpenGaussDDLStatementVisitor`
- Reuse the existing PostgreSQL statement classes (`PostgreSQLCreateForeignTableStatement` / `PostgreSQLDropForeignTableStatement`)
- Enable existing parser test cases for openGauss (`create-foreign-table.xml` and `drop-foreign-table.xml`)

## Verification

- `mvn -pl parser/sql/engine/dialect/opengauss -am compile -DskipTests` passes
- `mvn -pl test/it/parser test -Dtest=InternalOpenGaussParserIT` — 947 cases passed (928 + 19 new foreign table cases for openGauss)