### PR TITLE
Support parsing Oracle CREATE TYPE BODY SQL

### DIFF
--- a/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
+++ b/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
@@ -695,6 +695,8 @@ public enum SQLVisitorRule {
     
     CREATE_TYPE("CreateType", SQLStatementType.DDL),
     
+    CREATE_TYPE_BODY("CreateTypeBody", SQLStatementType.DDL),
+    
     DROP_CONVERSION("DropConversion", SQLStatementType.DDL),
     
     ALTER_DOMAIN("AlterDomain", SQLStatementType.DDL),

--- a/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/PLSQL.g4
+++ b/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/PLSQL.g4
@@ -115,6 +115,21 @@ packageInitialization
     : BEGIN plsqlStatements (EXCEPTION exceptionHandler+)?
     ;
 
+createTypeBody
+    : CREATE (OR REPLACE)? (EDITIONABLE | NONEDITIONABLE)? TYPE BODY plsqlTypeBodySource
+    ;
+
+plsqlTypeBodySource
+    : typeName (IS | AS) typeBodyElement+ END typeName? SEMI_?
+    ;
+
+typeBodyElement
+    : (MEMBER | STATIC)? FUNCTION function (LP_ parameterDeclaration (COMMA_ parameterDeclaration)* RP_)? returnDateType (IS | AS) declareSection? body
+    | (MEMBER | STATIC)? PROCEDURE procedureName (LP_ parameterDeclaration (COMMA_ parameterDeclaration)* RP_)? (IS | AS) declareSection? body
+    | (FINAL | INSTANTIABLE)? CONSTRUCTOR FUNCTION function (LP_ parameterDeclaration (COMMA_ parameterDeclaration)* RP_)? RETURN SELF AS RESULT (IS | AS) declareSection? body
+    | (MAP | ORDER) MEMBER FUNCTION function (LP_ parameterDeclaration (COMMA_ parameterDeclaration)* RP_)? returnDateType (IS | AS) declareSection? body
+    ;
+
 plsqlProcedureSource
     : (schemaName DOT_)? procedureName (LP_ parameterDeclaration (COMMA_ parameterDeclaration)* RP_)? sharingClause?
     ((defaultCollationClause | invokerRightsClause | accessibleByClause)*)? (IS | AS) (callSpec | declareSection? body)

--- a/parser/sql/engine/dialect/oracle/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OracleStatement.g4
+++ b/parser/sql/engine/dialect/oracle/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OracleStatement.g4
@@ -153,6 +153,7 @@ execute
     | dropCluster
     | systemAction
     | alterType
+    | createTypeBody
     | createType
     | createCluster
     | createJava

--- a/parser/sql/engine/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/engine/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/engine/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
@@ -116,6 +116,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.Create
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CreateTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CreateTablespaceContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CreateTriggerContext;
+import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CreateTypeBodyContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CreateTypeContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CreateViewContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CursorDefinitionContext;
@@ -375,6 +376,7 @@ import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.lockdown.Oracle
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.lockdown.OracleCreateLockdownProfileStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.lockdown.OracleDropLockdownProfileStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.outline.OracleAlterOutlineStatement;
+import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.OracleCreateTypeBodyStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.outline.OracleCreateOutlineStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.outline.OracleDropOutlineStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.pkg.OracleCreatePackageStatement;
@@ -947,6 +949,11 @@ public final class OracleDDLStatementVisitor extends OracleStatementVisitor impl
         result.getDynamicSqlStatementExpressions().addAll(getDynamicSqlStatementExpressions());
         result.getCursorForLoopStatements().addAll(getCursorForLoopStatementSegments());
         return result;
+    }
+    
+    @Override
+    public ASTNode visitCreateTypeBody(final CreateTypeBodyContext ctx) {
+        return new OracleCreateTypeBodyStatement(getDatabaseType(), ctx.plsqlTypeBodySource().typeName(0).getText());
     }
     
     private PackageSegment createPackageEndNameSegment(final List<PackageNameContext> packageNames) {

--- a/parser/sql/statement/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/statement/oracle/ddl/OracleCreateTypeBodyStatement.java
+++ b/parser/sql/statement/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/statement/oracle/ddl/OracleCreateTypeBodyStatement.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.oracle.ddl;
+
+import lombok.Getter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.DDLStatement;
+
+/**
+ * Create type body statement for Oracle.
+ */
+@Getter
+public final class OracleCreateTypeBodyStatement extends DDLStatement {
+    
+    private final String typeName;
+    
+    public OracleCreateTypeBodyStatement(final DatabaseType databaseType, final String typeName) {
+        super(databaseType);
+        this.typeName = typeName;
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/oracle/OracleDDLStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/oracle/OracleDDLStatementAssert.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.OracleAlterSess
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.OracleAlterSystemStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.OracleAnalyzeStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.OracleAuditStatement;
+import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.OracleCreateTypeBodyStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.OracleNoAuditStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.OraclePurgeStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.flashback.OracleFlashbackTableStatement;
@@ -38,6 +39,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.d
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.oracle.type.OracleAssociateStatisticsStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.oracle.type.OracleAuditStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.oracle.type.OracleCreatePackageStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.oracle.type.OracleCreateTypeBodyStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.oracle.type.OracleDisassociateStatisticsStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.oracle.type.OracleFlashbackTableStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.oracle.type.OracleNoAuditStatementAssert;
@@ -48,6 +50,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleAnalyzeStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleAuditStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleCreatePackageStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleCreateTypeBodyStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleNoAuditStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OraclePurgeStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.flashback.OracleFlashbackTableStatementTestCase;
@@ -83,6 +86,8 @@ public final class OracleDDLStatementAssert {
             OracleAuditStatementAssert.assertIs(assertContext, (OracleAuditStatement) actual, (OracleAuditStatementTestCase) expected);
         } else if (actual instanceof OracleCreatePackageStatement) {
             OracleCreatePackageStatementAssert.assertIs(assertContext, (OracleCreatePackageStatement) actual, (OracleCreatePackageStatementTestCase) expected);
+        } else if (actual instanceof OracleCreateTypeBodyStatement) {
+            OracleCreateTypeBodyStatementAssert.assertIs(assertContext, (OracleCreateTypeBodyStatement) actual, (OracleCreateTypeBodyStatementTestCase) expected);
         } else if (actual instanceof OracleNoAuditStatement) {
             OracleNoAuditStatementAssert.assertIs(assertContext, (OracleNoAuditStatement) actual, (OracleNoAuditStatementTestCase) expected);
         } else if (actual instanceof OracleFlashbackTableStatement) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/oracle/type/OracleCreateTypeBodyStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/oracle/type/OracleCreateTypeBodyStatementAssert.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.oracle.type;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.oracle.ddl.OracleCreateTypeBodyStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleCreateTypeBodyStatementTestCase;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Create type body statement assert for Oracle.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class OracleCreateTypeBodyStatementAssert {
+    
+    /**
+     * Assert create type body statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual create type body statement
+     * @param expected expected create type body statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final OracleCreateTypeBodyStatement actual, final OracleCreateTypeBodyStatementTestCase expected) {
+        if (null != expected.getTypeName()) {
+            assertThat(assertContext.getText("Actual type name does not match: "), actual.getTypeName(), is(expected.getTypeName()));
+        }
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -186,6 +186,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleAnalyzeStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleAuditStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleCreatePackageStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleCreateTypeBodyStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleDropPackageStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OracleNoAuditStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle.OraclePurgeStatementTestCase;
@@ -1060,6 +1061,9 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "create-package")
     private final List<OracleCreatePackageStatementTestCase> createPackageTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "create-type-body")
+    private final List<OracleCreateTypeBodyStatementTestCase> createTypeBodyTestCases = new LinkedList<>();
     
     @XmlElement(name = "create-dimension")
     private final List<OracleCreateDimensionStatementTestCase> createDimensionTestCases = new LinkedList<>();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/dialect/oracle/OracleCreateTypeBodyStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/dialect/oracle/OracleCreateTypeBodyStatementTestCase.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.oracle;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+/**
+ * Create type body statement test case for Oracle.
+ */
+@Getter
+@Setter
+public final class OracleCreateTypeBodyStatementTestCase extends SQLParserTestCase {
+    
+    @XmlAttribute(name = "type-name")
+    private String typeName;
+}

--- a/test/it/parser/src/main/resources/case/ddl/create-type-body.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-type-body.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <create-type-body sql-case-id="create_type_body_with_member_functions_oracle" type-name="data_typ1" />
+    <create-type-body sql-case-id="create_type_body_with_map_member_and_procedure_oracle" type-name="rational" />
+    <create-type-body sql-case-id="create_type_body_with_constructor_member_and_static_oracle" type-name="rectangle" />
+    <create-type-body sql-case-id="create_type_body_with_order_member_oracle" type-name="point" />
+</sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-type-body.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-type-body.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="create_type_body_with_member_functions_oracle" value="CREATE OR REPLACE TYPE BODY data_typ1 IS MEMBER FUNCTION prod (invent NUMBER) RETURN NUMBER IS BEGIN RETURN (year + invent); END; MEMBER FUNCTION qtr(der_qtr DATE) RETURN CHAR IS BEGIN IF (der_qtr &lt; TO_DATE('01-APR', 'DD-MON')) THEN RETURN 'FIRST'; ELSIF (der_qtr &lt; TO_DATE('01-JUL', 'DD-MON')) THEN RETURN 'SECOND'; ELSIF (der_qtr &lt; TO_DATE('01-OCT', 'DD-MON')) THEN RETURN 'THIRD'; ELSE RETURN 'FOURTH'; END IF; END; END;" db-types="Oracle" />
+    <sql-case id="create_type_body_with_map_member_and_procedure_oracle" value="CREATE OR REPLACE TYPE BODY rational AS MAP MEMBER FUNCTION convert RETURN REAL IS BEGIN RETURN num / den; END convert; MEMBER PROCEDURE normalize IS g INTEGER; BEGIN g := gcd(num, den); num := num / g; den := den / g; END normalize; END;" db-types="Oracle" />
+    <sql-case id="create_type_body_with_constructor_member_and_static_oracle" value="CREATE OR REPLACE TYPE BODY rectangle AS CONSTRUCTOR FUNCTION rectangle(len NUMBER, wid NUMBER) RETURN SELF AS RESULT IS BEGIN length := len; width := wid; RETURN; END; MEMBER FUNCTION get_length RETURN NUMBER IS BEGIN RETURN length; END; STATIC FUNCTION new_square(side NUMBER) RETURN rectangle IS result rectangle := rectangle(side, side); BEGIN RETURN result; END; END;" db-types="Oracle" />
+    <sql-case id="create_type_body_with_order_member_oracle" value="CREATE OR REPLACE TYPE BODY point AS ORDER MEMBER FUNCTION match(p NUMBER) RETURN NUMBER IS BEGIN IF id = p THEN RETURN 0; ELSE RETURN 1; END IF; END; END;" db-types="Oracle" />
+</sql-cases>


### PR DESCRIPTION
- Add createTypeBody, plsqlTypeBodySource and typeBodyElement rules to the Oracle PLSQL grammar, covering MEMBER/STATIC function and procedure bodies, CONSTRUCTOR FUNCTION with RETURN SELF AS RESULT, and MAP/ORDER MEMBER FUNCTION bodies with optional declare sections and full PL/SQL statement bodies
- Reuse the existing body, declareSection and parameterDeclaration building blocks already exercised by CREATE PACKAGE BODY, CREATE FUNCTION and CREATE TRIGGER, and dispatch createTypeBody before createType in the execute rule
- Build a lightweight OracleCreateTypeBodyStatement carrying the type name and register the CREATE_TYPE_BODY visitor rule, DDL assert branch and JAXB test case
- Add 4 parser IT cases from issue #27005 and the official PL/SQL reference examples

Fixes #27005
