### PR TITLE
Support parsing Oracle CREATE TABLESPACE with datafile autoextend clause and encryption using algorithm

### DIFF
--- a/test/it/parser/src/main/resources/case/ddl/create-tablespace.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-tablespace.xml
@@ -35,6 +35,7 @@
     <create-tablespace sql-case-id="create_tablespace_with_datafile_extent_management" />
     <create-tablespace sql-case-id="create_tablespace_with_datafile_logging_extent_management" />
     <create-tablespace sql-case-id="create_tablespace_with_datafile_extent_segment_online" />
+    <create-tablespace sql-case-id="create_tablespace_with_datafile_autoextend_off" />
     <create-tablespace sql-case-id="create_tablespace_with_minimum_extend_k" />
     <create-tablespace sql-case-id="create_tablespace_with_minimum_extend_m" />
     <create-tablespace sql-case-id="create_tablespace_with_minimum_extend_g" />
@@ -48,6 +49,7 @@
     <create-tablespace sql-case-id="create_tablespace_with_force_logging" />
     <create-tablespace sql-case-id="create_tablespace_with_encrypt" />
     <create-tablespace sql-case-id="create_tablespace_with_datafile_encryption_storage_encrypt" />
+    <create-tablespace sql-case-id="create_tablespace_with_encryption_using_storage_encrypt" />
     <create-tablespace sql-case-id="create_tablespace_with_compress" />
     <create-tablespace sql-case-id="create_tablespace_with_nocompress" />
     <create-tablespace sql-case-id="create_tablespace_with_compress_basic" />

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-tablespace.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-tablespace.xml
@@ -44,6 +44,7 @@
     <sql-case id="create_tablespace_with_datafile_extent_management" value="CREATE TABLESPACE tbs_04 DATAFILE 'file_1.dbf' SIZE 10M EXTENT MANAGEMENT LOCAL UNIFORM SIZE 128K;" db-types="Oracle" />
     <sql-case id="create_tablespace_with_datafile_logging_extent_management" value="CREATE TABLESPACE tbs_05 DATAFILE 'tbs_f05.dbf' SIZE 5M LOGGING EXTENT MANAGEMENT LOCAL;" db-types="Oracle" />
     <sql-case id="create_tablespace_with_datafile_extent_segment_online" value="CREATE TABLESPACE sysaux DATAFILE 'sysaux01.dbf' SIZE 500M REUSE EXTENT MANAGEMENT LOCAL SEGMENT SPACE MANAGEMENT AUTO ONLINE;" db-types="Oracle" />
+    <sql-case id="create_tablespace_with_datafile_autoextend_off" value="CREATE TABLESPACE omf_ts2 DATAFILE AUTOEXTEND OFF;" db-types="Oracle" />
     <sql-case id="create_tablespace_with_minimum_extend_k" value="CREATE TABLESPACE test_space MINIMUM EXTEND 1K" db-types="Oracle" />
     <sql-case id="create_tablespace_with_minimum_extend_m" value="CREATE TABLESPACE test_space MINIMUM EXTEND 12M" db-types="Oracle" />
     <sql-case id="create_tablespace_with_minimum_extend_g" value="CREATE TABLESPACE test_space MINIMUM EXTEND 31G" db-types="Oracle" />
@@ -57,6 +58,7 @@
     <sql-case id="create_tablespace_with_force_logging" value="CREATE TABLESPACE test_space FORCE LOGGING" db-types="Oracle" />
     <sql-case id="create_tablespace_with_encrypt" value="CREATE TABLESPACE test_space ENCRYPTION USING 'encrypt_algorithm'" db-types="Oracle" />
     <sql-case id="create_tablespace_with_datafile_encryption_storage_encrypt" value="CREATE TABLESPACE securespace DATAFILE '/u01/app/oracle/oradata/orcl/secure01.dbf' SIZE 100M ENCRYPTION DEFAULT STORAGE (ENCRYPT);" db-types="Oracle" />
+    <sql-case id="create_tablespace_with_encryption_using_storage_encrypt" value="CREATE TABLESPACE securespace DATAFILE '/home/user/oradata/secure01.dbf' SIZE 150M ENCRYPTION USING '3DES168' DEFAULT STORAGE (ENCRYPT);" db-types="Oracle" />
     <sql-case id="create_tablespace_with_compress" value="CREATE TABLESPACE test_space DEFAULT COMPRESS" db-types="Oracle" />
     <sql-case id="create_tablespace_with_nocompress" value="CREATE TABLESPACE test_space DEFAULT NOCOMPRESS" db-types="Oracle" />
     <sql-case id="create_tablespace_with_compress_basic" value="CREATE TABLESPACE test_space DEFAULT COMPRESS BASIC" db-types="Oracle" />


### PR DESCRIPTION
- Add parser IT case for OMF DATAFILE AUTOEXTEND OFF without datafile name
- Add parser IT case for ENCRYPTION USING algorithm combined with DEFAULT STORAGE (ENCRYPT)

Closes #27115
