### PR TITLE
Support parsing Doris REFRESH MATERIALIZED VIEW syntax

### DIFF
--- a/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
+++ b/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
@@ -831,6 +831,8 @@ public enum SQLVisitorRule {
     
     CREATE_MATERIALIZED_VIEW_LOG("CreateMaterializedViewLog", SQLStatementType.DDL),
     
+    DORIS_REFRESH_MATERIALIZED_VIEW("RefreshMaterializedView", SQLStatementType.DDL),
+    
     CREATE_OPERATOR("CreateOperator", SQLStatementType.DDL),
     
     CREATE_INDEX_TYPE("CreateIndexType", SQLStatementType.DDL),

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DDLStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DDLStatement.g4
@@ -515,6 +515,18 @@ refreshSchedule
     ;
 // DORIS ADDED END
 
+// DORIS ADDED BEGIN
+refreshMaterializedView
+    : REFRESH MATERIALIZED VIEW name (partitionSpec | refreshMethod)
+    ;
+// DORIS ADDED END
+
+// DORIS ADDED BEGIN
+partitionSpec
+    : PARTITIONS LP_ identifierList RP_
+    ;
+// DORIS ADDED END
+
 alterView
     : ALTER (ALGORITHM EQ_ (UNDEFINED | MERGE | TEMPTABLE))?
       ownerStatement?

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
@@ -142,6 +142,7 @@ execute
     | delimiter
     | startReplica
     | createMaterializedView
+    | refreshMaterializedView
     | resumeJob
     | pauseJob
     | dropJob

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDDLStatementVisitor.java
@@ -80,6 +80,7 @@ import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CreateS
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CreateLikeClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CreateLogfileGroupContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CreateMaterializedViewContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RefreshMaterializedViewContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CreateProcedureContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CreateServerContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CreateSyncJobContext;
@@ -291,6 +292,7 @@ import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisPauseJobSta
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisResumeJobStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisResumeSyncJobStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisStopSyncJobStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisRefreshMaterializedViewStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.ddl.event.MySQLAlterEventStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.ddl.event.MySQLCreateEventStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.ddl.event.MySQLDropEventStatement;
@@ -2035,6 +2037,19 @@ public final class DorisDDLStatementVisitor extends DorisStatementVisitor implem
     @Override
     public ASTNode visitCreateMaterializedView(final CreateMaterializedViewContext ctx) {
         return new CreateMaterializedViewStatement(getDatabaseType());
+    }
+    
+    @Override
+    public ASTNode visitRefreshMaterializedView(final RefreshMaterializedViewContext ctx) {
+        boolean auto = null != ctx.refreshMethod() && null != ctx.refreshMethod().AUTO();
+        boolean complete = null != ctx.refreshMethod() && null != ctx.refreshMethod().COMPLETE();
+        List<String> partitionNames = new LinkedList<>();
+        if (null != ctx.partitionSpec()) {
+            for (IdentifierContext each : ctx.partitionSpec().identifierList().identifier()) {
+                partitionNames.add(((IdentifierValue) visit(each)).getValue());
+            }
+        }
+        return new DorisRefreshMaterializedViewStatement(getDatabaseType(), ((IdentifierValue) visit(ctx.name().identifier())).getValue(), auto, complete, partitionNames);
     }
     
     @Override

--- a/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/ddl/DorisRefreshMaterializedViewStatement.java
+++ b/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/ddl/DorisRefreshMaterializedViewStatement.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.ddl;
+
+import lombok.Getter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.DDLStatement;
+
+import java.util.List;
+
+/**
+ * Refresh materialized view statement for Doris.
+ */
+@Getter
+public final class DorisRefreshMaterializedViewStatement extends DDLStatement {
+    
+    private final String mvName;
+    
+    private final boolean auto;
+    
+    private final boolean complete;
+    
+    private final List<String> partitionNames;
+    
+    public DorisRefreshMaterializedViewStatement(final DatabaseType databaseType, final String mvName, final boolean auto, final boolean complete, final List<String> partitionNames) {
+        super(databaseType);
+        this.mvName = mvName;
+        this.auto = auto;
+        this.complete = complete;
+        this.partitionNames = partitionNames;
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/doris/DorisDDLStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/doris/DorisDDLStatementAssert.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisAlterWorklo
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCreateFunctionStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisDropFunctionStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCancelMaterializedViewTaskStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisRefreshMaterializedViewStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCancelTaskStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisAlterJobStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisDropJobStatement;
@@ -41,6 +42,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAsse
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.doris.type.DorisAlterColocateGroupStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.doris.type.DorisAlterStoragePolicyStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.doris.type.DorisAlterWorkloadGroupStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.doris.type.DorisRefreshMaterializedViewStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisAlterColocateGroupStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisAlterStoragePolicyStatementTestCase;
@@ -48,6 +50,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCreateJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisDropFunctionStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCancelMaterializedViewTaskStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisRefreshMaterializedViewStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCancelTaskStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisAlterJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisDropJobStatementTestCase;
@@ -108,6 +111,8 @@ public final class DorisDDLStatementAssert {
             DorisCancelTaskStatementAssert.assertIs(assertContext, (DorisCancelTaskStatement) actual, (DorisCancelTaskStatementTestCase) expected);
         } else if (actual instanceof DorisCancelMaterializedViewTaskStatement) {
             DorisCancelMaterializedViewTaskStatementAssert.assertIs(assertContext, (DorisCancelMaterializedViewTaskStatement) actual, (DorisCancelMaterializedViewTaskStatementTestCase) expected);
+        } else if (actual instanceof DorisRefreshMaterializedViewStatement) {
+            DorisRefreshMaterializedViewStatementAssert.assertIs(assertContext, (DorisRefreshMaterializedViewStatement) actual, (DorisRefreshMaterializedViewStatementTestCase) expected);
         }
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/doris/type/DorisRefreshMaterializedViewStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/doris/type/DorisRefreshMaterializedViewStatementAssert.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.doris.type;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisRefreshMaterializedViewStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisRefreshMaterializedViewStatementTestCase;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Refresh materialized view statement assert for Doris.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DorisRefreshMaterializedViewStatementAssert {
+    
+    /**
+     * Assert refresh materialized view statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual refresh materialized view statement
+     * @param expected expected refresh materialized view statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DorisRefreshMaterializedViewStatement actual, final DorisRefreshMaterializedViewStatementTestCase expected) {
+        if (null != expected.getMvName()) {
+            assertThat(assertContext.getText("materialized view name does not match: "), actual.getMvName(), is(expected.getMvName()));
+        }
+        if (expected.isAuto()) {
+            assertTrue(actual.isAuto(), assertContext.getText("materialized view refresh type AUTO does not match: "));
+        }
+        if (expected.isComplete()) {
+            assertTrue(actual.isComplete(), assertContext.getText("materialized view refresh type COMPLETE does not match: "));
+        }
+        if (!expected.getPartitionNames().isEmpty()) {
+            assertThat(assertContext.getText("materialized view partition names do not match: "), actual.getPartitionNames(), is(expected.getPartitionNames()));
+        }
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -165,6 +165,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCreateJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCreateStreamingJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCreateSyncJobStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisRefreshMaterializedViewStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisDropFunctionStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisDropJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisPauseJobStatementTestCase;
@@ -650,6 +651,9 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "create-streaming-job")
     private final List<DorisCreateStreamingJobStatementTestCase> createStreamingJobTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "doris-refresh-materialized-view")
+    private final List<DorisRefreshMaterializedViewStatementTestCase> dorisRefreshMaterializedViewTestCases = new LinkedList<>();
     
     @XmlElement(name = "alter-catalog")
     private final List<AlterCatalogStatementTestCase> alterCatalogTestCases = new LinkedList<>();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/dialect/doris/DorisRefreshMaterializedViewStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/dialect/doris/DorisRefreshMaterializedViewStatementTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Refresh materialized view statement test case for Doris.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+public final class DorisRefreshMaterializedViewStatementTestCase extends SQLParserTestCase {
+    
+    @XmlElement(name = "mv-name")
+    private String mvName;
+    
+    private boolean auto;
+    
+    private boolean complete;
+    
+    @XmlElement(name = "partition-name")
+    private final List<String> partitionNames = new LinkedList<>();
+}

--- a/test/it/parser/src/main/resources/case/ddl/refresh-materialized-view.xml
+++ b/test/it/parser/src/main/resources/case/ddl/refresh-materialized-view.xml
@@ -21,4 +21,17 @@
     <refresh-materialized-view sql-case-id="refresh_mat_view_concurrently_no_data" />
     <refresh-materialized-view sql-case-id="refresh_mat_view_point" />
     <refresh-materialized-view sql-case-id="refresh_mat_view" />
+    <doris-refresh-materialized-view sql-case-id="doris_refresh_materialized_view_auto">
+        <mv-name>mv1</mv-name>
+        <auto>true</auto>
+    </doris-refresh-materialized-view>
+    <doris-refresh-materialized-view sql-case-id="doris_refresh_materialized_view_partitions">
+        <mv-name>mv1</mv-name>
+        <partition-name>p_19950801_19950901</partition-name>
+        <partition-name>p_19950901_19951001</partition-name>
+    </doris-refresh-materialized-view>
+    <doris-refresh-materialized-view sql-case-id="doris_refresh_materialized_view_complete">
+        <mv-name>mv1</mv-name>
+        <complete>true</complete>
+    </doris-refresh-materialized-view>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/refresh-materialized-view.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/refresh-materialized-view.xml
@@ -21,4 +21,7 @@
     <sql-case id="refresh_mat_view_concurrently_no_data" value="REFRESH MATERIALIZED VIEW CONCURRENTLY mvtest_tvmm WITH NO DATA;" db-types="PostgreSQL" />
     <sql-case id="refresh_mat_view_point" value="REFRESH MATERIALIZED VIEW matview_schema.mv_nodata2;" db-types="PostgreSQL" />
     <sql-case id="refresh_mat_view" value="REFRESH MATERIALIZED VIEW mvtest_mv;" db-types="PostgreSQL" />
+    <sql-case id="doris_refresh_materialized_view_auto" value="REFRESH MATERIALIZED VIEW mv1 AUTO" db-types="Doris" />
+    <sql-case id="doris_refresh_materialized_view_partitions" value="REFRESH MATERIALIZED VIEW mv1 partitions(p_19950801_19950901,p_19950901_19951001)" db-types="Doris" />
+    <sql-case id="doris_refresh_materialized_view_complete" value="REFRESH MATERIALIZED VIEW mv1 complete" db-types="Doris" />
 </sql-cases>


### PR DESCRIPTION
- Add REFRESH MATERIALIZED VIEW <mv-name> (AUTO | COMPLETE | PARTITIONS) grammar rule to the Doris dialect
- Add DorisRefreshMaterializedViewStatement and visitRefreshMaterializedView to extract mv name, refresh type and partition names
- Add parser IT cases covering the AUTO, COMPLETE and PARTITIONS variants from issue #31457

Fixes #31457