### PR TITLE
Support parsing Doris CREATE VIEW with IF NOT EXISTS and COMMENT clauses

### DIFF
--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DDLStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DDLStatement.g4
@@ -478,7 +478,9 @@ createView
       (ALGORITHM EQ_ (UNDEFINED | MERGE | TEMPTABLE))?
       ownerStatement?
       (SQL SECURITY (DEFINER | INVOKER))?
-      VIEW viewName (LP_ columnNames RP_)?
+      // DORIS CHANGED BEGIN
+      VIEW ifNotExists? viewName (LP_ (columnNames | viewColumnDefinitions) RP_)? commentClause?
+      // DORIS CHANGED END
       AS select
       (WITH (CASCADED | LOCAL)? CHECK OPTION)?
     ;

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDDLStatementVisitor.java
@@ -320,6 +320,18 @@ public final class DorisDDLStatementVisitor extends DorisStatementVisitor implem
         CreateViewStatement result = new CreateViewStatement(getDatabaseType());
         result.setReplaceView(null != ctx.REPLACE());
         result.setView((SimpleTableSegment) visit(ctx.viewName()));
+        // DORIS CHANGED BEGIN
+        if (null != ctx.columnNames()) {
+            CollectionValue<ColumnSegment> columns = (CollectionValue<ColumnSegment>) visit(ctx.columnNames());
+            for (ColumnSegment each : columns.getValue()) {
+                result.getColumns().add(new ViewColumnSegment(each.getStartIndex(), each.getStopIndex(), each, null));
+            }
+        }
+        if (null != ctx.viewColumnDefinitions()) {
+            CollectionValue<ViewColumnSegment> columns = (CollectionValue<ViewColumnSegment>) visit(ctx.viewColumnDefinitions());
+            result.getColumns().addAll(columns.getValue());
+        }
+        // DORIS CHANGED END
         result.setViewDefinition(getOriginalText(ctx.select()));
         result.setSelect((SelectStatement) visit(ctx.select()));
         return result;

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/standard/type/CreateViewStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/standard/type/CreateViewStatementAssert.java
@@ -31,8 +31,10 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Create view statement assert.
@@ -65,6 +67,13 @@ public final class CreateViewStatementAssert {
             ExpectedViewColumn expectedColumn = expected.getColumns().get(count);
             IdentifierValueAssert.assertIs(assertContext, each.getColumn().getIdentifier(), expectedColumn, "View column");
             SQLSegmentAssert.assertIs(assertContext, each, expectedColumn);
+            if (null != expectedColumn.getComment()) {
+                assertTrue(each.getComment().isPresent(), assertContext.getText(String.format("View column `%s` should have comment", expectedColumn.getName())));
+                assertThat(assertContext.getText(String.format("View column `%s` comment assertion error: ", expectedColumn.getName())),
+                        each.getComment().get(), is(expectedColumn.getComment()));
+            } else {
+                assertFalse(each.getComment().isPresent(), assertContext.getText(String.format("View column `%s` should not have comment", expectedColumn.getName())));
+            }
             count++;
         }
     }

--- a/test/it/parser/src/main/resources/case/ddl/create-view.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-view.xml
@@ -115,10 +115,9 @@
     </create-view>
 
     <create-view sql-case-id="create_view_with_columns_doris" view-definition="SELECT k1, k2 FROM example_table">
-        <view name="example_view" start-index="12" stop-index="23">
-            <column name="c1" start-index="26" stop-index="27" />
-            <column name="c2" start-index="30" stop-index="31" />
-        </view>
+        <view name="example_view" start-index="12" stop-index="23" />
+        <column name="c1" start-index="26" stop-index="27" />
+        <column name="c2" start-index="30" stop-index="31" />
         <select>
             <projections start-index="44" stop-index="49">
                 <column-projection name="k1" start-index="44" stop-index="45" />
@@ -126,6 +125,60 @@
             </projections>
             <from>
                 <simple-table name="example_table" start-index="56" stop-index="68" />
