### PR TITLE
Fix isSameGroupByAndOrderByItems to ignore order direction for group by and order by items

### DIFF
--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
@@ -45,6 +45,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.Bina
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.GroupBySegment;
@@ -289,6 +290,33 @@ class ShardingDQLResultMergerTest {
     }
     
     @Test
+    void assertBuildGroupByStreamMergedResultWithDifferentOrderDirection() throws SQLException {
+        SelectStatement selectStatement = buildSelectStatement(mysqlDatabaseType);
+        selectStatement = withGroupBy(selectStatement, new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, NullsOrderType.FIRST))));
+        selectStatement = withOrderBy(selectStatement, new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, NullsOrderType.FIRST))));
+        selectStatement = withProjections(selectStatement, new ProjectionsSegment(0, 0));
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        SelectStatementContext selectStatementContext = new SelectStatementContext(
+                selectStatement, createShardingSphereMetaData(database), "foo_db", Collections.emptyList());
+        ShardingDQLResultMerger resultMerger = new ShardingDQLResultMerger(mysqlDatabaseType);
+        assertThat(resultMerger.merge(createQueryResults(), selectStatementContext, createDatabase(), mock(ConnectionContext.class)), isA(GroupByStreamMergedResult.class));
+    }
+    
+    @Test
+    void assertBuildGroupByStreamMergedResultWithDistinctRow() throws SQLException {
+        SelectStatement selectStatement = buildSelectStatement(mysqlDatabaseType);
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        projectionsSegment.setDistinctRow(true);
+        projectionsSegment.getProjections().add(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("count(*)"))));
+        selectStatement = withProjections(selectStatement, projectionsSegment);
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        SelectStatementContext selectStatementContext = new SelectStatementContext(
+                selectStatement, createShardingSphereMetaData(database), "foo_db", Collections.emptyList());
+        ShardingDQLResultMerger resultMerger = new ShardingDQLResultMerger(mysqlDatabaseType);
+        assertThat(resultMerger.merge(createQueryResults(), selectStatementContext, createDatabase(), mock(ConnectionContext.class)), isA(GroupByStreamMergedResult.class));
+    }
+    
+    @Test
     void assertBuildGroupByStreamMergedResultWithMySQLLimit() throws SQLException {
         SelectStatement selectStatement = buildSelectStatement(mysqlDatabaseType);
         selectStatement = withGroupBy(selectStatement, new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, NullsOrderType.FIRST))));
@@ -405,23 +433,6 @@ class ShardingDQLResultMergerTest {
         ShardingDQLResultMerger resultMerger = new ShardingDQLResultMerger(oracleDatabaseType);
         MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createDatabase(), mock(ConnectionContext.class));
         assertThat(actual, isA(GroupByStreamMergedResult.class));
-    }
-    
-    @Test
-    void assertBuildGroupByMemoryMergedResultWithSQLServerLimit() throws SQLException {
-        SelectStatement selectStatement = buildSelectStatement(sqlserverDatabaseType);
-        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
-        selectStatement = withProjections(selectStatement, projectionsSegment);
-        selectStatement = withGroupBy(selectStatement, new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, NullsOrderType.FIRST))));
-        selectStatement = withOrderBy(selectStatement, new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, NullsOrderType.FIRST))));
-        selectStatement = withLimit(selectStatement, new LimitSegment(0, 0, new NumberLiteralRowNumberValueSegment(0, 0, 1L, true), null));
-        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
-        SelectStatementContext selectStatementContext = new SelectStatementContext(
-                selectStatement, createShardingSphereMetaData(database), "foo_db", Collections.emptyList());
-        ShardingDQLResultMerger resultMerger = new ShardingDQLResultMerger(sqlserverDatabaseType);
-        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
-        assertThat(actual, isA(TopAndRowNumberDecoratorMergedResult.class));
-        assertThat(((TopAndRowNumberDecoratorMergedResult) actual).getMergedResult(), isA(GroupByMemoryMergedResult.class));
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByMemoryMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByMemoryMergedResultTest.java
@@ -127,7 +127,8 @@ class GroupByMemoryMergedResultTest {
                 .databaseType(databaseType)
                 .projections(projectionsSegment)
                 .groupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 3, OrderDirection.ASC, NullsOrderType.FIRST))))
