### PR TITLE
Support parsing Oracle RMAN CHANGE DB_UNIQUE_NAME SQL

### DIFF
--- a/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DALStatement.g4
+++ b/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DALStatement.g4
@@ -205,7 +205,8 @@ report
     ;
 
 change
-    : CHANGE BACKUPSET numberLiterals changeOption?
+    : CHANGE DB_UNIQUE_NAME FROM identifier TO identifier
+    | CHANGE BACKUPSET numberLiterals changeOption?
     | CHANGE DATAFILECOPY (stringLiterals | numberLiterals) changeOption?
     | CHANGE COPY OF ARCHIVELOG SEQUENCE BETWEEN numberLiterals AND numberLiterals changeOption?
     | CHANGE BACKUP OF SPFILE TAG (stringLiterals | DOUBLE_QUOTED_TEXT) changeOption?

--- a/test/it/parser/src/main/resources/case/dal/change.xml
+++ b/test/it/parser/src/main/resources/case/dal/change.xml
@@ -17,6 +17,7 @@
   -->
 
 <sql-parser-test-cases>
+    <change sql-case-id="change_db_unique_name_oracle" />
     <change sql-case-id="change_backupset_nokeep_oracle" />
     <change sql-case-id="change_backupset_unavailable_oracle" />
     <change sql-case-id="change_backupset_available_oracle" />

--- a/test/it/parser/src/main/resources/sql/supported/dal/change.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/change.xml
@@ -17,6 +17,7 @@
   -->
 
 <sql-cases>
+    <sql-case id="change_db_unique_name_oracle" value="CHANGE DB_UNIQUE_NAME FROM BOSTON_A TO BOSTON_B" db-types="Oracle" />
     <sql-case id="change_backupset_nokeep_oracle" value="CHANGE BACKUPSET 231 NOKEEP" db-types="Oracle" />
     <sql-case id="change_backupset_unavailable_oracle" value="CHANGE BACKUPSET 12 UNAVAILABLE" db-types="Oracle" />
     <sql-case id="change_backupset_available_oracle" value="CHANGE BACKUPSET 12 AVAILABLE" db-types="Oracle" />


### PR DESCRIPTION
- Add the CHANGE DB_UNIQUE_NAME FROM identifier TO identifier branch to the Oracle DAL change rule introduced for RMAN CHANGE statements, covering the rename form requested by issue #27017
- Reuse the field-less OracleChangeStatement passthrough model and existing CHANGE visitor rule, so no statement, visitor or assert change is required
- Add the CHANGE DB_UNIQUE_NAME FROM BOSTON_A TO BOSTON_B parser IT case

Fixes #27017