+            </from>
+        </select>
+    </create-view>
+
+    <create-view sql-case-id="create_view_with_column_comments_doris" view-definition="SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table WHERE k1 = 20160112 GROUP BY k1,k2,k3">
+        <view name="example_view" start-index="12" stop-index="34">
+            <owner name="example_db" start-index="12" stop-index="21" />
+        </view>
+        <column name="k1" start-index="37" stop-index="58" comment="first key" />
+        <column name="k2" start-index="61" stop-index="83" comment="second key" />
+        <column name="k3" start-index="86" stop-index="107" comment="third key" />
+        <column name="v1" start-index="110" stop-index="133" comment="first value" />
+        <select>
+            <projections start-index="170" stop-index="194">
+                <column-projection name="c1" alias="k1" start-index="170" stop-index="177" />
+                <column-projection name="k2" start-index="180" stop-index="181" />
+                <column-projection name="k3" start-index="184" stop-index="185" />
+                <aggregation-projection type="SUM" expression="SUM(v1)" start-index="188" stop-index="194" />
+            </projections>
+            <from>
+                <simple-table name="example_table" start-index="201" stop-index="213" />
+            </from>
+            <where start-index="215" stop-index="233">
+                <expr>
+                    <binary-operation-expression start-index="221" stop-index="233">
+                        <left>
+                            <column name="k1" start-index="221" stop-index="222" />
+                        </left>
+                        <right>
+                            <literal-expression value="20160112" start-index="226" stop-index="233" />
+                        </right>
+                        <operator>=</operator>
+                    </binary-operation-expression>
+                </expr>
+            </where>
+            <group-by>
+                <column-item name="k1" start-index="244" stop-index="245" />
+                <column-item name="k2" start-index="247" stop-index="248" />
+                <column-item name="k3" start-index="250" stop-index="251" />
+            </group-by>
+        </select>
+    </create-view>
+
+    <create-view sql-case-id="create_view_with_if_not_exists_doris" view-definition="SELECT k1, k2 FROM example_table">
+        <view name="example_view" start-index="26" stop-index="37" />
+        <column name="c1" start-index="40" stop-index="61" comment="first key" />
+        <column name="c2" start-index="64" stop-index="65" />
+        <select>
+            <projections start-index="78" stop-index="83">
+                <column-projection name="k1" start-index="78" stop-index="79" />
+                <column-projection name="k2" start-index="82" stop-index="83" />
+            </projections>
+            <from>
+                <simple-table name="example_table" start-index="90" stop-index="102" />
             </from>
         </select>
     </create-view>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-view.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-view.xml
@@ -23,6 +23,8 @@
     <sql-case id="create_view" value="CREATE VIEW comedies AS SELECT * FROM films WHERE kind = 'Comedy'" db-types="MySQL,PostgreSQL,openGauss,SQLServer,Doris" />
     <sql-case id="create_view_with_owner_doris" value="CREATE VIEW report.v_sales AS SELECT order_id, user_id FROM t_order" db-types="Doris" />
     <sql-case id="create_view_with_columns_doris" value="CREATE VIEW example_view (c1, c2) AS SELECT k1, k2 FROM example_table" db-types="Doris" />
+    <sql-case id="create_view_with_column_comments_doris" value="CREATE VIEW example_db.example_view (k1 COMMENT &quot;first key&quot;, k2 COMMENT &quot;second key&quot;, k3 COMMENT &quot;third key&quot;, v1 COMMENT &quot;first value&quot;) COMMENT &quot;my first view&quot; AS SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table WHERE k1 = 20160112 GROUP BY k1,k2,k3" db-types="Doris" />
+    <sql-case id="create_view_with_if_not_exists_doris" value="CREATE VIEW IF NOT EXISTS example_view (c1 COMMENT 'first key', c2) AS SELECT k1, k2 FROM example_table" db-types="Doris" />
     <sql-case id="create_view_with_check_option" value="CREATE VIEW universal_comedies AS SELECT * FROM comedies WHERE classification = 'U' WITH LOCAL CHECK OPTION" db-types="PostgreSQL,openGauss" />
     <sql-case id="create_view_with_recursive" value="CREATE RECURSIVE VIEW public.nums_1_100 (n) AS VALUES (1) UNION ALL SELECT n+1 FROM nums_1_100 WHERE n = 100" db-types="PostgreSQL" />
     <sql-case id="create_view_with_recursive_opengauss" value="CREATE RECURSIVE VIEW public.nums_1_100 (n) AS VALUES (1) UNION ALL SELECT n+1 FROM nums_1_100 WHERE n = 100" db-types="openGauss" />


### PR DESCRIPTION
- Align Doris createView grammar with the existing ALTER VIEW support: IF NOT EXISTS, per-column COMMENT and view-level COMMENT before AS
- Extract view columns into CreateViewStatement in visitCreateView, mirroring visitAlterView; view-level comment is parsed and ignored as done for CREATE MATERIALIZED VIEW
- Assert view column comments in CreateViewStatementAssert and add parser IT cases; relocate existing column asserts to statement level so they are actually bound

Fixes #31476
