### PR TITLE
Support parsing Oracle CREATE TYPE BODY SQL

### DIFF
--- a/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/engine/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -4300,7 +4300,7 @@ dropFunction
     ;
 
 compileTypeClause
-    : COMPILE DEBUG? (SPECIFICATION|BODY)? compilerParametersClause? REUSE SETTINGS
+    : COMPILE DEBUG? (SPECIFICATION|BODY)? compilerParametersClause? (REUSE SETTINGS)?
     ;
 
 inheritanceClauses

--- a/test/it/parser/src/main/resources/case/ddl/alter-type.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-type.xml
@@ -30,6 +30,9 @@
     <alter-type sql-case-id="alter_type_debug" />
     <alter-type sql-case-id="alter_type_spec" />
     <alter-type sql-case-id="alter_type_body" />
+    <alter-type sql-case-id="alter_type_spec_without_reuse_settings" />
+    <alter-type sql-case-id="alter_type_body_without_reuse_settings" />
+    <alter-type sql-case-id="alter_type_compile_without_reuse_settings" />
     <alter-type sql-case-id="alter_type_compile_bool" />
     <alter-type sql-case-id="alter_type_compile_bool_false" />
     <alter-type sql-case-id="alter_type_compile_string" />

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-type.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-type.xml
@@ -30,6 +30,9 @@
     <sql-case id="alter_type_debug" value="ALTER TYPE type_name COMPILE DEBUG REUSE SETTINGS" db-types="Oracle" />
     <sql-case id="alter_type_spec" value="ALTER TYPE type_name COMPILE SPECIFICATION REUSE SETTINGS" db-types="Oracle" />
     <sql-case id="alter_type_body" value="ALTER TYPE type_name COMPILE BODY REUSE SETTINGS" db-types="Oracle" />
+    <sql-case id="alter_type_spec_without_reuse_settings" value="ALTER TYPE type_name COMPILE SPECIFICATION" db-types="Oracle" />
+    <sql-case id="alter_type_body_without_reuse_settings" value="ALTER TYPE type_name COMPILE BODY" db-types="Oracle" />
+    <sql-case id="alter_type_compile_without_reuse_settings" value="ALTER TYPE type_name COMPILE" db-types="Oracle" />
     <sql-case id="alter_type_compile_bool" value="ALTER TYPE type_name COMPILE bool_variable = TRUE REUSE SETTINGS" db-types="Oracle" />
     <sql-case id="alter_type_compile_bool_false" value="ALTER TYPE type_name COMPILE bool_variable = FALSE REUSE SETTINGS" db-types="Oracle" />
     <sql-case id="alter_type_compile_string" value="ALTER TYPE type_name COMPILE string_variable = 'String Value' REUSE SETTINGS" db-types="Oracle" />


### PR DESCRIPTION
- Add createTypeBody, plsqlTypeBodySource and typeBodyElement rules to the Oracle PLSQL grammar, covering MEMBER/STATIC function and procedure bodies, CONSTRUCTOR FUNCTION with RETURN SELF AS RESULT, and MAP/ORDER MEMBER FUNCTION bodies with optional declare sections and full PL/SQL statement bodies
- Reuse the existing body, declareSection and parameterDeclaration building blocks already exercised by CREATE PACKAGE BODY, CREATE FUNCTION and CREATE TRIGGER, and dispatch createTypeBody before createType in the execute rule
- Make REUSE SETTINGS optional in compileTypeClause according to the Oracle PL/SQL Language Reference, so ALTER TYPE ... COMPILE, COMPILE SPECIFICATION and COMPILE BODY statements parse without trailing REUSE SETTINGS
- Build a lightweight OracleCreateTypeBodyStatement carrying the type name and register the CREATE_TYPE_BODY visitor rule, DDL assert branch and JAXB test case
- Add parser IT cases from issue #27005, the official PL/SQL reference examples, and the ALTER TYPE COMPILE forms without REUSE SETTINGS

Fixes #27005
