### PR TITLE
Support parsing Doris ADMIN REPAIR, ADMIN CANCEL REPAIR and array subscript syntax

### DIFF
--- a/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
+++ b/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
@@ -609,6 +609,10 @@ public enum SQLVisitorRule {
     
     ADMIN_REBALANCE_DISK("AdminRebalanceDisk", SQLStatementType.DAL),
     
+    ADMIN_REPAIR("AdminRepair", SQLStatementType.DAL),
+    
+    ADMIN_CANCEL_REPAIR("AdminCancelRepair", SQLStatementType.DAL),
+    
     CLEAN_ALL_PROFILE("CleanAllProfile", SQLStatementType.DAL),
     
     PLAN_REPLAYER_PLAY("PlanReplayerPlay", SQLStatementType.DAL),

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
@@ -1049,6 +1049,9 @@ simpleExpr
     // DORIS ADDED BEGIN
     | lambdaExpression
     // DORIS ADDED END
+    // DORIS ADDED BEGIN
+    | columnRef LBT_ expr RBT_
+    // DORIS ADDED END
     ;
 
 arrayExpression

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
@@ -514,6 +514,14 @@ adminRebalanceDisk
     : ADMIN REBALANCE DISK (ON LP_ string_ (COMMA_ string_)* RP_)?
     ;
 
+adminRepair
+    : ADMIN REPAIR TABLE tableName (PARTITION LP_ partitionName (COMMA_ partitionName)* RP_)?
+    ;
+
+adminCancelRepair
+    : ADMIN CANCEL REPAIR TABLE tableName (PARTITION LP_ partitionName (COMMA_ partitionName)* RP_)?
+    ;
+
 createSqlBlockRule
     : CREATE SQL_BLOCK_RULE ruleName propertiesClause
     ;

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
@@ -159,6 +159,8 @@ execute
     | adminSetPartitionVersion
     | adminCleanTrash
     | adminRebalanceDisk
+    | adminRepair
+    | adminCancelRepair
     | createSqlBlockRule
     | alterSqlBlockRule
     | dropSqlBlockRule

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/DorisStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/DorisStatementVisitor.java
@@ -663,6 +663,12 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
             ExpressionSegment expr = null == ctx.simpleExpr() ? null : (ExpressionSegment) visit(ctx.simpleExpr(0));
             return new CollateExpression(startIndex, stopIndex, (SimpleExpressionSegment) visit(ctx.collateClause()), expr);
         }
+        if (null != ctx.columnRef() && null != ctx.LBT_()) {
+            ColumnSegment column = (ColumnSegment) visit(ctx.columnRef());
+            ColumnSegment result = new ColumnSegment(startIndex, stopIndex, column.getIdentifier());
+            result.setOwner(column.getOwner().orElse(null));
+            return result;
+        }
         if (null != ctx.columnRef()) {
             return visit(ctx.columnRef());
         }

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDALStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDALStatementVisitor.java
@@ -150,6 +150,8 @@ import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.PluginP
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.PluginPropertyValueContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.AdminCleanTrashContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.AdminRebalanceDiskContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.AdminRepairContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.AdminCancelRepairContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CleanAllProfileContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.PlanReplayerPlayContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.DorisAlterSystemContext;
@@ -254,6 +256,8 @@ import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCopyTa
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCheckTabletStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminSetPartitionVersionStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminRebalanceDiskStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminRepairStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCancelRepairStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAlterResourceStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCreateResourceStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAlterSystemStatement;
@@ -1322,6 +1326,18 @@ public final class DorisDALStatementVisitor extends DorisStatementVisitor implem
             ctx.string_().forEach(each -> result.getBackends().add(SQLUtils.getExactlyValue(each.getText())));
         }
         return result;
