### PR TITLE
Add parser IT cases for Oracle CLUSTER_SET function and BIGFILE tablespace with datafile

### DIFF
--- a/test/it/parser/src/main/resources/case/ddl/create-tablespace.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-tablespace.xml
@@ -27,6 +27,7 @@
     <create-tablespace sql-case-id="create_permanent_tablespace_offline" />
     <create-tablespace sql-case-id="create_permanent_tablespace_bigfile" />
     <create-tablespace sql-case-id="create_permanent_tablespace_smallfile" />
+    <create-tablespace sql-case-id="create_bigfile_tablespace_with_datafile" />
     <create-tablespace sql-case-id="create_tablespace_with_multi_filespecification" />
     <create-tablespace sql-case-id="create_tablespace_with_filespecification_next" />
     <create-tablespace sql-case-id="create_tablespace_with_filespecification" />

--- a/test/it/parser/src/main/resources/case/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-expression.xml
@@ -2969,6 +2969,17 @@
         </from>
     </select>
 
+    <select sql-case-id="select_cluster_set_function">
+        <projections start-index="7" stop-index="52">
+            <expression-projection text="CLUSTER_SET(km_sh_clus_sample, 2, 0.1 USING *)" start-index="7" stop-index="52">
+                <function function-name="CLUSTER_SET" text="CLUSTER_SET(km_sh_clus_sample, 2, 0.1 USING *)" />
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="mining_data_apply_v" start-index="59" stop-index="77" />
+        </from>
+    </select>
+
     <select sql-case-id="select_with_multiset_except_expression">
         <from>
             <simple-table name="customers_demo" start-index="103" stop-index="116" />

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-tablespace.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-tablespace.xml
@@ -27,6 +27,7 @@
     <sql-case id="create_permanent_tablespace_offline" value="CREATE TABLESPACE test_space OFFLINE" db-types="Oracle" />
     <sql-case id="create_permanent_tablespace_bigfile" value="CREATE BIGFILE TABLESPACE test_space ONLINE" db-types="Oracle" />
     <sql-case id="create_permanent_tablespace_smallfile" value="CREATE SMALLFILE TABLESPACE test_space ONLINE" db-types="Oracle" />
+    <sql-case id="create_bigfile_tablespace_with_datafile" value="CREATE BIGFILE TABLESPACE bigtbs_01 DATAFILE 'bigtbs_f1.dbf' SIZE 20M AUTOEXTEND ON;" db-types="Oracle" />
     <sql-case id="create_tablespace_with_multi_filespecification" value="CREATE TABLESPACE test_space
         DATAFILE 'disk1:df1.dbf' AUTOEXTEND ON,
         'disk2:df2.dbf' AUTOEXTEND ON NEXT 10M MAXSIZE UNLIMITED

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
@@ -123,6 +123,7 @@
     <sql-case id="select_interval_day_to_second_expression" value="SELECT (SYSTIMESTAMP - order_date) DAY(9) TO SECOND FROM orders" db-types="Oracle" />
     <sql-case id="select_feature_function" value="SELECT FEATURE_VALUE(nmf_sh_sample, 3 USING *) FROM nmf_sh_sample_apply_prepared" db-types="Oracle" />
     <sql-case id="select_cluster_function" value="SELECT CLUSTER_PROBABILITY(km_sh_clus_sample, 2 USING *) FROM mining_data_apply_v" db-types="Oracle" />
+    <sql-case id="select_cluster_set_function" value="SELECT CLUSTER_SET(km_sh_clus_sample, 2, 0.1 USING *) FROM mining_data_apply_v" db-types="Oracle" />
     <sql-case id="select_with_multiset_except_expression" value="SELECT customer_id, cust_address_ntab MULTISET EXCEPT DISTINCT cust_address2_ntab multiset_except FROM customers_demo ORDER BY customer_id;" db-types="Oracle" />
     <sql-case id="select_with_multiset_intersect_expression" value="SELECT customer_id, cust_address_ntab MULTISET INTERSECT DISTINCT cust_address2_ntab multiset_intersect FROM customers_demo ORDER BY customer_id;" db-types="Oracle" />
     <sql-case id="select_with_multiset_union_expression" value="SELECT customer_id, cust_address_ntab MULTISET UNION cust_address2_ntab multiset_union FROM customers_demo ORDER BY customer_id;" db-types="Oracle" />


### PR DESCRIPTION
Cover the Oracle CLUSTER_SET mining function with topN and cutoff arguments through the featureFunction rule, and CREATE BIGFILE TABLESPACE with DATAFILE, SIZE and AUTOEXTEND clauses through permanentTablespaceClause. Both forms are already supported by the grammar, so only test resources change.

Fixes #27018
