### PR TITLE
Fix Oracle CREATE USER and ALTER USER TEMPORARY TABLESPACE parse error

### DIFF
--- a/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DCLStatement.g4
+++ b/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DCLStatement.g4
@@ -388,7 +388,7 @@ tablespaceOption
     ;
 
 temporaryOption
-    : LOCAL? TEMPORARY TABLESPACE tablespaceName tablespaceGroupName
+    : LOCAL? TEMPORARY TABLESPACE (tablespaceName | tablespaceGroupName)
     ;
 
 quotaOption
@@ -422,7 +422,7 @@ alterUser
     | NO AUTHENTICATION
     | DEFAULT COLLATION collationName
     | DEFAULT TABLESPACE tablespaceName
-    | LOCAL? TEMPORARY TABLESPACE tablespaceName tablespaceGroupName
+    | LOCAL? TEMPORARY TABLESPACE (tablespaceName | tablespaceGroupName)
     | QUOTA (sizeClause | UNLIMITED) ON tablespaceName
     | PROFILE profileName
     | DEFAULT ROLE (roleName (COMMA_ roleName)* |  allClause | NONE )

--- a/test/it/parser/src/main/resources/case/dcl/alter-user.xml
+++ b/test/it/parser/src/main/resources/case/dcl/alter-user.xml
@@ -57,6 +57,7 @@
     <alter-user sql-case-id="alter_external_user" />
     <alter-user sql-case-id="alter_global_user" />
     <alter-user sql-case-id="alter_user_with_tablespace_option" />
+    <alter-user sql-case-id="alter_user_with_temporary_tablespace" />
     <alter-user sql-case-id="alter_user_with_container" />
     <alter-user sql-case-id="alter_user_with_quota_option" />
     <alter-user sql-case-id="alter_user_password_with_lock_option" />

--- a/test/it/parser/src/main/resources/case/dcl/create-user.xml
+++ b/test/it/parser/src/main/resources/case/dcl/create-user.xml
@@ -59,6 +59,8 @@
     <create-user sql-case-id="create_user_with_password" />
     <create-user sql-case-id="create_user_with_tablespace" />
     <create-user sql-case-id="create_user_with_quota_option" />
+    <create-user sql-case-id="create_user_with_temporary_tablespace" />
+    <create-user sql-case-id="create_user_with_temporary_tablespace_unlimited_quota" />
     <create-user sql-case-id="create_user_with_password_expire_lock" />
     <create-user sql-case-id="create_user_only_with_name" />
     <create-user sql-case-id="create_user_with_role_postgresql" />

--- a/test/it/parser/src/main/resources/sql/supported/dcl/alter-user.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dcl/alter-user.xml
@@ -62,6 +62,7 @@
     <sql-case id="alter_external_user" value="ALTER USER user1 IDENTIFIED EXTERNALLY" db-types="Oracle" />
     <sql-case id="alter_global_user" value="ALTER USER user1 IDENTIFIED GLOBALLY AS 'CN=user1'" db-types="Oracle" />
     <sql-case id="alter_user_with_tablespace_option" value="ALTER USER user1 DEFAULT TABLESPACE tablespace1" db-types="Oracle" />
+    <sql-case id="alter_user_with_temporary_tablespace" value="ALTER USER johndoe TEMPORARY TABLESPACE temp_ts" db-types="Oracle" />
     <sql-case id="alter_user_with_container" value="ALTER USER user1 CONTAINER = ALL" db-types="Oracle" />
     <sql-case id="alter_user_with_quota_option" value="ALTER USER user1 QUOTA 1M ON tablespace1" db-types="Oracle" />
     <sql-case id="alter_user_password_with_lock_option" value="ALTER USER user1 IDENTIFIED BY password ACCOUNT LOCK" db-types="Oracle" />

--- a/test/it/parser/src/main/resources/sql/supported/dcl/create-user.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dcl/create-user.xml
@@ -80,6 +80,8 @@
     <sql-case id="create_user_with_password" value="CREATE USER user1 IDENTIFIED BY RANDOM password default role role1" db-types="H2,MySQL" />
     <sql-case id="create_user_with_tablespace" value="CREATE USER user1 IDENTIFIED BY password DEFAULT TABLESPACE tablespace1" db-types="Oracle" />
     <sql-case id="create_user_with_quota_option" value="CREATE USER user1 IDENTIFIED BY password QUOTA 1M ON tablespace1" db-types="Oracle" />
+    <sql-case id="create_user_with_temporary_tablespace" value="CREATE USER jfee IDENTIFIED BY password DEFAULT TABLESPACE users TEMPORARY TABLESPACE temp_ts QUOTA 500K ON users PROFILE clerk" db-types="Oracle" />
+    <sql-case id="create_user_with_temporary_tablespace_unlimited_quota" value="CREATE USER dcranney IDENTIFIED BY password DEFAULT TABLESPACE users TEMPORARY TABLESPACE temp_ts QUOTA unlimited ON users" db-types="Oracle" />
     <sql-case id="create_user_with_password_expire_lock" value="CREATE USER user1 IDENTIFIED BY RANDOM password default role role1 PASSWORD EXPIRE ACCOUNT LOCK" db-types="H2,MySQL" />
     <sql-case id="create_user_only_with_name" value="CREATE USER user1" db-types="PostgreSQL,openGauss,SQLServer" />
     <sql-case id="create_user_with_password_postgresql" value="CREATE USER user1 WITH ENCRYPTED PASSWORD 'password'" db-types="PostgreSQL,openGauss" />


### PR DESCRIPTION
The temporaryOption rule of CREATE USER and the TEMPORARY TABLESPACE branch of ALTER USER required both a tablespace name and a tablespace group name, while Oracle syntax accepts either one of them. Align both rules with the (tablespaceName | tablespaceGroupName) alternation already used by DEFAULT TEMPORARY TABLESPACE in DDLStatement, and cover the single-name form with parser IT cases.

Fixes #27080
