### PR TITLE
Fall back to the default execution plan cache when SQL federation YAML omits it

### DIFF
--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/yaml/swapper/YamlSQLFederationRuleConfigurationSwapper.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/yaml/swapper/YamlSQLFederationRuleConfigurationSwapper.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.infra.yaml.config.swapper.rule.YamlRuleConfigur
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.sqlfederation.constant.SQLFederationOrder;
+import org.apache.shardingsphere.sqlfederation.rule.builder.DefaultSQLFederationRuleConfigurationBuilder;
 import org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration;
 
 /**
@@ -41,7 +42,9 @@ public final class YamlSQLFederationRuleConfigurationSwapper implements YamlRule
     
     @Override
     public SQLFederationRuleConfiguration swapToObject(final YamlSQLFederationRuleConfiguration yamlConfig) {
-        SQLFederationCacheOption executionPlanCacheConfig = executionPlanCacheConfigSwapper.swapToObject(yamlConfig.getExecutionPlanCache());
+        SQLFederationCacheOption executionPlanCacheConfig = null == yamlConfig.getExecutionPlanCache()
+                ? DefaultSQLFederationRuleConfigurationBuilder.DEFAULT_EXECUTION_PLAN_CACHE_OPTION
+                : executionPlanCacheConfigSwapper.swapToObject(yamlConfig.getExecutionPlanCache());
         return new SQLFederationRuleConfiguration(yamlConfig.isSqlFederationEnabled(), yamlConfig.isAllQueryUseSQLFederation(), executionPlanCacheConfig);
     }
     

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/yaml/swapper/YamlSQLFederationRuleConfigurationSwapperTest.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/yaml/swapper/YamlSQLFederationRuleConfigurationSwapperTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sqlfederation.yaml.swapper;
+
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
+import org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class YamlSQLFederationRuleConfigurationSwapperTest {
+    
+    @Test
+    void assertSwapToObjectWithoutExecutionPlanCache() {
+        YamlSQLFederationRuleConfiguration yamlConfig = new YamlSQLFederationRuleConfiguration();
+        yamlConfig.setSqlFederationEnabled(true);
+        SQLFederationRuleConfiguration actual = new YamlSQLFederationRuleConfigurationSwapper().swapToObject(yamlConfig);
+        assertThat(actual.getExecutionPlanCache().getInitialCapacity(), is(2000));
+        assertThat(actual.getExecutionPlanCache().getMaximumSize(), is(65535L));
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

  - Fall back to the default execution plan cache when a `SQL_FEDERATION` rule omits `executionPlanCache`.

`executionPlanCache` is a plain object field on `YamlSQLFederationRuleConfiguration` with no default, so it is null whenever the YAML leaves it out:

```yaml
- !SQL_FEDERATION
  sqlFederationEnabled: true
```

`swapToObject` then hands that null straight to the cache swapper, which dereferences it:

```java
SQLFederationCacheOption executionPlanCacheConfig =
        executionPlanCacheConfigSwapper.swapToObject(yamlConfig.getExecutionPlanCache());
```

```
java.lang.NullPointerException: Cannot invoke
"...YamlSQLFederationExecutionPlanCacheRuleConfiguration.getInitialCapacity()"
because "yamlConfig" is null
```

Omitting the whole `SQL_FEDERATION` block is fine — `DefaultSQLFederationRuleConfigurationBuilder` supplies `DEFAULT_EXECUTION_PLAN_CACHE_OPTION`. It is only writing the rule and leaving out this one sub-block that fails, which is the more natural thing to do when all you want is to turn federation on.

The fix uses that same default, so the two ways of not specifying a cache now agree. Null-guarding a nested YAML config this way is what the encrypt, sharding and readwrite-splitting swappers already do.

### Tests

`YamlSQLFederationRuleConfigurationSwapperTest#assertSwapToObjectWithoutExecutionPlanCache` builds the config without the cache block and asserts it comes back as 2000 / 65535. Reverting the change, it errors with the NPE above.

`mvn test -pl kernel/sql-federation/core` — 282 tests, all passing.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
