### PR TITLE
Use database default schema in sharding DAL result merger

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/ShardingDALResultMerger.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/ShardingDALResultMerger.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.sharding.merge.dal;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResult;
 import org.apache.shardingsphere.infra.merge.engine.merger.ResultMerger;
@@ -60,7 +59,6 @@ public final class ShardingDALResultMerger implements ResultMerger {
     }
     
     private ShardingSphereSchema getSchema(final SQLStatementContext sqlStatementContext, final ShardingSphereDatabase database) {
-        String defaultSchemaName = new DatabaseTypeRegistry(sqlStatementContext.getSqlStatement().getDatabaseType()).getDefaultSchemaName(database.getName());
-        return sqlStatementContext.getTablesContext().getSchemaName().map(database::getSchema).orElseGet(() -> database.getSchema(defaultSchemaName));
+        return sqlStatementContext.getTablesContext().getSchemaName().map(database::getSchema).orElseGet(() -> database.findDefaultSchema().orElse(null));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/ShardingDALResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/ShardingDALResultMergerTest.java
@@ -70,7 +70,7 @@ class ShardingDALResultMergerTest {
         when(sqlStatementContext.getSqlStatement().getDatabaseType()).thenReturn(databaseType);
         assertThat(resultMerger.merge(queryResults, sqlStatementContext, mock(), mock()), isA(TransparentMergedResult.class));
     }
-
+    
     @Test
     void assertMergeWithDatabaseDefaultSchema() throws SQLException {
         SQLStatementContext sqlStatementContext = mockSQLStatementContext(mock(DALStatement.class));

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/ShardingDALResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/ShardingDALResultMergerTest.java
@@ -17,15 +17,19 @@
 
 package org.apache.shardingsphere.sharding.merge.dal;
 
+import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResult;
 import org.apache.shardingsphere.infra.merge.result.impl.transparent.TransparentMergedResult;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.DALStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.ExplainStatement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.SQLException;
@@ -35,8 +39,13 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -60,6 +69,20 @@ class ShardingDALResultMergerTest {
         when(sqlStatementContext.getTablesContext().getDatabaseNames()).thenReturn(Collections.emptyList());
         when(sqlStatementContext.getSqlStatement().getDatabaseType()).thenReturn(databaseType);
         assertThat(resultMerger.merge(queryResults, sqlStatementContext, mock(), mock()), isA(TransparentMergedResult.class));
+    }
+
+    @Test
+    void assertMergeWithDatabaseDefaultSchema() throws SQLException {
+        SQLStatementContext sqlStatementContext = mockSQLStatementContext(mock(DALStatement.class));
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
+        ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
+        when(database.findDefaultSchema()).thenReturn(Optional.of(schema));
+        DialectShardingDALResultMerger dialectResultMerger = mock(DialectShardingDALResultMerger.class);
+        try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
+            databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(DialectShardingDALResultMerger.class, databaseType)).thenReturn(Optional.of(dialectResultMerger));
+            resultMerger.merge(queryResults, sqlStatementContext, database, mock());
+        }
+        verify(dialectResultMerger).merge(eq("foo_db"), any(), eq(sqlStatementContext), same(schema), eq(queryResults));
     }
     
     private SQLStatementContext mockSQLStatementContext(final DALStatement dalStatement) {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [ ] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
