### PR TITLE
Fix binding table lookup for schema-qualified data nodes

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingTable.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingTable.java
@@ -202,7 +202,7 @@ public final class ShardingTable {
                 throw new DataNodeGenerateException(each);
             }
             result.add(dataNode);
-            dataNodeIndexMap.put(dataNode, index);
+            dataNodeIndexMap.put(new DataNode(dataNode.getDataSourceName(), (String) null, dataNode.getTableName()), index);
             actualDataSourceNames.add(dataNode.getDataSourceName());
             addActualTable(dataNode.getDataSourceName(), dataNode.getTableName());
             index++;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingTableTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingTableTest.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -61,6 +62,14 @@ class ShardingTableTest {
         assertTrue(actual.containsDataNode("ds0", "table_0"));
         assertFalse(actual.containsDataNode("ds0", "table_9"));
         assertFalse(actual.containsDataNode("ds9", "table_0"));
+    }
+    
+    @Test
+    void assertFindActualTableIndex() {
+        ShardingTableRuleConfiguration config = new ShardingTableRuleConfiguration("foo_order", "foo_ds.public.foo_order_0");
+        ShardingTable actual = new ShardingTable(config, Collections.singleton("foo_ds"), null);
+        assertThat(actual.getActualDataNodes().get(0), is(new DataNode("foo_ds", "public", "foo_order_0")));
+        assertThat(actual.findActualTableIndex("foo_ds", "foo_order_0"), is(0));
     }
     
     private ShardingTable createShardingTable() {

--- a/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -1418,7 +1418,7 @@ compositeHashPartitions
     ;
 
 referencePartitioning
-    :PARTITION BY REFERENCE LP_ constraint RP_ (LP_? referencePartitionDesc (COMMA_ referencePartitionDesc)* RP_?)?
+    : PARTITION BY REFERENCE LP_ constraintName RP_ (LP_? referencePartitionDesc (COMMA_ referencePartitionDesc)* RP_?)?
     ;
 
 referencePartitionDesc

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -2596,7 +2596,29 @@
             <column name="unit_price" start-index="82" stop-index="91" />
         </column-definition>
     </create-table>
-    
+
+    <create-table sql-case-id="create_table_partition_by_reference">
+        <table name="order_items" start-index="13" stop-index="23" />
+        <column-definition type="NUMBER" start-index="31" stop-index="68">
+            <column name="order_id" start-index="31" stop-index="38" />
+        </column-definition>
+        <column-definition type="NUMBER" start-index="77" stop-index="114">
+            <column name="line_item_id" start-index="77" stop-index="88" />
+        </column-definition>
+        <column-definition type="NUMBER" start-index="123" stop-index="160">
+            <column name="product_id" start-index="123" stop-index="132" />
+        </column-definition>
+        <column-definition type="NUMBER" start-index="169" stop-index="198">
+            <column name="unit_price" start-index="169" stop-index="178" />
+        </column-definition>
+        <column-definition type="NUMBER" start-index="207" stop-index="234">
+            <column name="quantity" start-index="207" stop-index="214" />
+        </column-definition>
+        <constraint-definition constraint-name="order_items_fk" start-index="243" stop-index="323">
+            <referenced-table name="orders" start-index="308" stop-index="313" />
+        </constraint-definition>
+    </create-table>
+
     <create-table sql-case-id="create_table_default_user">
         <table name="audit_trail" start-index="13" stop-index="23"  />
         <column-definition type="NUMBER" start-index="26" stop-index="38">

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -188,6 +188,16 @@
     PARTITION costs_q1_2003 VALUES LESS THAN (TO_DATE('01-APR-2003', 'DD-MON-YYYY')),
     PARTITION costs_q2_2003 VALUES LESS THAN (TO_DATE('01-JUN-2003', 'DD-MON-YYYY')),
     PARTITION costs_recent VALUES LESS THAN (MAXVALUE))" db-types="Oracle" />
+    <sql-case id="create_table_partition_by_reference" value="CREATE TABLE order_items
+    ( order_id           NUMBER(12) NOT NULL,
+      line_item_id       NUMBER(3)  NOT NULL,
+      product_id         NUMBER(6)  NOT NULL,
+      unit_price         NUMBER(8,2),
+      quantity           NUMBER(8),
+      CONSTRAINT order_items_fk
+      FOREIGN KEY(order_id) REFERENCES orders(order_id)
+    )
+    PARTITION BY REFERENCE(order_items_fk)" db-types="Oracle" />
     <sql-case id="create_table_default_user" value="CREATE TABLE audit_trail (value1 NUMBER, value2 VARCHAR2(32), inserter VARCHAR2(30) DEFAULT USER)" db-types="Oracle" />
     <sql-case id="create_table_partition_by_list_subpartition_by_hash1" value="CREATE TABLE car_rentals
     (id NUMBER NOT NULL,


### PR DESCRIPTION
Normalize ShardingTable's private index keys while preserving schema information in actual data nodes.