### PR TITLE
Truncate timestamps towards the past when comparing them for consistency

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtils.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtils.java
@@ -107,12 +107,18 @@ public final class DataConsistencyCheckUtils {
          * strategies with different database types could be considered.
          */
         if (thisColumnValue instanceof Timestamp && thatColumnValue instanceof Timestamp) {
-            return ((Timestamp) thisColumnValue).getTime() / 1000L * 1000L == ((Timestamp) thatColumnValue).getTime() / 1000L * 1000L;
+            return toSeconds((Timestamp) thisColumnValue) == toSeconds((Timestamp) thatColumnValue);
         }
         if (thisColumnValue instanceof Array && thatColumnValue instanceof Array) {
             return Objects.deepEquals(((Array) thisColumnValue).getArray(), ((Array) thatColumnValue).getArray());
         }
         return equalsBuilder.append(thisColumnValue, thatColumnValue).isEquals();
+    }
+    
+    private static long toSeconds(final Timestamp timestamp) {
+        // Math.floorDiv, not /: integer division truncates towards zero, so it would put a
+        // pre-epoch value in the second above the one it belongs to.
+        return Math.floorDiv(timestamp.getTime(), 1000L);
     }
     
     private static boolean isNumberEquals(final Number one, final Number another) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtils.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtils.java