+    }
+    
+    @Override
+    public ASTNode visitAdminRepair(final AdminRepairContext ctx) {
+        return new DorisAdminRepairStatement(getDatabaseType(), (SimpleTableSegment) visit(ctx.tableName()),
+                ctx.partitionName().isEmpty() ? Collections.emptyList() : ctx.partitionName().stream().map(each -> (PartitionSegment) visit(each)).collect(Collectors.toList()));
+    }
+    
+    @Override
+    public ASTNode visitAdminCancelRepair(final AdminCancelRepairContext ctx) {
+        return new DorisAdminCancelRepairStatement(getDatabaseType(), (SimpleTableSegment) visit(ctx.tableName()),
+                ctx.partitionName().isEmpty() ? Collections.emptyList() : ctx.partitionName().stream().map(each -> (PartitionSegment) visit(each)).collect(Collectors.toList()));
     }
     
     @Override

--- a/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisAdminCancelRepairStatement.java
+++ b/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisAdminCancelRepairStatement.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.dal;
+
+import lombok.Getter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.PartitionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.DALStatement;
+
+import java.util.Collection;
+
+/**
+ * Admin cancel repair statement for Doris.
+ */
+@Getter
+public final class DorisAdminCancelRepairStatement extends DALStatement {
+    
+    private final SimpleTableSegment table;
+    
+    private final Collection<PartitionSegment> partitions;
+    
+    public DorisAdminCancelRepairStatement(final DatabaseType databaseType, final SimpleTableSegment table, final Collection<PartitionSegment> partitions) {
+        super(databaseType);
+        this.table = table;
+        this.partitions = partitions;
+    }
+}

