### PR TITLE
Add Cartesian routing fix to 5.5.4 release notes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -70,6 +70,7 @@
 1. Sharding: Fix generated actual index names exceeding database identifier length limits while preserving legacy generated index name compatibility - [#38449](https://github.com/apache/shardingsphere/pull/38449)
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
+1. Sharding: Fix order-dependent data source intersection in Cartesian routing - [#39407](https://github.com/apache/shardingsphere/pull/39407)
 1. Sharding: Fix incorrect AVG(DISTINCT) merge result across shards - [#39429](https://github.com/apache/shardingsphere/pull/39429)
 1. Readwrite-splitting: Evaluate inline expressions in data source names of rule configuration checker - [#39374](https://github.com/apache/shardingsphere/pull/39374)
 1. SQL Federation: Fix SQL Federation pagination binding for long LIMIT parameters - [#39237](https://github.com/apache/shardingsphere/pull/39237)


### PR DESCRIPTION
Related to #39407.

Changes proposed in this pull request:
- Add the missing ShardingSphere 5.5.4 bug-fix release note for the order-dependent data source intersection correction merged in #39407.

### Verification

- Confirmed #39407 is merged and assigned to milestone 5.5.4.
- Confirmed the entry was absent from current `master` and from open pull requests.
- `git diff --check`
- `./mvnw -Pcheck -T1C -DskipTests spotless:check checkstyle:check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`
- Unit tests are not applicable because this changes only `RELEASE-NOTES.md`.

### AI assistance disclosure

Codex was used to inspect #39407, identify the missing release-note entry, draft the one-line change, and run the checks listed above. The affected scope is only `RELEASE-NOTES.md`. Maintainer review is still required before merge.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project. *(maintainer confirmation pending)*
- [ ] I have self-reviewed the commit code. *(maintainer confirmation pending)*
- [x] I have (or in comment I request) added corresponding labels for the pull request. *(request: `in: document`, `feature: sharding`)*
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes. *(not applicable to a one-line release-note entry)*
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [x] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy](https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md).