### PR TITLE
Close every statement in JDBCDataRowEnumerator even when one of them fails

### DIFF
--- a/kernel/sql-federation/executor/src/main/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/jdbc/JDBCDataRowEnumerator.java
+++ b/kernel/sql-federation/executor/src/main/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/jdbc/JDBCDataRowEnumerator.java
@@ -97,7 +97,9 @@ public final class JDBCDataRowEnumerator implements Enumerator<Object> {
         if (null == previousFailure) {
             return failure;
         }
-        previousFailure.addSuppressed(failure);
+        if (previousFailure != failure) {
+            previousFailure.addSuppressed(failure);
+        }
         return previousFailure;
     }
 }

--- a/kernel/sql-federation/executor/src/main/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/jdbc/JDBCDataRowEnumerator.java
+++ b/kernel/sql-federation/executor/src/main/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/jdbc/JDBCDataRowEnumerator.java
@@ -79,13 +79,25 @@ public final class JDBCDataRowEnumerator implements Enumerator<Object> {
     
     @Override
     public void close() {
-        try {
-            for (Statement each : statements) {
+        SQLException failure = null;
+        for (Statement each : statements) {
+            try {
                 each.close();
+            } catch (final SQLException ex) {
+                failure = appendFailure(failure, ex);
             }
-            currentRow = null;
-        } catch (final SQLException ex) {
-            throw new SQLWrapperException(ex);
         }
+        currentRow = null;
+        if (null != failure) {
+            throw new SQLWrapperException(failure);
+        }
+    }
+    
+    private SQLException appendFailure(final SQLException previousFailure, final SQLException failure) {
+        if (null == previousFailure) {
+            return failure;
+        }
+        previousFailure.addSuppressed(failure);
+        return previousFailure;
     }
 }

--- a/kernel/sql-federation/executor/src/test/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/jdbc/JDBCDataRowEnumeratorTest.java
+++ b/kernel/sql-federation/executor/src/test/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/jdbc/JDBCDataRowEnumeratorTest.java
@@ -111,6 +111,22 @@ class JDBCDataRowEnumeratorTest {
     }
     
     @Test
+    void assertCloseContinuesWhenTwoStatementsThrowTheSameException() throws SQLException {
+        SQLException sharedException = new SQLException("shared failure");
+        Statement firstStatement = mock(Statement.class);
+        doThrow(sharedException).when(firstStatement).close();
+        Statement secondStatement = mock(Statement.class);
+        doThrow(sharedException).when(secondStatement).close();
+        Statement thirdStatement = mock(Statement.class);
+        JDBCDataRowEnumerator enumerator = new JDBCDataRowEnumerator(
+                mock(MergedResult.class), mock(QueryResultMetaData.class), Arrays.asList(firstStatement, secondStatement, thirdStatement));
+        SQLWrapperException actualException = assertThrows(SQLWrapperException.class, enumerator::close);
+        assertThat(actualException.getCause(), is(sharedException));
+        verify(thirdStatement).close();
+        assertNull(enumerator.current());
+    }
+    
+    @Test
     void assertCloseSuppressesLaterFailures() throws SQLException {
         Statement firstStatement = mock(Statement.class);
         SQLException firstException = new SQLException("first");

--- a/kernel/sql-federation/executor/src/test/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/jdbc/JDBCDataRowEnumeratorTest.java
+++ b/kernel/sql-federation/executor/src/test/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/jdbc/JDBCDataRowEnumeratorTest.java
@@ -93,4 +93,36 @@ class JDBCDataRowEnumeratorTest {
         SQLWrapperException actualException = assertThrows(SQLWrapperException.class, enumerator::close);
         assertThat(actualException.getCause(), isA(SQLException.class));
     }
+    
+    @Test
+    void assertCloseClosesRemainingStatementsAfterFailure() throws SQLException {
+        Statement failedStatement = mock(Statement.class);
+        SQLException expectedException = new SQLException("failed to close");
+        doThrow(expectedException).when(failedStatement).close();
+        Statement secondStatement = mock(Statement.class);
+        Statement thirdStatement = mock(Statement.class);
+        JDBCDataRowEnumerator enumerator = new JDBCDataRowEnumerator(
+                mock(MergedResult.class), mock(QueryResultMetaData.class), Arrays.asList(failedStatement, secondStatement, thirdStatement));
+        SQLWrapperException actualException = assertThrows(SQLWrapperException.class, enumerator::close);
+        assertThat(actualException.getCause(), is(expectedException));
+        verify(secondStatement).close();
+        verify(thirdStatement).close();
+        assertNull(enumerator.current());
+    }
+    
+    @Test
+    void assertCloseSuppressesLaterFailures() throws SQLException {
+        Statement firstStatement = mock(Statement.class);
+        SQLException firstException = new SQLException("first");
+        doThrow(firstException).when(firstStatement).close();
+        Statement secondStatement = mock(Statement.class);
+        SQLException secondException = new SQLException("second");
+        doThrow(secondException).when(secondStatement).close();
+        JDBCDataRowEnumerator enumerator = new JDBCDataRowEnumerator(
+                mock(MergedResult.class), mock(QueryResultMetaData.class), Arrays.asList(firstStatement, secondStatement));
+        SQLWrapperException actualException = assertThrows(SQLWrapperException.class, enumerator::close);
+        assertThat(actualException.getCause(), is(firstException));
+        assertThat(actualException.getCause().getSuppressed().length, is(1));
+        assertThat(actualException.getCause().getSuppressed()[0], is(secondException));
+    }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

  - Close every statement in `JDBCDataRowEnumerator.close()`, not just the ones before the first failure.

The close loop was inside the `try` block:

```java
public void close() {
    try {
        for (Statement each : statements) {
            each.close();
        }
        currentRow = null;
    } catch (final SQLException ex) {
        throw new SQLWrapperException(ex);
    }
}
```

`statements` holds one statement per data source the federated query touched, so when the first one throws the loop aborts and the remaining statements — and the server side cursors behind them — are never closed. `currentRow` is left dangling too.

Each statement is now closed independently. The first failure is kept and later ones are attached to it with `addSuppressed`, following `MCPJdbcStatementExecutor#appendFailure`, so the `SQLWrapperException` a caller already sees is unchanged and nothing is silently dropped.

Two tests in `JDBCDataRowEnumeratorTest`:

  - `assertCloseClosesRemainingStatementsAfterFailure` — the first of three statements throws; the other two are still closed and the original exception still surfaces. Without the change this fails with `Wanted but not invoked: secondStatement.close()`.
  - `assertCloseSuppressesLaterFailures` — two failing statements; the first is the cause and the second is suppressed rather than lost.

The three existing tests are unchanged and still pass.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