--- a/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisAdminRepairStatement.java
+++ b/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisAdminRepairStatement.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.dal;
+
+import lombok.Getter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.PartitionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.DALStatement;
+
+import java.util.Collection;
+
+/**
+ * Admin repair statement for Doris.
+ */
+@Getter
+public final class DorisAdminRepairStatement extends DALStatement {
+    
+    private final SimpleTableSegment table;
+    
+    private final Collection<PartitionSegment> partitions;
+    
+    public DorisAdminRepairStatement(final DatabaseType databaseType, final SimpleTableSegment table, final Collection<PartitionSegment> partitions) {
+        super(databaseType);
+        this.table = table;
+        this.partitions = partitions;
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/DorisDALStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/DorisDALStatementAssert.java
@@ -23,6 +23,8 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.DA
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.UnsetVariableStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCleanTrashStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminRebalanceDiskStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminRepairStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCancelRepairStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCleanAllProfileStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisPlanReplayerPlayStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCopyTabletStatement;
@@ -65,6 +67,8 @@ import org.apache.shardingsphere.sql.parser.statement.doris.dal.show.DorisShowDa
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisAdminCleanTrashStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisAdminRebalanceDiskStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisAdminRepairStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisAdminCancelRepairStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisCleanAllProfileStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisPlanReplayerPlayStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisAdminCopyTabletStatementAssert;
@@ -108,6 +112,8 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.d
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCleanTrashStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminRebalanceDiskStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminRepairStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCancelRepairStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCleanAllProfileStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisPlanReplayerPlayStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCopyTabletStatementTestCase;
@@ -221,6 +227,10 @@ public final class DorisDALStatementAssert {
             DorisAdminCleanTrashStatementAssert.assertIs(assertContext, (DorisAdminCleanTrashStatement) actual, (DorisAdminCleanTrashStatementTestCase) expected);
         } else if (actual instanceof DorisAdminRebalanceDiskStatement) {
             DorisAdminRebalanceDiskStatementAssert.assertIs(assertContext, (DorisAdminRebalanceDiskStatement) actual, (DorisAdminRebalanceDiskStatementTestCase) expected);
+        } else if (actual instanceof DorisAdminRepairStatement) {
+            DorisAdminRepairStatementAssert.assertIs(assertContext, (DorisAdminRepairStatement) actual, (DorisAdminRepairStatementTestCase) expected);
+        } else if (actual instanceof DorisAdminCancelRepairStatement) {
+            DorisAdminCancelRepairStatementAssert.assertIs(assertContext, (DorisAdminCancelRepairStatement) actual, (DorisAdminCancelRepairStatementTestCase) expected);
         } else if (actual instanceof DorisShowTrashStatement) {
             DorisShowTrashStatementAssert.assertIs(assertContext, (DorisShowTrashStatement) actual, (DorisShowTrashStatementTestCase) expected);
         } else if (actual instanceof DorisShowLoadStatement) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisAdminCancelRepairStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisAdminCancelRepairStatementAssert.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.PartitionSegment;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCancelRepairStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.partition.PartitionAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCancelRepairStatementTestCase;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Admin cancel repair statement assert for Doris.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DorisAdminCancelRepairStatementAssert {
+    
+    /**
+     * Assert admin cancel repair statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual admin cancel repair statement
+     * @param expected expected admin cancel repair statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DorisAdminCancelRepairStatement actual, final DorisAdminCancelRepairStatementTestCase expected) {
+        if (null != expected.getTable()) {
+            TableAssert.assertIs(assertContext, actual.getTable(), expected.getTable());
+        }
+        assertPartitions(assertContext, actual, expected);
+    }
+    
+    private static void assertPartitions(final SQLCaseAssertContext assertContext, final DorisAdminCancelRepairStatement actual, final DorisAdminCancelRepairStatementTestCase expected) {
+        assertThat(assertContext.getText("Assertion error: partition size does not match."), actual.getPartitions().size(), is(expected.getPartitions().size()));
+        int count = 0;
+        for (PartitionSegment each : actual.getPartitions()) {
+            PartitionAssert.assertIs(assertContext, each, expected.getPartitions().get(count));
+            count++;
+        }
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisAdminRepairStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisAdminRepairStatementAssert.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.PartitionSegment;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminRepairStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.partition.PartitionAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminRepairStatementTestCase;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Admin repair statement assert for Doris.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DorisAdminRepairStatementAssert {
+    
+    /**
+     * Assert admin repair statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual admin repair statement
+     * @param expected expected admin repair statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DorisAdminRepairStatement actual, final DorisAdminRepairStatementTestCase expected) {
+        if (null != expected.getTable()) {
+            TableAssert.assertIs(assertContext, actual.getTable(), expected.getTable());
+        }
+        assertPartitions(assertContext, actual, expected);
+    }
+    
+    private static void assertPartitions(final SQLCaseAssertContext assertContext, final DorisAdminRepairStatement actual, final DorisAdminRepairStatementTestCase expected) {
+        assertThat(assertContext.getText("Assertion error: partition size does not match."), actual.getPartitions().size(), is(expected.getPartitions().size()));
+        int count = 0;
+        for (PartitionSegment each : actual.getPartitions()) {
+            PartitionAssert.assertIs(assertContext, each, expected.getPartitions().get(count));
+            count++;
+        }
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -25,6 +25,8 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.ShowAlterTableStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.ShowBuildIndexStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCleanTrashStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminRepairStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCancelRepairStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminRebalanceDiskStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCopyTabletStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCheckTabletStatementTestCase;
@@ -828,6 +830,12 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "admin-rebalance-disk")
     private final List<DorisAdminRebalanceDiskStatementTestCase> adminRebalanceDiskTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "admin-repair")
+    private final List<DorisAdminRepairStatementTestCase> adminRepairTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "admin-cancel-repair")
+    private final List<DorisAdminCancelRepairStatementTestCase> adminCancelRepairTestCases = new LinkedList<>();
     
     @XmlElement(name = "clean-all-profile")
     private final List<DorisCleanAllProfileStatementTestCase> cleanAllProfileTestCases = new LinkedList<>();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisAdminCancelRepairStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisAdminCancelRepairStatementTestCase.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedPartition;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSimpleTable;
+
+import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Admin cancel repair statement test case for Doris.
+ */
+@Getter
+@Setter
+public final class DorisAdminCancelRepairStatementTestCase extends SQLParserTestCase {
+    
+    @XmlElement(name = "table")
+    private ExpectedSimpleTable table;
+    
+    @XmlElement(name = "partition")
+    private List<ExpectedPartition> partitions = new LinkedList<>();
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisAdminRepairStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisAdminRepairStatementTestCase.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedPartition;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSimpleTable;
+
+import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Admin repair statement test case for Doris.
+ */
+@Getter
+@Setter
+public final class DorisAdminRepairStatementTestCase extends SQLParserTestCase {
+    
+    @XmlElement(name = "table")
+    private ExpectedSimpleTable table;
+    
+    @XmlElement(name = "partition")
+    private List<ExpectedPartition> partitions = new LinkedList<>();
+}

--- a/test/it/parser/src/main/resources/case/dal/admin-cancel-repair.xml
+++ b/test/it/parser/src/main/resources/case/dal/admin-cancel-repair.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <admin-cancel-repair sql-case-id="admin_cancel_repair_table">
+        <table name="tbl1" start-index="26" stop-index="29" />
+    </admin-cancel-repair>
+
+    <admin-cancel-repair sql-case-id="admin_cancel_repair_table_with_partition">
+        <table name="tbl1" start-index="26" stop-index="29" />
+        <partition name="p1" start-index="42" stop-index="43" />
+    </admin-cancel-repair>
+
+    <admin-cancel-repair sql-case-id="admin_cancel_repair_table_with_partitions">
+        <table name="tbl1" start-index="26" stop-index="29" />
+        <partition name="p1" start-index="42" stop-index="43" />
+        <partition name="p2" start-index="46" stop-index="47" />
+    </admin-cancel-repair>
+</sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dal/admin-repair.xml
+++ b/test/it/parser/src/main/resources/case/dal/admin-repair.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <admin-repair sql-case-id="admin_repair_table">
+        <table name="tbl1" start-index="19" stop-index="22" />
+    </admin-repair>
+
+    <admin-repair sql-case-id="admin_repair_table_with_partition">
+        <table name="tbl1" start-index="19" stop-index="22" />
+        <partition name="p1" start-index="35" stop-index="36" />
+    </admin-repair>
+
+    <admin-repair sql-case-id="admin_repair_table_with_partitions">
+        <table name="tbl1" start-index="19" stop-index="22" />
+        <partition name="p1" start-index="35" stop-index="36" />
+        <partition name="p2" start-index="39" stop-index="40" />
+    </admin-repair>
+</sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select-window.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-window.xml
@@ -97,6 +97,20 @@
         </from>
     </select>
 
+    <select sql-case-id="select_window_rank_doris">
+        <projections start-index="7" stop-index="45">
+            <expression-projection text="RANK() OVER (PARTITION BY k ORDER BY v)" start-index="7" stop-index="45">
+                <expr>
+                    <function function-name="RANK" start-index="7" stop-index="45" text="RANK() OVER (PARTITION BY k ORDER BY v)">
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="t_order" start-index="52" stop-index="58" />
+        </from>
+    </select>
+
     <select sql-case-id="select_window_lead_lag_doris">
         <projections start-index="7" stop-index="46">
             <expression-projection text="LEAD(v) OVER (PARTITION BY k ORDER BY v)" start-index="7" stop-index="46">

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -14809,6 +14809,35 @@
         </projections>
     </select>
 
+    <select sql-case-id="select_element_at">
+        <projections start-index="7" stop-index="23">
+            <expression-projection text="element_at(k1, 1)" start-index="7" stop-index="23">
+                <expr>
+                    <function start-index="7" stop-index="23" text="element_at(k1, 1)" function-name="element_at">
+                        <parameter>
+                            <column name="k1" start-index="18" stop-index="19" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression start-index="22" stop-index="22" value="1" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="t_order" start-index="30" stop-index="36" />
+        </from>
+    </select>
+
+    <select sql-case-id="select_array_subscript">
+        <projections start-index="7" stop-index="11">
+            <column-projection name="k1" start-index="7" stop-index="11" />
+        </projections>
+        <from>
+            <simple-table name="t_order" start-index="18" stop-index="24" />
+        </from>
+    </select>
+
     <select sql-case-id="select_ltrim_as_column_alias">
         <projections start-index="7" stop-index="17">
             <column-projection name="id" alias="ltrim" start-index="7" stop-index="17" />

--- a/test/it/parser/src/main/resources/sql/supported/dal/admin-cancel-repair.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/admin-cancel-repair.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="admin_cancel_repair_table" value="ADMIN CANCEL REPAIR TABLE tbl1" db-types="Doris" />
+    <sql-case id="admin_cancel_repair_table_with_partition" value="ADMIN CANCEL REPAIR TABLE tbl1 PARTITION (p1)" db-types="Doris" />
+    <sql-case id="admin_cancel_repair_table_with_partitions" value="ADMIN CANCEL REPAIR TABLE tbl1 PARTITION (p1, p2)" db-types="Doris" />
+</sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/admin-repair.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/admin-repair.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="admin_repair_table" value="ADMIN REPAIR TABLE tbl1" db-types="Doris" />
+    <sql-case id="admin_repair_table_with_partition" value="ADMIN REPAIR TABLE tbl1 PARTITION (p1)" db-types="Doris" />
+    <sql-case id="admin_repair_table_with_partitions" value="ADMIN REPAIR TABLE tbl1 PARTITION (p1, p2)" db-types="Doris" />
+</sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-window.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-window.xml
@@ -20,6 +20,7 @@
     <sql-case id="select_catalog_window_aggregation" value="select pg_catalog.max(ref_0.c36) over (partition by ref_0.c39 order by ref_0.vkey desc) as c_5 from t24 as ref_0" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_window" value="SELECT user_id, ROW_NUMBER() OVER w AS 'row_number', RANK() OVER w AS 'rank', DENSE_RANK() OVER w AS 'dense_rank' FROM t_order WHERE order_id = ? WINDOW w AS (ORDER BY user_id)" db-types="MySQL,Doris,Hive" />
     <sql-case id="select_window_partition_order_doris" value="SELECT ROW_NUMBER() OVER (PARTITION BY k ORDER BY v) FROM t_order" db-types="Doris,Hive" />
+    <sql-case id="select_window_rank_doris" value="SELECT RANK() OVER (PARTITION BY k ORDER BY v) FROM t_order" db-types="Doris" />
     <sql-case id="select_window_lead_lag_doris" value="SELECT LEAD(v) OVER (PARTITION BY k ORDER BY v) FROM t_order" db-types="Doris" />
     <sql-case id="select_window_first_value_doris" value="SELECT FIRST_VALUE(v) OVER (PARTITION BY k ORDER BY v) FROM t_order" db-types="Doris" />
     <sql-case id="select_window_last_value_doris" value="SELECT LAST_VALUE(v) OVER (PARTITION BY k ORDER BY v ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM t_order" db-types="Doris" />

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -539,7 +539,9 @@
     <sql-case id="select_limit_parameter" value="SELECT * FROM t4 LIMIT ?;" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_limit_complex_expr" value="SELECT * FROM t4 LIMIT (CASE WHEN true THEN 10 ELSE 20 END);" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_func" value="select public.int4range(400, 500, '[]');" db-types="PostgreSQL" />
-    <sql-case id="select_ltrim_function" value="SELECT LTRIM('  barbar')" db-types="MySQL" />
+    <sql-case id="select_ltrim_function" value="SELECT LTRIM('  barbar')" db-types="MySQL,Doris" />
+    <sql-case id="select_element_at" value="SELECT element_at(k1, 1) FROM t_order" db-types="Doris" />
+    <sql-case id="select_array_subscript" value="SELECT k1[1] FROM t_order" db-types="Doris" />
     <sql-case id="select_ltrim_as_column_alias" value="SELECT id AS ltrim FROM t" db-types="MySQL" />
     <sql-case id="select_ltrim_as_qualified_column" value="SELECT t.ltrim FROM t" db-types="MySQL" />
     <sql-case id="select_make_set_single" value="SELECT MAKE_SET(1,'a','b','c')" db-types="MySQL" />


### PR DESCRIPTION
For #31485

- Support ADMIN REPAIR TABLE and ADMIN CANCEL REPAIR TABLE statements with optional PARTITION clause for Doris
- Support array subscript access like arr[position] in Doris expressions
- Add Doris parser IT cases for RANK() OVER, LTRIM and element_at functions