-                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 3, OrderDirection.DESC, NullsOrderType.FIRST))))
+                .orderBy(new OrderBySegment(0, 0, Arrays.asList(new IndexOrderByItemSegment(0, 0, 3, OrderDirection.DESC, NullsOrderType.FIRST),
+                        new IndexOrderByItemSegment(0, 0, 4, OrderDirection.ASC, NullsOrderType.FIRST))))
                 .build();
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementBaseContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementBaseContext.java
@@ -73,6 +73,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.Iden
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -356,12 +357,40 @@ public final class SelectStatementBaseContext implements SQLStatementContext {
     }
     
     /**
-     * Judge group by and order by sequence is same or not.
+     * Judge whether group by items and order by items refer to the same select items in the same sequence, ignoring order direction.
      *
-     * @return group by and order by sequence is same or not
+     * <p>Either order direction keeps rows of the same group by keys adjacent in the merged result, so the direction-insensitive judgment
+     * keeps pagination rewrite and group by stream merge available when the order by keys are exactly the group by keys.</p>
+     *
+     * @return group by and order by items are the same or not
      */
     public boolean isSameGroupByAndOrderByItems() {
-        return !groupByContext.getItems().isEmpty() && groupByContext.getItems().equals(orderByContext.getItems());
+        if (groupByContext.getItems().isEmpty() || groupByContext.getItems().size() != orderByContext.getItems().size()) {
+            return false;
+        }
+        Iterator<OrderByItem> groupByItems = groupByContext.getItems().iterator();
+        Iterator<OrderByItem> orderByItems = orderByContext.getItems().iterator();
+        while (groupByItems.hasNext()) {
+            if (!isSameGroupByAndOrderByItem(groupByItems.next(), orderByItems.next())) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    private boolean isSameGroupByAndOrderByItem(final OrderByItem groupByItem, final OrderByItem orderByItem) {
+        // Resolved indexes are 1-based and point to select items; index 0 means the index has not been resolved yet.
+        if (0 != groupByItem.getIndex() && groupByItem.getIndex() == orderByItem.getIndex()) {
+            return true;
+        }
+        OrderByItemSegment groupBySegment = groupByItem.getSegment();
+        OrderByItemSegment orderBySegment = orderByItem.getSegment();
+        if (groupBySegment instanceof IndexOrderByItemSegment && orderBySegment instanceof IndexOrderByItemSegment) {
+            return ((IndexOrderByItemSegment) groupBySegment).getColumnIndex() == ((IndexOrderByItemSegment) orderBySegment).getColumnIndex();
+        }
+        return groupBySegment instanceof TextOrderByItemSegment && orderBySegment instanceof TextOrderByItemSegment
+                && SQLUtils.getExactlyValue(((TextOrderByItemSegment) groupBySegment).getText())
+                        .equalsIgnoreCase(SQLUtils.getExactlyValue(((TextOrderByItemSegment) orderBySegment).getText()));
     }
     
     /**

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementBaseContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementBaseContext.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.orderby.eng
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.engine.ProjectionsContextEngine;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.ProjectionIdentifierExtractEngine;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.AggregationDistinctProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.AggregationProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection;
@@ -77,6 +78,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -357,7 +359,7 @@ public final class SelectStatementBaseContext implements SQLStatementContext {
     }
     
     /**
-     * Judge whether group by items and order by items refer to the same select items in the same sequence, ignoring order direction.
+     * Judge whether group by items and order by items can be proven to refer to the same select items in the same sequence, ignoring order direction.
      *
      * <p>Either order direction keeps rows of the same group by keys adjacent in the merged result, so the direction-insensitive judgment
      * keeps pagination rewrite and group by stream merge available when the order by keys are exactly the group by keys.</p>
@@ -367,6 +369,9 @@ public final class SelectStatementBaseContext implements SQLStatementContext {
     public boolean isSameGroupByAndOrderByItems() {
         if (groupByContext.getItems().isEmpty() || groupByContext.getItems().size() != orderByContext.getItems().size()) {
             return false;
+        }
+        if (orderByContext.isGenerated()) {
+            return true;
         }
         Iterator<OrderByItem> groupByItems = groupByContext.getItems().iterator();
         Iterator<OrderByItem> orderByItems = orderByContext.getItems().iterator();
@@ -379,18 +384,61 @@ public final class SelectStatementBaseContext implements SQLStatementContext {
     }
     
     private boolean isSameGroupByAndOrderByItem(final OrderByItem groupByItem, final OrderByItem orderByItem) {
-        // Resolved indexes are 1-based and point to select items; index 0 means the index has not been resolved yet.
-        if (0 != groupByItem.getIndex() && groupByItem.getIndex() == orderByItem.getIndex()) {
-            return true;
+        if (0 != groupByItem.getIndex() && 0 != orderByItem.getIndex() && groupByItem.getIndex() != orderByItem.getIndex()) {
+            return false;
         }
         OrderByItemSegment groupBySegment = groupByItem.getSegment();
         OrderByItemSegment orderBySegment = orderByItem.getSegment();
-        if (groupBySegment instanceof IndexOrderByItemSegment && orderBySegment instanceof IndexOrderByItemSegment) {
+        if (groupBySegment.getClass() != orderBySegment.getClass()) {
+            return false;
+        }
+        if (groupBySegment instanceof IndexOrderByItemSegment) {
             return ((IndexOrderByItemSegment) groupBySegment).getColumnIndex() == ((IndexOrderByItemSegment) orderBySegment).getColumnIndex();
         }
-        return groupBySegment instanceof TextOrderByItemSegment && orderBySegment instanceof TextOrderByItemSegment
-                && SQLUtils.getExactlyValue(((TextOrderByItemSegment) groupBySegment).getText())
-                        .equalsIgnoreCase(SQLUtils.getExactlyValue(((TextOrderByItemSegment) orderBySegment).getText()));
+        if (groupBySegment instanceof ColumnOrderByItemSegment) {
+            ColumnSegment groupByColumn = ((ColumnOrderByItemSegment) groupBySegment).getColumn();
+            ColumnSegment orderByColumn = ((ColumnOrderByItemSegment) orderBySegment).getColumn();
+            return isSameColumn(groupByColumn, orderByColumn);
+        }
+        return false;
+    }
+
+    private boolean isSameColumn(final ColumnSegment groupByColumn, final ColumnSegment orderByColumn) {
+        ColumnSegmentBoundInfo groupByBoundInfo = groupByColumn.getColumnBoundInfo();
+        ColumnSegmentBoundInfo orderByBoundInfo = orderByColumn.getColumnBoundInfo();
+        ColumnSegmentBoundInfo groupByOtherUsingBoundInfo = groupByColumn.getOtherUsingColumnBoundInfo();
+        ColumnSegmentBoundInfo orderByOtherUsingBoundInfo = orderByColumn.getOtherUsingColumnBoundInfo();
+        return groupByColumn.getQualifiedName().equals(orderByColumn.getQualifiedName()) && null != groupByBoundInfo && null != orderByBoundInfo
+                && isSameColumnBoundInfo(groupByBoundInfo, orderByBoundInfo)
+                && (null == groupByOtherUsingBoundInfo ? null == orderByOtherUsingBoundInfo
+                        : null != orderByOtherUsingBoundInfo && isSameColumnBoundInfo(groupByOtherUsingBoundInfo, orderByOtherUsingBoundInfo))
+                && !isAmbiguousProjectionReference(groupByColumn);
+    }
+
+    private boolean isAmbiguousProjectionReference(final ColumnSegment column) {
+        if (null != column.getNestedObjectAttributes() && !column.getNestedObjectAttributes().isEmpty()) {
+            return true;
+        }
+        if (column.getOwner().isPresent()) {
+            return false;
+        }
+        String identifier = new ProjectionIdentifierExtractEngine(sqlStatement.getDatabaseType()).getIdentifierValue(column.getIdentifier());
+        for (Projection each : projectionsContext.getExpandProjections()) {
+            if (!identifier.equalsIgnoreCase(each.getColumnLabel())) {
+                continue;
+            }
+            if (each.getAlias().isPresent() || !(each instanceof ColumnProjection) || null == ((ColumnProjection) each).getColumnBoundInfo()
+                    || !isSameColumnBoundInfo(column.getColumnBoundInfo(), ((ColumnProjection) each).getColumnBoundInfo())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isSameColumnBoundInfo(final ColumnSegmentBoundInfo left, final ColumnSegmentBoundInfo right) {
+        return null != left && null != right && left.getTableSourceType() == right.getTableSourceType()
+                && Objects.equals(left.getOriginalDatabase(), right.getOriginalDatabase()) && Objects.equals(left.getOriginalSchema(), right.getOriginalSchema())
+                && Objects.equals(left.getOriginalTable(), right.getOriginalTable()) && Objects.equals(left.getOriginalColumn(), right.getOriginalColumn());
     }
     
     /**

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementBaseContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementBaseContext.java
@@ -402,7 +402,7 @@ public final class SelectStatementBaseContext implements SQLStatementContext {
         }
         return false;
     }
-
+    
     private boolean isSameColumn(final ColumnSegment groupByColumn, final ColumnSegment orderByColumn) {
         ColumnSegmentBoundInfo groupByBoundInfo = groupByColumn.getColumnBoundInfo();
         ColumnSegmentBoundInfo orderByBoundInfo = orderByColumn.getColumnBoundInfo();
@@ -414,7 +414,7 @@ public final class SelectStatementBaseContext implements SQLStatementContext {
                         : null != orderByOtherUsingBoundInfo && isSameColumnBoundInfo(groupByOtherUsingBoundInfo, orderByOtherUsingBoundInfo))
                 && !isAmbiguousProjectionReference(groupByColumn);
     }
-
+    
     private boolean isAmbiguousProjectionReference(final ColumnSegment column) {
         if (null != column.getNestedObjectAttributes() && !column.getNestedObjectAttributes().isEmpty()) {
             return true;
@@ -434,7 +434,7 @@ public final class SelectStatementBaseContext implements SQLStatementContext {
         }
         return false;
     }
-
+    
     private boolean isSameColumnBoundInfo(final ColumnSegmentBoundInfo left, final ColumnSegmentBoundInfo right) {
         return null != left && null != right && left.getTableSourceType() == right.getTableSourceType()
                 && Objects.equals(left.getOriginalDatabase(), right.getOriginalDatabase()) && Objects.equals(left.getOriginalSchema(), right.getOriginalSchema())

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/pagination/PaginationContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/pagination/PaginationContextTest.java
@@ -161,10 +161,21 @@ class PaginationContextTest {
     }
     
     @Test
-    void assertGetRevisedRowCountWithMax() {
+    void assertGetRevisedRowCountWithDifferentOrderDirection() {
         SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
                 .groupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, NullsOrderType.LAST))))
                 .orderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, NullsOrderType.LAST)))).build();
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
+        SelectStatementContext selectStatementContext = new SelectStatementContext(selectStatement, metaData, "foo_db", Collections.emptyList());
+        assertThat(new PaginationContext(getOffsetSegment(), getRowCountSegment(), getParameters()).getRevisedRowCount(selectStatementContext), is(50L));
+    }
+    
+    @Test
+    void assertGetRevisedRowCountWithMax() {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, NullsOrderType.LAST))))
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 2, OrderDirection.DESC, NullsOrderType.LAST)))).build();
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
         SelectStatementContext selectStatementContext = new SelectStatementContext(selectStatement, metaData, "foo_db", Collections.emptyList());

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContextTest.java
@@ -56,6 +56,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.PivotSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.TableSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.JoinTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
@@ -190,6 +191,77 @@ class SelectStatementContextTest {
                 .build();
         SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
         assertTrue(selectStatementContext.isSameGroupByAndOrderByItems());
+    }
+
+    @Test
+    void assertIsSameGroupByAndOrderByItemsWithGeneratedOrderBy() {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(
+                        new ExpressionOrderByItemSegment(0, 0, "LOWER(id)", OrderDirection.ASC, NullsOrderType.LAST))))
+                .build();
+        SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
+        assertTrue(selectStatementContext.isSameGroupByAndOrderByItems());
+    }
+
+    @Test
+    void assertIsNotSameGroupByAndOrderByItemsWhenResolvedExpressionIndexesCollide() {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(
+                        new ExpressionOrderByItemSegment(0, 0, "CONCAT('a,b', name, 'c')", OrderDirection.ASC, NullsOrderType.LAST))))
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(
+                        new ExpressionOrderByItemSegment(0, 0, "CONCAT('a', 'b,name', 'c')", OrderDirection.DESC, NullsOrderType.LAST))))
+                .build();
+        SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
+        selectStatementContext.getGroupByContext().getItems().iterator().next().setIndex(1);
+        selectStatementContext.getOrderByContext().getItems().iterator().next().setIndex(1);
+        assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
+    }
+
+    @Test
+    void assertIsNotSameGroupByAndOrderByItemsWhenExpressionsContainDifferentParameterMarkers() {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(new ExpressionOrderByItemSegment(
+                        0, 0, "MOD(id, ?)", OrderDirection.ASC, NullsOrderType.LAST, new ParameterMarkerExpressionSegment(0, 0, 0)))))
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(new ExpressionOrderByItemSegment(
+                        0, 0, "MOD(id, ?)", OrderDirection.DESC, NullsOrderType.LAST, new ParameterMarkerExpressionSegment(0, 0, 1)))))
+                .build();
+        SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
+        assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
+    }
+
+    @Test
+    void assertIsNotSameGroupByAndOrderByItemsWhenQuotedColumnCaseDiffers() {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(
+                        new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("\"Foo\"")), OrderDirection.ASC, NullsOrderType.LAST))))
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(
+                        new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("\"foo\"")), OrderDirection.DESC, NullsOrderType.LAST))))
+                .build();
+        SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
+        assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
+    }
+
+    @Test
+    void assertIsNotSameGroupByAndOrderByItemsWhenColumnMatchesDifferentProjectionAliasIgnoringCase() {
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        ColumnSegmentBoundInfo boundInfo = new ColumnSegmentBoundInfo(new IdentifierValue("name"));
+        ColumnSegment projectionColumn = new ColumnSegment(0, 0, new IdentifierValue("name"));
+        projectionColumn.setColumnBoundInfo(boundInfo);
+        ColumnProjectionSegment projectionSegment = new ColumnProjectionSegment(projectionColumn);
+        projectionSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("ID")));
+        projectionsSegment.getProjections().add(projectionSegment);
+        ColumnSegment groupByColumn = new ColumnSegment(0, 0, new IdentifierValue("id"));
+        groupByColumn.setColumnBoundInfo(boundInfo);
+        ColumnSegment orderByColumn = new ColumnSegment(0, 0, new IdentifierValue("id"));
+        orderByColumn.setColumnBoundInfo(boundInfo);
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(projectionsSegment)
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(
+                        new ColumnOrderByItemSegment(groupByColumn, OrderDirection.ASC, NullsOrderType.LAST))))
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(
+                        new ColumnOrderByItemSegment(orderByColumn, OrderDirection.DESC, NullsOrderType.LAST))))
+                .build();
+        SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
+        assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
     }
     
     @Test

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContextTest.java
@@ -48,6 +48,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.Subq
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.GroupBySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.OrderBySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.ColumnOrderByItemSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.ExpressionOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.IndexOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.OrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
@@ -171,6 +172,27 @@ class SelectStatementContextTest {
     }
     
     @Test
+    void assertIsSameGroupByAndOrderByItemsWithDifferentOrderDirection() {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, NullsOrderType.LAST))))
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, NullsOrderType.LAST)))).build();
+        SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
+        assertTrue(selectStatementContext.isSameGroupByAndOrderByItems());
+    }
+    
+    @Test
+    void assertIsSameGroupByAndOrderByItemsWithColumnOrderByAndDifferentOrderDirection() {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(
+                        new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("id")), OrderDirection.ASC, NullsOrderType.LAST))))
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(
+                        new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("id")), OrderDirection.DESC, NullsOrderType.LAST))))
+                .build();
+        SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
+        assertTrue(selectStatementContext.isSameGroupByAndOrderByItems());
+    }
+    
+    @Test
     void assertIsNotSameGroupByAndOrderByItemsWhenEmptyGroupBy() {
         SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0)).build();
         SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
@@ -181,7 +203,31 @@ class SelectStatementContextTest {
     void assertIsNotSameGroupByAndOrderByItemsWhenDifferentGroupByAndOrderBy() {
         SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
                 .groupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, NullsOrderType.LAST))))
-                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, NullsOrderType.LAST)))).build();
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 2, OrderDirection.DESC, NullsOrderType.LAST)))).build();
+        SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
+        assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
+    }
+    
+    @Test
+    void assertIsNotSameGroupByAndOrderByItemsWhenDifferentColumnOrderBy() {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(
+                        new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("id")), OrderDirection.ASC, NullsOrderType.LAST))))
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(
+                        new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("name")), OrderDirection.DESC, NullsOrderType.LAST))))
+                .build();
+        SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
+        assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
+    }
+    
+    @Test
+    void assertIsNotSameGroupByAndOrderByItemsWhenExpressionOrderBy() {
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
+                .groupBy(new GroupBySegment(0, 0, Collections.singletonList(
+                        new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("id")), OrderDirection.ASC, NullsOrderType.LAST))))
+                .orderBy(new OrderBySegment(0, 0, Collections.singletonList(
+                        new ExpressionOrderByItemSegment(0, 0, "COUNT(*)", OrderDirection.DESC, NullsOrderType.LAST))))
+                .build();
         SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
         assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
     }

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContextTest.java
@@ -192,7 +192,7 @@ class SelectStatementContextTest {
         SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
         assertTrue(selectStatementContext.isSameGroupByAndOrderByItems());
     }
-
+    
     @Test
     void assertIsSameGroupByAndOrderByItemsWithGeneratedOrderBy() {
         SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
@@ -202,7 +202,7 @@ class SelectStatementContextTest {
         SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
         assertTrue(selectStatementContext.isSameGroupByAndOrderByItems());
     }
-
+    
     @Test
     void assertIsNotSameGroupByAndOrderByItemsWhenResolvedExpressionIndexesCollide() {
         SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
@@ -216,7 +216,7 @@ class SelectStatementContextTest {
         selectStatementContext.getOrderByContext().getItems().iterator().next().setIndex(1);
         assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
     }
-
+    
     @Test
     void assertIsNotSameGroupByAndOrderByItemsWhenExpressionsContainDifferentParameterMarkers() {
         SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
@@ -228,7 +228,7 @@ class SelectStatementContextTest {
         SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
         assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
     }
-
+    
     @Test
     void assertIsNotSameGroupByAndOrderByItemsWhenQuotedColumnCaseDiffers() {
         SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
@@ -240,7 +240,7 @@ class SelectStatementContextTest {
         SelectStatementContext selectStatementContext = createSelectStatementContext(selectStatement);
         assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
     }
-
+    
     @Test
     void assertIsNotSameGroupByAndOrderByItemsWhenColumnMatchesDifferentProjectionAliasIgnoringCase() {
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
@@ -1425,7 +1425,9 @@ dataType
     | (dataTypeName = NCHAR | dataTypeName = NATIONAL_CHAR) fieldLength? BINARY?
     | dataTypeName = (SIGNED | SIGNED_INT | SIGNED_INTEGER)
     | dataTypeName = BINARY fieldLength?
-    | (dataTypeName = CHAR_VARYING | dataTypeName = CHARACTER_VARYING | dataTypeName = VARCHAR) fieldLength charsetWithOptBinary?
+    // DORIS CHANGED BEGIN
+    | (dataTypeName = CHAR_VARYING | dataTypeName = CHARACTER_VARYING | dataTypeName = VARCHAR) fieldLength? charsetWithOptBinary?
+    // DORIS CHANGED END
     | (dataTypeName = NATIONAL VARCHAR | dataTypeName = NVARCHAR | dataTypeName = NCHAR VARCHAR | dataTypeName = NATIONAL_CHAR_VARYING | dataTypeName = NCHAR VARYING) fieldLength BINARY?
     | dataTypeName = VARBINARY fieldLength?
     | dataTypeName = YEAR fieldLength? fieldOptions?

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -2656,6 +2656,22 @@
         </column-definition>
     </create-table>
 
+    <create-table sql-case-id="create_table_with_varchar_without_length_doris" db-types="Doris">
+        <table name="tags" start-index="13" stop-index="16" />
+        <column-definition type="VARCHAR" start-index="19" stop-index="29">
+            <column name="tag" start-index="19" stop-index="21" />
+        </column-definition>
+        <column-definition type="DATETIME" start-index="32" stop-index="44">
+            <column name="date" start-index="32" stop-index="35" />
+        </column-definition>
+        <column-definition type="BITMAP" agg-type="BITMAP_UNION" start-index="47" stop-index="73">
+            <column name="user_id" start-index="47" stop-index="53" />
+        </column-definition>
+        <create-table-option start-index="76" stop-index="86">
+            <engine name="OLAP" start-index="83" stop-index="86" />
+        </create-table-option>
+    </create-table>
+
     <create-table sql-case-id="create_table_inverted_index_doris" db-types="Doris">
         <table name="table_hash" start-index="13" stop-index="33">
             <owner name="example_db" start-index="13" stop-index="22" />

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -6436,4 +6436,211 @@
             <simple-table name="t_order" start-index="37" stop-index="43" />
         </from>
     </select>
+
+    <select sql-case-id="select_ucase" db-types="MySQL,Doris">
+        <projections start-index="7" stop-index="20">
+            <expression-projection start-index="7" stop-index="20" text="UCASE('hello')">
+                <expr>
+                    <function function-name="UCASE" text="UCASE('hello')" start-index="7" stop-index="20">
+                        <parameter>
+                            <literal-expression value="hello" start-index="13" stop-index="19" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_starts_with_doris" db-types="Doris">
+        <projections start-index="7" stop-index="41">
+            <expression-projection start-index="7" stop-index="41" text="STARTS_WITH(&quot;hello world&quot;, &quot;hello&quot;)">
+                <expr>
+                    <function function-name="STARTS_WITH" text="STARTS_WITH(&quot;hello world&quot;, &quot;hello&quot;)" start-index="7" stop-index="41">
+                        <parameter>
+                            <literal-expression value="hello world" start-index="19" stop-index="31" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="hello" start-index="34" stop-index="40" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_conv_with_number" db-types="MySQL,Doris">
+        <projections start-index="7" stop-index="21">
+            <expression-projection start-index="7" stop-index="21" text="CONV(15, 10, 2)">
+                <expr>
+                    <function function-name="CONV" text="CONV(15, 10, 2)" start-index="7" stop-index="21">
+                        <parameter>
+                            <literal-expression value="15" start-index="12" stop-index="13" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="10" start-index="16" stop-index="17" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="2" start-index="20" stop-index="20" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_conv_with_string" db-types="MySQL,Doris">
+        <projections start-index="7" stop-index="24">
+            <expression-projection start-index="7" stop-index="24" text="CONV('ff', 16, 10)">
+                <expr>
+                    <function function-name="CONV" text="CONV('ff', 16, 10)" start-index="7" stop-index="24">
+                        <parameter>
+                            <literal-expression value="ff" start-index="12" stop-index="15" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="16" start-index="18" stop-index="19" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="10" start-index="22" stop-index="23" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_bitmap_intersect_doris" db-types="Doris">
+        <projections start-index="7" stop-index="36">
+            <column-projection name="tag" start-index="7" stop-index="9" />
+            <expression-projection start-index="12" stop-index="36" text="BITMAP_INTERSECT(user_id)">
+                <expr>
+                    <function function-name="BITMAP_INTERSECT" text="BITMAP_INTERSECT(user_id)" start-index="12" stop-index="36">
+                        <parameter>
+                            <column name="user_id" start-index="29" stop-index="35" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from start-index="43" stop-index="166">
+            <subquery-table alias="a" start-index="43" stop-index="166">
+                <subquery start-index="43" stop-index="164">
+                    <select>
+                        <projections start-index="51" stop-index="90">
+                            <column-projection name="tag" start-index="51" stop-index="53" />
+                            <column-projection name="date" start-index="56" stop-index="59" />
+                            <expression-projection alias="user_id" start-index="62" stop-index="90" text="BITMAP_UNION(user_id)">
+                                <expr>
+                                    <function function-name="BITMAP_UNION" text="BITMAP_UNION(user_id)" start-index="62" stop-index="82">
+                                        <parameter>
+                                            <column name="user_id" start-index="75" stop-index="81" />
+                                        </parameter>
+                                    </function>
+                                </expr>
+                            </expression-projection>
+                        </projections>
+                        <from>
+                            <simple-table name="table" start-index="97" stop-index="101" />
+                        </from>
+                        <where start-index="103" stop-index="144">
+                            <expr>
+                                <in-expression start-index="109" stop-index="144">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="date" start-index="109" stop-index="112" />
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="117" stop-index="144">
+                                            <items>
+                                                <literal-expression value="2020-05-18" start-index="118" stop-index="129" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2020-05-19" start-index="132" stop-index="143" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </expr>
+                        </where>
+                        <group-by>
+                            <column-item name="tag" order-direction="ASC" start-index="155" stop-index="157" />
+                            <column-item name="date" order-direction="ASC" start-index="160" stop-index="163" />
+                        </group-by>
+                    </select>
+                </subquery>
+            </subquery-table>
+        </from>
+        <group-by>
+            <column-item name="tag" order-direction="ASC" start-index="177" stop-index="179" />
+        </group-by>
+    </select>
+
+    <select sql-case-id="select_bitmap_to_string_with_bitmap_intersect_doris" db-types="Doris">
+        <projections start-index="7" stop-index="54">
+            <column-projection name="tag" start-index="7" stop-index="9" />
+            <expression-projection start-index="12" stop-index="54" text="BITMAP_TO_STRING(BITMAP_INTERSECT(user_id))">
+                <expr>
+                    <function function-name="BITMAP_TO_STRING" text="BITMAP_TO_STRING(BITMAP_INTERSECT(user_id))" start-index="12" stop-index="54">
+                        <parameter>
+                            <function function-name="BITMAP_INTERSECT" text="BITMAP_INTERSECT(user_id)" start-index="29" stop-index="53">
+                                <parameter>
+                                    <column name="user_id" start-index="46" stop-index="52" />
+                                </parameter>
+                            </function>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from start-index="61" stop-index="184">
+            <subquery-table alias="a" start-index="61" stop-index="184">
+                <subquery start-index="61" stop-index="182">
+                    <select>
+                        <projections start-index="69" stop-index="108">
+                            <column-projection name="tag" start-index="69" stop-index="71" />
+                            <column-projection name="date" start-index="74" stop-index="77" />
+                            <expression-projection alias="user_id" start-index="80" stop-index="108" text="BITMAP_UNION(user_id)">
+                                <expr>
+                                    <function function-name="BITMAP_UNION" text="BITMAP_UNION(user_id)" start-index="80" stop-index="100">
+                                        <parameter>
+                                            <column name="user_id" start-index="93" stop-index="99" />
+                                        </parameter>
+                                    </function>
+                                </expr>
+                            </expression-projection>
+                        </projections>
+                        <from>
+                            <simple-table name="table" start-index="115" stop-index="119" />
+                        </from>
+                        <where start-index="121" stop-index="162">
+                            <expr>
+                                <in-expression start-index="127" stop-index="162">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="date" start-index="127" stop-index="130" />
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="135" stop-index="162">
+                                            <items>
+                                                <literal-expression value="2020-05-18" start-index="136" stop-index="147" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2020-05-19" start-index="150" stop-index="161" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </expr>
+                        </where>
+                        <group-by>
+                            <column-item name="tag" order-direction="ASC" start-index="173" stop-index="175" />
+                            <column-item name="date" order-direction="ASC" start-index="178" stop-index="181" />
+                        </group-by>
+                    </select>
+                </subquery>
+            </subquery-table>
+        </from>
+        <group-by>
+            <column-item name="tag" order-direction="ASC" start-index="195" stop-index="197" />
+        </group-by>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -202,6 +202,7 @@
     <sql-case id="create_table_hash_buckets_auto_doris" value="CREATE TABLE t_auto2 (k1 INT) DISTRIBUTED BY HASH(k1) BUCKETS AUTO" db-types="Doris" />
     <sql-case id="create_table_rollup_with_duplicate_key_doris" value="CREATE TABLE t_r (k1 INT, v1 INT SUM) AGGREGATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 ROLLUP (r1(k1, v1) DUPLICATE KEY(k1) PROPERTIES(&quot;replication_num&quot; = &quot;1&quot;))" db-types="Doris" />
     <sql-case id="create_table_with_hll_as_identifier_doris" value="CREATE TABLE hll (hll INT) DISTRIBUTED BY HASH(hll) BUCKETS 1" db-types="Doris" />
+    <sql-case id="create_table_with_varchar_without_length_doris" value="CREATE TABLE tags (tag VARCHAR, date DATETIME, user_id BITMAP BITMAP_UNION) ENGINE=OLAP AGGREGATE KEY(tag, date) DISTRIBUTED BY HASH(tag) BUCKETS 8" db-types="Doris" />
     <sql-case id="create_table_with_select_without_query" value="CREATE TABLE t_order_new AS SELECT * FROM t_order" db-types="Oracle"/>
     <sql-case id="create_table_as_select_with_pivot" value="CREATE TABLE pivot_table AS SELECT * FROM (SELECT EXTRACT(YEAR FROM order_date) year, order_mode, order_total FROM orders) PIVOT (SUM(order_total) FOR order_mode IN ('direct' AS Store, 'online' AS Internet));" db-types="Oracle"/>
     <sql-case id="create_table_as_select_with_pivot_and_aggregate_alias" value="CREATE TABLE pivot_alias_table AS SELECT * FROM (SELECT quarter, quantity_sold FROM sales_view) PIVOT (SUM(quantity_sold) AS sumq FOR quarter IN ('01' AS Q1, '02' AS Q2))" db-types="Oracle" />

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -355,4 +355,10 @@
     <sql-case id="select_array_cum_sum" value="SELECT ARRAY_CUM_SUM([1, 2, 3])" db-types="Doris" />
     <sql-case id="select_array_cum_sum_empty_array" value="SELECT ARRAY_CUM_SUM([])" db-types="Doris" />
     <sql-case id="select_array_cum_sum_from_table" value="SELECT ARRAY_CUM_SUM([1, 2, 3]) FROM t_order" db-types="Doris" />
+    <sql-case id="select_ucase" value="SELECT UCASE('hello')" db-types="MySQL,Doris" />
+    <sql-case id="select_starts_with_doris" value="SELECT STARTS_WITH(&quot;hello world&quot;, &quot;hello&quot;)" db-types="Doris" />
+    <sql-case id="select_conv_with_number" value="SELECT CONV(15, 10, 2)" db-types="MySQL,Doris" />
+    <sql-case id="select_conv_with_string" value="SELECT CONV('ff', 16, 10)" db-types="MySQL,Doris" />
+    <sql-case id="select_bitmap_intersect_doris" value="SELECT tag, BITMAP_INTERSECT(user_id) FROM (SELECT tag, date, BITMAP_UNION(user_id) user_id FROM table WHERE date IN ('2020-05-18', '2020-05-19') GROUP BY tag, date) a GROUP BY tag" db-types="Doris" />
+    <sql-case id="select_bitmap_to_string_with_bitmap_intersect_doris" value="SELECT tag, BITMAP_TO_STRING(BITMAP_INTERSECT(user_id)) FROM (SELECT tag, date, BITMAP_UNION(user_id) user_id FROM table WHERE date IN ('2020-05-18', '2020-05-19') GROUP BY tag, date) a GROUP BY tag" db-types="Doris" />
 </sql-cases>

--- a/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
+++ b/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
@@ -291,14 +291,14 @@
     
     <rewrite-assertion id="select_limit_with_multiple_route_with_memory_group_by_for_parameters_for_mysql" db-types="MySQL">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="100, 10" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="0, 2147483647" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="0, 2147483647" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="0, 110" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="0, 110" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_limit_with_multiple_route_with_memory_group_by_for_literals_for_mysql" db-types="MySQL">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 100, 10" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 0, 2147483647" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 0, 2147483647" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 0, 110" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 0, 110" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_limit_with_single_route_for_parameters_for_postgresql" db-types="PostgreSQL,openGauss">
@@ -325,14 +325,14 @@
     
     <rewrite-assertion id="select_limit_with_multiple_route_with_memory_group_by_for_parameters_for_postgresql" db-types="PostgreSQL,openGauss">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="10, 100" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="2147483647, 0" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="2147483647, 0" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="110, 0" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="110, 0" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_limit_with_multiple_route_with_memory_group_by_for_literals_for_postgresql" db-types="PostgreSQL,openGauss">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 10 OFFSET 100" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 2147483647 OFFSET 0" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 2147483647 OFFSET 0" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 110 OFFSET 0" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 110 OFFSET 0" />
     </rewrite-assertion>
     
     <!-- FIXME -->


### PR DESCRIPTION
Judge group by and order by item sameness by select item identity, which is
the resolved projection index or the segment text or column index, instead of
the direction-sensitive OrderByItem equality. This keeps pagination rewrite
using the original row count and group by stream merge eligible for queries
like GROUP BY a, b ORDER BY a DESC, b DESC, and closes the latent wrong-result
path where unresolved rewrite-time indexes made GROUP BY a ORDER BY SUM(c) ASC keep the per-shard limit.

Fixes #23014