@@ -107,7 +107,7 @@ public final class DataConsistencyCheckUtils {
          * strategies with different database types could be considered.
          */
         if (thisColumnValue instanceof Timestamp && thatColumnValue instanceof Timestamp) {
-            return toSeconds((Timestamp) thisColumnValue) == toSeconds((Timestamp) thatColumnValue);
+            return toFlooredSeconds((Timestamp) thisColumnValue) == toFlooredSeconds((Timestamp) thatColumnValue);
         }
         if (thisColumnValue instanceof Array && thatColumnValue instanceof Array) {
             return Objects.deepEquals(((Array) thisColumnValue).getArray(), ((Array) thatColumnValue).getArray());
@@ -115,9 +115,7 @@ public final class DataConsistencyCheckUtils {
         return equalsBuilder.append(thisColumnValue, thatColumnValue).isEquals();
     }
     
-    private static long toSeconds(final Timestamp timestamp) {
-        // Math.floorDiv, not /: integer division truncates towards zero, so it would put a
-        // pre-epoch value in the second above the one it belongs to.
+    private static long toFlooredSeconds(final Timestamp timestamp) {
         return Math.floorDiv(timestamp.getTime(), 1000L);
     }
     

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtilsTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtilsTest.java
@@ -60,6 +60,19 @@ class DataConsistencyCheckUtilsTest {
     }
     
     @Test
+    void assertTimestampEqualsBeforeEpoch() {
+        EqualsBuilder equalsBuilder = new EqualsBuilder();
+        // -1500 and -1000 are half a second apart and fall in different seconds
+        assertFalse(DataConsistencyCheckUtils.isMatched(equalsBuilder, new Timestamp(-1500L), new Timestamp(-1000L)));
+        // -500 and 400 straddle the epoch and fall in different seconds
+        assertFalse(DataConsistencyCheckUtils.isMatched(equalsBuilder, new Timestamp(-500L), new Timestamp(400L)));
+        // -1000 and -999 differ by a millisecond and fall in the same second
+        assertTrue(DataConsistencyCheckUtils.isMatched(equalsBuilder, new Timestamp(-1000L), new Timestamp(-999L)));
+        // the sub-second tolerance still holds below the epoch
+        assertTrue(DataConsistencyCheckUtils.isMatched(equalsBuilder, new Timestamp(-1999L), new Timestamp(-1001L)));
+    }
+    
+    @Test
     void assertIsFirstUniqueKeysValueMatched() {
         Map<String, Object> record1 = ImmutableMap.of("order_id", 101, "user_id", 1, "status", "ok");
         Map<String, Object> record2 = ImmutableMap.of("order_id", 102, "user_id", 2, "status", "ok");

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtilsTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtilsTest.java
@@ -20,13 +20,19 @@ package org.apache.shardingsphere.data.pipeline.core.consistencycheck;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -59,17 +65,18 @@ class DataConsistencyCheckUtilsTest {
         assertFalse(DataConsistencyCheckUtils.isMatched(equalsBuilder, new Timestamp(time), new Timestamp(time + 1000L)));
     }
     
-    @Test
-    void assertTimestampEqualsBeforeEpoch() {
-        EqualsBuilder equalsBuilder = new EqualsBuilder();
-        // -1500 and -1000 are half a second apart and fall in different seconds
-        assertFalse(DataConsistencyCheckUtils.isMatched(equalsBuilder, new Timestamp(-1500L), new Timestamp(-1000L)));
-        // -500 and 400 straddle the epoch and fall in different seconds
-        assertFalse(DataConsistencyCheckUtils.isMatched(equalsBuilder, new Timestamp(-500L), new Timestamp(400L)));
-        // -1000 and -999 differ by a millisecond and fall in the same second
-        assertTrue(DataConsistencyCheckUtils.isMatched(equalsBuilder, new Timestamp(-1000L), new Timestamp(-999L)));
-        // the sub-second tolerance still holds below the epoch
-        assertTrue(DataConsistencyCheckUtils.isMatched(equalsBuilder, new Timestamp(-1999L), new Timestamp(-1001L)));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("preEpochTimestampCases")
+    void assertTimestampMatchedBeforeEpoch(final String scenario, final long thisMillis, final long thatMillis, final boolean expected) {
+        assertThat(DataConsistencyCheckUtils.isMatched(new EqualsBuilder(), new Timestamp(thisMillis), new Timestamp(thatMillis)), is(expected));
+    }
+    
+    private static Stream<Arguments> preEpochTimestampCases() {
+        return Stream.of(
+                Arguments.of("different seconds before epoch", -1500L, -1000L, false),
+                Arguments.of("different seconds across epoch", -500L, 400L, false),
+                Arguments.of("same second before epoch", -1000L, -999L, true),
+                Arguments.of("sub second tolerance before epoch", -1999L, -1001L, true));
     }
     
     @Test

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtilsTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtilsTest.java
@@ -31,8 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -66,17 +64,27 @@ class DataConsistencyCheckUtilsTest {
     }
     
     @ParameterizedTest(name = "{0}")
-    @MethodSource("preEpochTimestampCases")
-    void assertTimestampMatchedBeforeEpoch(final String scenario, final long thisMillis, final long thatMillis, final boolean expected) {
-        assertThat(DataConsistencyCheckUtils.isMatched(new EqualsBuilder(), new Timestamp(thisMillis), new Timestamp(thatMillis)), is(expected));
+    @MethodSource("matchedPreEpochTimestampCases")
+    void assertTimestampMatchedBeforeEpoch(final String scenario, final long thisMillis, final long thatMillis) {
+        assertTrue(DataConsistencyCheckUtils.isMatched(new EqualsBuilder(), new Timestamp(thisMillis), new Timestamp(thatMillis)));
     }
     
-    private static Stream<Arguments> preEpochTimestampCases() {
+    private static Stream<Arguments> matchedPreEpochTimestampCases() {
         return Stream.of(
-                Arguments.of("different seconds before epoch", -1500L, -1000L, false),
-                Arguments.of("different seconds across epoch", -500L, 400L, false),
-                Arguments.of("same second before epoch", -1000L, -999L, true),
-                Arguments.of("sub second tolerance before epoch", -1999L, -1001L, true));
+                Arguments.of("same second before epoch", -1000L, -999L),
+                Arguments.of("sub second tolerance before epoch", -1999L, -1001L));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("notMatchedPreEpochTimestampCases")
+    void assertTimestampNotMatchedBeforeEpoch(final String scenario, final long thisMillis, final long thatMillis) {
+        assertFalse(DataConsistencyCheckUtils.isMatched(new EqualsBuilder(), new Timestamp(thisMillis), new Timestamp(thatMillis)));
+    }
+    
+    private static Stream<Arguments> notMatchedPreEpochTimestampCases() {
+        return Stream.of(
+                Arguments.of("different seconds before epoch", -1500L, -1000L),
+                Arguments.of("different seconds across epoch", -500L, 400L));
     }
     
     @Test


### PR DESCRIPTION
Changes proposed in this pull request:

  - Truncate timestamps to the second with `Math.floorDiv`, so pre-epoch values land in the second they belong to.

`isMatched` compares `Timestamp` columns at second granularity, deliberately, to avoid precision differences between heterogeneous databases:

```java
return ((Timestamp) thisColumnValue).getTime() / 1000L * 1000L
    == ((Timestamp) thatColumnValue).getTime() / 1000L * 1000L;
```

Integer division truncates towards zero rather than downwards, so for a negative epoch value it rounds *up* — `-1500` becomes `-1000`, putting a timestamp in the second above the one it is in. Above the epoch the two agree; below it they do not, and the comparison goes wrong in both directions:

| the two values (ms) | apart | current | with `floorDiv` |
|---|---|---|---|
| `-1500`, `-1000` | 500 ms, different seconds | **matched** | differ |
| `-500`, `400` | 900 ms, straddles the epoch | **matched** | differ |
| `-1`, `1` | 2 ms, different seconds | **matched** | differ |
| `-1000`, `-999` | 1 ms, same second | **differ** | matched |

The first three are the ones that matter: a data consistency check reports two rows as equal while they hold different timestamps, which is the one answer the check exists to rule out. The last is the mirror image — two values inside the same second reported as a mismatch, so the check fails on data that is in fact consistent.

Any table with timestamps before 1970-01-01 is affected — dates of birth, historical records, backfilled series.

### Tests

`assertTimestampEqualsBeforeEpoch` covers all four rows of that table. On `master` the first assertion already fails:

```
DataConsistencyCheckUtilsTest.assertTimestampEqualsBeforeEpoch:66
expected: <false> but was: <true>
```

The existing `assertTimestampEquals` is untouched and still passes, so the above-epoch behaviour and the sub-second tolerance are unchanged.

`mvn test -pl kernel/data-pipeline/core` — 322 tests, all passing.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
