### PR TITLE
Replace Spotify Docker plugin in E2E fixture

### DIFF
--- a/test/e2e/fixture/pom.xml
+++ b/test/e2e/fixture/pom.xml
@@ -280,6 +280,7 @@
                                     <executable>docker</executable>
                                     <arguments>
                                         <argument>build</argument>
+                                        <argument>--pull</argument>
                                         <argument>--build-arg</argument>
                                         <argument>APP_NAME=${project.build.finalName}</argument>
                                         <argument>.</argument>

--- a/test/e2e/fixture/pom.xml
+++ b/test/e2e/fixture/pom.xml
@@ -266,22 +266,29 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>apache/shardingsphere-proxy-test</repository>
-                            <tag>${project.version}</tag>
-                            <tag>latest</tag>
-                            <buildArgs>
-                                <APP_NAME>${project.build.finalName}</APP_NAME>
-                            </buildArgs>
-                        </configuration>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>shardingsphere-proxy-bin</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>exec</goal>
                                 </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <executable>docker</executable>
+                                    <arguments>
+                                        <argument>build</argument>
+                                        <argument>--build-arg</argument>
+                                        <argument>APP_NAME=${project.build.finalName}</argument>
+                                        <argument>.</argument>
+                                        <argument>-t</argument>
+                                        <argument>apache/shardingsphere-proxy-test:${project.version}</argument>
+                                        <argument>-t</argument>
+                                        <argument>apache/shardingsphere-proxy-test:latest</argument>
+                                    </arguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
What: Build the E2E Proxy fixture image through the Docker CLI while preserving the package phase, build argument, and image tags.

Why: Avoid the Spotify client's x86-only JFFI dependency so Docker image packaging works on Apple Silicon.

Changes proposed in this pull request:
  - Replace Spotify Docker plugin in E2E fixture

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [ ] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
