### PR TITLE
Close the connection when CatalogSwitchableDataSource fails to switch catalog

### DIFF
--- a/infra/data-source-pool/core/src/main/java/org/apache/shardingsphere/infra/datasource/pool/CatalogSwitchableDataSource.java
+++ b/infra/data-source-pool/core/src/main/java/org/apache/shardingsphere/infra/datasource/pool/CatalogSwitchableDataSource.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.datasource.pool;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.util.close.QuietlyCloser;
 
 import javax.sql.DataSource;
 import java.io.PrintWriter;
@@ -44,8 +45,16 @@ public final class CatalogSwitchableDataSource implements DataSource, AutoClosea
     @Override
     public Connection getConnection() throws SQLException {
         Connection result = dataSource.getConnection();
-        if (null != catalog && !catalog.equals(result.getCatalog())) {
-            result.setCatalog(catalog);
+        boolean switched = false;
+        try {
+            if (null != catalog && !catalog.equals(result.getCatalog())) {
+                result.setCatalog(catalog);
+            }
+            switched = true;
+        } finally {
+            if (!switched) {
+                QuietlyCloser.close(result);
+            }
         }
         return result;
     }

--- a/infra/data-source-pool/core/src/test/java/org/apache/shardingsphere/infra/datasource/pool/CatalogSwitchableDataSourceTest.java
+++ b/infra/data-source-pool/core/src/test/java/org/apache/shardingsphere/infra/datasource/pool/CatalogSwitchableDataSourceTest.java
@@ -36,6 +36,8 @@ import java.util.logging.Logger;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -74,6 +76,32 @@ class CatalogSwitchableDataSourceTest {
         assertThat(actualConnection, is(connection));
         verify(dataSource).getConnection();
         verify(connection).setCatalog("db");
+    }
+    
+    @Test
+    void assertGetConnectionClosesTheConnectionWhenSwitchingCatalogFails() throws SQLException {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getCatalog()).thenReturn("other_db");
+        SQLException expectedException = new SQLException("unknown database");
+        doThrow(expectedException).when(connection).setCatalog("db");
+        CatalogSwitchableDataSource dataSourceUnderTest = new CatalogSwitchableDataSource(dataSource, "db", "jdbc:mysql://localhost:3306/db");
+        SQLException actualException = assertThrows(SQLException.class, dataSourceUnderTest::getConnection);
+        assertThat(actualException, is(expectedException));
+        verify(connection).close();
+    }
+    
+    @Test
+    void assertGetConnectionKeepsTheOriginalFailureWhenClosingAlsoFails() throws SQLException {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getCatalog()).thenReturn("other_db");
+        SQLException expectedException = new SQLException("unknown database");
+        doThrow(expectedException).when(connection).setCatalog("db");
+        SQLException closeException = new SQLException("connection already dead");
+        doThrow(closeException).when(connection).close();
+        CatalogSwitchableDataSource dataSourceUnderTest = new CatalogSwitchableDataSource(dataSource, "db", "jdbc:mysql://localhost:3306/db");
+        SQLException actualException = assertThrows(SQLException.class, dataSourceUnderTest::getConnection);
+        assertThat(actualException, is(expectedException));
+        verify(connection).close();
     }
     
     @Test


### PR DESCRIPTION
Changes proposed in this pull request:

  - Close the connection in `CatalogSwitchableDataSource#getConnection` when switching the catalog fails.

The connection is handed out by the pool before the catalog is applied:

```java
Connection result = dataSource.getConnection();
if (null != catalog && !catalog.equals(result.getCatalog())) {
    result.setCatalog(catalog);
}
return result;
```

If `getCatalog` or `setCatalog` throws, the method exits with the connection already checked out of the pool and no reference to it anywhere. It is never closed and never returned. A catalog that does not exist, or a user without rights to it, makes `setCatalog` throw on every call, so each attempt takes one more connection out of the pool until the pool is empty and the failure changes from "unknown database" to a checkout timeout, which points nowhere near the actual cause.

`QuietlyCloser` is used rather than a `catch`, so the original failure is what the caller sees. A failure to close cannot replace it.

### Tests

Two in `CatalogSwitchableDataSourceTest`:

  - `assertGetConnectionClosesTheConnectionWhenSwitchingCatalogFails` — `setCatalog` throws; the connection is closed and the original `SQLException` still comes out.
  - `assertGetConnectionKeepsTheOriginalFailureWhenClosingAlsoFails` — closing throws too; the caller still gets the `setCatalog` failure rather than the close failure.

Both fail on `master` with `Wanted but not invoked: connection.close()`.

`mvn test -pl infra/data-source-pool/core` — 15 tests in that class, all passing.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
