### PR TITLE
Fix incorrect range routing for right-side sharding columns

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -71,6 +71,7 @@
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
 1. Sharding: Fix incorrect AVG(DISTINCT) merge result across shards - [#39429](https://github.com/apache/shardingsphere/pull/39429)
+1. Sharding: Fix incorrect range routing for right-side sharding columns - [#39534](https://github.com/apache/shardingsphere/pull/39534)
 1. Readwrite-splitting: Evaluate inline expressions in data source names of rule configuration checker - [#39374](https://github.com/apache/shardingsphere/pull/39374)
 1. SQL Federation: Fix SQL Federation pagination binding for long LIMIT parameters - [#39237](https://github.com/apache/shardingsphere/pull/39237)
 

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
@@ -69,15 +69,15 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
         ExpressionSegment right = predicate.getRight();
         // MySQL evaluates BINARY range comparisons byte-wise, and range routing prunes partitions on converted endpoints,
         // so unwrapping BINARY is semantics-preserving only for equality predicates; range predicates keep broadcast routing.
-        if (isRangeOperator(operator) && (isBinaryOperator(left) || isBinaryOperator(right))) {
-            return Optional.empty();
-        }
         if (EQUAL.equals(operator)) {
             left = unwrapBinaryOperator(left);
             right = unwrapBinaryOperator(right);
+        } else if (isRangeOperator(operator) && (isBinaryOperator(left) || isBinaryOperator(right))) {
+            return Optional.empty();
         }
-        ExpressionSegment valueExpression = left instanceof ColumnSegment ? right : left;
-        operator = !(left instanceof ColumnSegment) && right instanceof ColumnSegment ? reverseOperator(operator) : operator;
+        boolean isLeftColumn = left instanceof ColumnSegment;
+        ExpressionSegment valueExpression = isLeftColumn ? right : left;
+        operator = !isLeftColumn && right instanceof ColumnSegment ? reverseOperator(operator) : operator;
         ConditionValue conditionValue = new ConditionValue(valueExpression, params);
         if (conditionValue.isNull()) {
             return generate(null, column, operator, conditionValue.getParameterMarkerIndex().orElse(-1));

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
@@ -69,6 +69,9 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
         ExpressionSegment right = predicate.getRight();
         // MySQL evaluates BINARY range comparisons byte-wise, and range routing prunes partitions on converted endpoints,
         // so unwrapping BINARY is semantics-preserving only for equality predicates; range predicates keep broadcast routing.
+        if (isRangeOperator(operator) && (isBinaryOperator(left) || isBinaryOperator(right))) {
+            return Optional.empty();
+        }
         if (EQUAL.equals(operator)) {
             left = unwrapBinaryOperator(left);
             right = unwrapBinaryOperator(right);
@@ -117,6 +120,10 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
         return OPERATORS.contains(operator);
     }
     
+    private boolean isRangeOperator(final String operator) {
+        return GREATER_THAN.equals(operator) || LESS_THAN.equals(operator) || AT_MOST.equals(operator) || AT_LEAST.equals(operator);
+    }
+    
     private String reverseOperator(final String operator) {
         switch (operator) {
             case GREATER_THAN:
@@ -133,9 +140,13 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
     }
     
     private ExpressionSegment unwrapBinaryOperator(final ExpressionSegment segment) {
+        return isBinaryOperator(segment)
+                ? ((UnaryOperationExpression) segment).getExpression()
+                : segment;
+    }
+    
+    private boolean isBinaryOperator(final ExpressionSegment segment) {
         return segment instanceof UnaryOperationExpression
-                && "BINARY".equalsIgnoreCase(((UnaryOperationExpression) segment).getOperator())
-                        ? ((UnaryOperationExpression) segment).getExpression()
-                        : segment;
+                && "BINARY".equalsIgnoreCase(((UnaryOperationExpression) segment).getOperator());
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
@@ -76,8 +76,13 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
             return Optional.empty();
         }
         boolean isLeftColumn = left instanceof ColumnSegment;
+        if (!isLeftColumn) {
+            if (!(right instanceof ColumnSegment)) {
+                return Optional.empty();
+            }
+            operator = reverseOperator(operator);
+        }
         ExpressionSegment valueExpression = isLeftColumn ? right : left;
-        operator = !isLeftColumn && right instanceof ColumnSegment ? reverseOperator(operator) : operator;
         ConditionValue conditionValue = new ConditionValue(valueExpression, params);
         if (conditionValue.isNull()) {
             return generate(null, column, operator, conditionValue.getParameterMarkerIndex().orElse(-1));

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGenerator.java
@@ -74,6 +74,7 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
             right = unwrapBinaryOperator(right);
         }
         ExpressionSegment valueExpression = left instanceof ColumnSegment ? right : left;
+        operator = !(left instanceof ColumnSegment) && right instanceof ColumnSegment ? reverseOperator(operator) : operator;
         ConditionValue conditionValue = new ConditionValue(valueExpression, params);
         if (conditionValue.isNull()) {
             return generate(null, column, operator, conditionValue.getParameterMarkerIndex().orElse(-1));
@@ -114,6 +115,21 @@ public final class ConditionValueCompareOperatorGenerator implements ConditionVa
     
     private boolean isSupportedOperator(final String operator) {
         return OPERATORS.contains(operator);
+    }
+    
+    private String reverseOperator(final String operator) {
+        switch (operator) {
+            case GREATER_THAN:
+                return LESS_THAN;
+            case LESS_THAN:
+                return GREATER_THAN;
+            case AT_MOST:
+                return AT_LEAST;
+            case AT_LEAST:
+                return AT_MOST;
+            default:
+                return operator;
+        }
     }
     
     private ExpressionSegment unwrapBinaryOperator(final ExpressionSegment segment) {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
@@ -138,4 +138,15 @@ class WhereClauseShardingConditionEngineTest {
         List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.emptyList());
         assertTrue(actual.isEmpty());
     }
+    
+    @Test
+    void assertCreateEmptyShardingConditionsForRightNestedColumnRangeStatement() {
+        ColumnSegment column = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        ExpressionSegment right = new BinaryOperationExpression(0, 0, column, new LiteralExpressionSegment(0, 0, 1), "+", null);
+        BinaryOperationExpression expression = new BinaryOperationExpression(0, 0, new LiteralExpressionSegment(0, 0, 100), right, "<", null);
+        when(whereSegment.getExpr()).thenReturn(expression);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.emptyList());
+        assertTrue(actual.isEmpty());
+    }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
@@ -127,4 +127,15 @@ class WhereClauseShardingConditionEngineTest {
         List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.emptyList());
         assertTrue(actual.isEmpty());
     }
+    
+    @Test
+    void assertCreateEmptyShardingConditionsForRightBinaryOperatorRangeStatement() {
+        ColumnSegment right = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        ExpressionSegment binaryColumn = new UnaryOperationExpression(0, 0, right, "BINARY", "BINARY foo_sharding_col");
+        BinaryOperationExpression expression = new BinaryOperationExpression(0, 0, new LiteralExpressionSegment(0, 0, "100"), binaryColumn, "<", null);
+        when(whereSegment.getExpr()).thenReturn(expression);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.emptyList());
+        assertTrue(actual.isEmpty());
+    }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueCompareOperatorGeneratorTest.java
@@ -31,10 +31,14 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simp
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.timeservice.core.rule.TimestampServiceRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -148,6 +152,17 @@ class ConditionValueCompareOperatorGeneratorTest {
     }
     
     @SuppressWarnings("unchecked")
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("rightColumnComparisonArguments")
+    void assertGenerateConditionValueWithRightColumn(final String name, final String operator, final Range<Integer> expectedRange) {
+        BinaryOperationExpression predicate = new BinaryOperationExpression(
+                0, 0, new LiteralExpressionSegment(0, 0, 1), mock(ColumnSegment.class), operator, null);
+        Optional<ShardingConditionValue> actual = generator.generate(predicate, column, new LinkedList<>(), mock(TimestampServiceRule.class));
+        assertTrue(actual.isPresent());
+        assertThat(((RangeShardingConditionValue<Integer>) actual.get()).getValueRange(), is(expectedRange));
+    }
+    
+    @SuppressWarnings("unchecked")
     @Test
     void assertGenerateConditionValueWithGreaterThanOperator() {
         BinaryOperationExpression rightValue = new BinaryOperationExpression(0, 0, mock(ColumnSegment.class), new LiteralExpressionSegment(0, 0, 1), ">", null);
@@ -222,5 +237,13 @@ class ConditionValueCompareOperatorGeneratorTest {
         BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0, left, right, "=", "order_id = ?");
         Optional<ShardingConditionValue> actual = generator.generate(predicate, column, new LinkedList<>(), mock(TimestampServiceRule.class));
         assertFalse(actual.isPresent());
+    }
+    
+    private static Stream<Arguments> rightColumnComparisonArguments() {
+        return Stream.of(
+                Arguments.of("less than", "<", Range.greaterThan(1)),
+                Arguments.of("at most", "<=", Range.atLeast(1)),
+                Arguments.of("greater than", ">", Range.lessThan(1)),
+                Arguments.of("at least", ">=", Range.atMost(1)));
     }
 }


### PR DESCRIPTION
No associated issue.

Changes proposed in this pull request:
- Reverse ordered comparison operators when a sharding column is on the right side of a binary predicate.
- Add parameterized unit coverage for `<`, `<=`, `>`, and `>=`.

Requested labels: `type: bug`, `in: Kernel`.

Verification:
- `./mvnw -pl features/sharding/core -am -DskipITs -Dspotless.skip=true -Dtest=org.apache.shardingsphere.sharding.route.engine.condition.generator.impl.ConditionValueCompareOperatorGeneratorTest -Dsurefire.failIfNoSpecifiedTests=false test`: 23 tests passed.
- `./mvnw spotless:apply -Pcheck -T1C`: passed with no file changes.
- `./mvnw checkstyle:check -Pcheck -T1C`: passed with 0 violations.

AI assistance disclosure:
- Tool: OpenAI Codex.
- Scope: `ConditionValueCompareOperatorGenerator.java`, `ConditionValueCompareOperatorGeneratorTest.java`, and `WhereClauseShardingConditionEngineTest.java`.
- The contributor reviewed and verified the complete change.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have requested corresponding labels for the pull request.
- [ ] I have passed the full Maven check locally: `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] Documentation changes are not required because this does not change public APIs or configuration.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [x] I have disclosed the tool and affected scope for material AI assistance as required by the [AI-assisted contribution policy](https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md).