### PR TITLE
Fix NPE when extracting Oracle projection identifier

### DIFF
--- a/infra/binder/dialect/oracle/src/main/java/org/apache/shardingsphere/infra/binder/oracle/OracleProjectionIdentifierExtractor.java
+++ b/infra/binder/dialect/oracle/src/main/java/org/apache/shardingsphere/infra/binder/oracle/OracleProjectionIdentifierExtractor.java
@@ -47,7 +47,8 @@ public final class OracleProjectionIdentifierExtractor implements DialectProject
                 return String.format("'%s'", literal.toString().replace("'", "''"));
             }
         }
-        return expressionSegment.getText().replace(" ", "").toUpperCase();
+        String text = expressionSegment.getText();
+        return null == text ? "" : text.replace(" ", "").toUpperCase();
     }
     
     @Override

--- a/infra/binder/dialect/oracle/src/test/java/org/apache/shardingsphere/infra/binder/oracle/OracleProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/oracle/src/test/java/org/apache/shardingsphere/infra/binder/oracle/OracleProjectionIdentifierExtractorTest.java
@@ -55,6 +55,11 @@ class OracleProjectionIdentifierExtractorTest {
     }
     
     @Test
+    void assertGetColumnNameFromNullTextExpression() {
+        assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, null)), is(""));
+    }
+    
+    @Test
     void assertGetColumnNameFromStringLiteralExpression() {
         assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 7, "EXTMSG", new LiteralExpressionSegment(0, 7, "EXTMSG"))), is("'EXTMSG'"));
     }


### PR DESCRIPTION
No associated issue.

Changes proposed in this pull request:
- Return an empty Oracle projection identifier when an expression segment has no source text.
- Add focused regression coverage for the null-text expression path.

The Oracle projection identifier extractor currently dereferences `ExpressionSegment.getText()` unconditionally. `ExpressionProjectionSegment` can retain a null text value, causing identifier extraction to fail with a `NullPointerException` instead of returning a non-null identifier.

Validation:
- `OracleProjectionIdentifierExtractorTest`: 6 tests passed.
- `./mvnw spotless:apply -Pcheck -T1C`: passed.
- Oracle binder module Checkstyle: 0 violations.

AI assistance disclosure:
- OpenAI Codex materially assisted with the implementation and regression test in `OracleProjectionIdentifierExtractor.java` and `OracleProjectionIdentifierExtractorTest.java`. The human contributor reviewed the complete two-file change and its validation results.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I request the maintainers apply the appropriate bug label.
- [ ] I have passed the full Maven check locally. Focused unit, Spotless, and Checkstyle verification are listed above.
- [x] Documentation changes are not required because this fixes internal binder behavior without changing a public contract.
- [x] I have added corresponding unit tests for my changes.
- [x] A release-note change is not required for this internal bug fix.
- [x] I have disclosed the tool and affected files or scope for material AI assistance, as required by the [AI-assisted contribution policy](https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md).
