### PR TITLE
Use database default schema in encrypt assignment tokens

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGenerator.java
@@ -71,7 +71,7 @@ public final class EncryptAssignmentTokenGenerator {
     public Collection<SQLToken> generateSQLTokens(final TablesContext tablesContext, final SetAssignmentSegment setAssignmentSegment) {
         Collection<SQLToken> result = new LinkedList<>();
         DatabaseTypeRegistry databaseTypeRegistry = new DatabaseTypeRegistry(databaseType);
-        String schemaName = tablesContext.getSchemaName().orElseGet(() -> databaseTypeRegistry.getDefaultSchemaName(database.getName()));
+        String schemaName = tablesContext.getSchemaName().orElseGet(database::getDefaultSchemaName);
         QuoteCharacter quoteCharacter = databaseTypeRegistry.getDialectDatabaseMetaData().getQuoteCharacter();
         for (ColumnAssignmentSegment each : setAssignmentSegment.getAssignments()) {
             ColumnSegment assignedColumn = getAssignedColumn(each);

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGeneratorTest.java
@@ -99,6 +99,7 @@ class EncryptAssignmentTokenGeneratorTest {
     private EncryptRule mockEncryptRule() {
         EncryptRule result = mock(EncryptRule.class, RETURNS_DEEP_STUBS);
         EncryptTable encryptTable = mock(EncryptTable.class);
+        when(encryptTable.getTable()).thenReturn("table");
         when(encryptTable.isEncryptColumn("columns")).thenReturn(true);
         when(encryptTable.getEncryptColumn("columns")).thenReturn(mock(EncryptColumn.class, RETURNS_DEEP_STUBS));
         when(result.findEncryptTable("table")).thenReturn(Optional.of(encryptTable));
@@ -116,9 +117,17 @@ class EncryptAssignmentTokenGeneratorTest {
     void assertGenerateSQLTokenWithUpdateLiteralExpressionSegment() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
         when(database.getName()).thenReturn("foo_db");
-        tokenGenerator = new EncryptAssignmentTokenGenerator(mockEncryptRule(), database, TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
-        when(assignmentSegment.getValue()).thenReturn(mock(LiteralExpressionSegment.class));
-        assertThat(tokenGenerator.generateSQLTokens(tablesContext, setAssignmentSegment).size(), is(1));
+        when(database.getDefaultSchemaName()).thenReturn("foo_default_schema");
+        EncryptRule rule = mockEncryptRule();
+        EncryptColumn encryptColumn = rule.findEncryptTable("table").get().getEncryptColumn("columns");
+        when(encryptColumn.getName()).thenReturn("columns");
+        when(encryptColumn.getCipher().getName()).thenReturn("cipher_columns");
+        when(encryptColumn.getCipher().encrypt("foo_db", "foo_default_schema", "table", "columns", Collections.singletonList("foo_value")))
+                .thenReturn(Collections.singletonList("encrypted_value"));
+        tokenGenerator = new EncryptAssignmentTokenGenerator(rule, database, TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        when(tablesContext.getSchemaName()).thenReturn(Optional.empty());
+        when(assignmentSegment.getValue()).thenReturn(new LiteralExpressionSegment(0, 0, "foo_value"));
+        assertThat(tokenGenerator.generateSQLTokens(tablesContext, setAssignmentSegment).iterator().next().toString(), is("cipher_columns = 'encrypted_value'"));
     }
     
     @Test


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [ ] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
