### PR TITLE
Floor the seconds when converting a pre-epoch date to a protobuf timestamp

### DIFF
--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtils.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtils.java
@@ -145,9 +145,6 @@ public final class ColumnValueConvertUtils {
     }
     
     private static com.google.protobuf.Timestamp converToProtobufTimestamp(final Date timestamp) {
-        // A protobuf timestamp is a second plus a non-negative nanosecond offset into it, so the
-        // seconds have to be floored. Integer division truncates towards zero, which for a value
-        // before the epoch names the second above the one the value is in.
         if (timestamp instanceof Timestamp) {
             Timestamp value = (Timestamp) timestamp;
             return com.google.protobuf.Timestamp.newBuilder().setSeconds(Math.floorDiv(value.getTime(), 1000L)).setNanos(value.getNanos()).build();

--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtils.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtils.java
@@ -145,11 +145,14 @@ public final class ColumnValueConvertUtils {
     }
     
     private static com.google.protobuf.Timestamp converToProtobufTimestamp(final Date timestamp) {
+        // A protobuf timestamp is a second plus a non-negative nanosecond offset into it, so the
+        // seconds have to be floored. Integer division truncates towards zero, which for a value
+        // before the epoch names the second above the one the value is in.
         if (timestamp instanceof Timestamp) {
             Timestamp value = (Timestamp) timestamp;
-            return com.google.protobuf.Timestamp.newBuilder().setSeconds(value.getTime() / 1000L).setNanos(value.getNanos()).build();
+            return com.google.protobuf.Timestamp.newBuilder().setSeconds(Math.floorDiv(value.getTime(), 1000L)).setNanos(value.getNanos()).build();
         }
         long millis = timestamp.getTime();
-        return com.google.protobuf.Timestamp.newBuilder().setSeconds(millis / 1000L).setNanos((int) ((millis % 1000L) * 1000000L)).build();
+        return com.google.protobuf.Timestamp.newBuilder().setSeconds(Math.floorDiv(millis, 1000L)).setNanos((int) (Math.floorMod(millis, 1000L) * 1000000L)).build();
     }
 }

--- a/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
@@ -26,6 +26,9 @@ import com.google.protobuf.Int32Value;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.rowset.serial.SerialBlob;
@@ -35,6 +38,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.Time;
+import java.util.stream.Stream;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -48,6 +52,7 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
@@ -164,22 +169,32 @@ class ColumnValueConvertUtilsTest {
         assertThat(actual.getNanos(), is(expectedTimestamp.getNanos()));
     }
     
-    @Test
-    void assertConvertPreEpochTimestampToTimestampMessage() {
-        for (long millis : new long[]{-1500L, -1L, -1000L, -86400000L, 1500L, 0L}) {
-            assertRoundTrip(new Timestamp(millis), millis);
-            assertRoundTrip(new Date(millis), millis);
-        }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("preEpochInstantCases")
+    void assertConvertPreEpochSqlTimestampToTimestampMessage(final String scenario, final long millis) {
+        com.google.protobuf.Timestamp actual = (com.google.protobuf.Timestamp) ColumnValueConvertUtils.convertToProtobufMessage(new Timestamp(millis));
+        assertThat(actual.getNanos(), allOf(greaterThanOrEqualTo(0), lessThan(1_000_000_000)));
+        assertThat(actual.getSeconds() * 1000L + actual.getNanos() / 1_000_000L, is(millis));
     }
     
-    private void assertRoundTrip(final Date value, final long millis) {
-        com.google.protobuf.Timestamp actual = (com.google.protobuf.Timestamp) ColumnValueConvertUtils.convertToProtobufMessage(value);
-        // a protobuf timestamp is only valid with a nanosecond offset inside the second
-        assertThat(value.getClass().getSimpleName() + " " + millis, actual.getNanos(), greaterThanOrEqualTo(0));
-        assertThat(value.getClass().getSimpleName() + " " + millis, actual.getNanos(), lessThan(1_000_000_000));
-        assertThat(value.getClass().getSimpleName() + " " + millis, actual.getSeconds() * 1000L + actual.getNanos() / 1_000_000L, is(millis));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("preEpochInstantCases")
+    void assertConvertPreEpochUtilDateToTimestampMessage(final String scenario, final long millis) {
+        com.google.protobuf.Timestamp actual = (com.google.protobuf.Timestamp) ColumnValueConvertUtils.convertToProtobufMessage(new Date(millis));
+        assertThat(actual.getNanos(), allOf(greaterThanOrEqualTo(0), lessThan(1_000_000_000)));
+        assertThat(actual.getSeconds() * 1000L + actual.getNanos() / 1_000_000L, is(millis));
     }
     
+    private static Stream<Arguments> preEpochInstantCases() {
+        return Stream.of(
+                Arguments.of("sub second before epoch", -1500L),
+                Arguments.of("one millisecond before epoch", -1L),
+                Arguments.of("whole second before epoch", -1000L),
+                Arguments.of("one day before epoch", -86400000L),
+                Arguments.of("sub second after epoch", 1500L),
+                Arguments.of("epoch", 0L));
+    }
+
     @Test
     void assertConvertLocalDateToInt64Value() {
         LocalDate localDate = LocalDate.of(2022, 3, 4);

--- a/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
@@ -48,8 +48,10 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("UseOfObsoleteDateTimeApi")
@@ -160,6 +162,22 @@ class ColumnValueConvertUtilsTest {
         Timestamp expectedTimestamp = Timestamp.valueOf(localDateTime);
         assertThat(actual.getSeconds(), is(expectedTimestamp.getTime() / 1000L));
         assertThat(actual.getNanos(), is(expectedTimestamp.getNanos()));
+    }
+    
+    @Test
+    void assertConvertPreEpochTimestampToTimestampMessage() {
+        for (long millis : new long[]{-1500L, -1L, -1000L, -86400000L, 1500L, 0L}) {
+            assertRoundTrip(new Timestamp(millis), millis);
+            assertRoundTrip(new Date(millis), millis);
+        }
+    }
+    
+    private void assertRoundTrip(final Date value, final long millis) {
+        com.google.protobuf.Timestamp actual = (com.google.protobuf.Timestamp) ColumnValueConvertUtils.convertToProtobufMessage(value);
+        // a protobuf timestamp is only valid with a nanosecond offset inside the second
+        assertThat(value.getClass().getSimpleName() + " " + millis, actual.getNanos(), greaterThanOrEqualTo(0));
+        assertThat(value.getClass().getSimpleName() + " " + millis, actual.getNanos(), lessThan(1_000_000_000));
+        assertThat(value.getClass().getSimpleName() + " " + millis, actual.getSeconds() * 1000L + actual.getNanos() / 1_000_000L, is(millis));
     }
     
     @Test


### PR DESCRIPTION
Changes proposed in this pull request:

  - Floor the seconds when converting a date to a protobuf timestamp, so pre-epoch values are not shifted forward by a second.

A protobuf `Timestamp` is a second plus a **non-negative** nanosecond offset into that second. `converToProtobufTimestamp` derives the seconds with integer division, which truncates towards zero, so below the epoch it names the second *above* the one the value is in:

```java
if (timestamp instanceof Timestamp) {
    Timestamp value = (Timestamp) timestamp;
    return ...newBuilder().setSeconds(value.getTime() / 1000L).setNanos(value.getNanos()).build();
}
long millis = timestamp.getTime();
return ...newBuilder().setSeconds(millis / 1000L).setNanos((int) ((millis % 1000L) * 1000000L)).build();
```

`java.sql.Timestamp#getNanos` is already the non-negative offset into the second the value falls in, so pairing it with a truncated second does not describe the same instant:

| input | seconds | nanos | describes | should be |
|---|---|---|---|---|
| `new Timestamp(-1500)` | `-1` | `500000000` | `-0.5 s` | `-1.5 s` |
| `new Timestamp(-1)` | `0` | `999000000` | `+0.999 s` | `-0.001 s` |

Off by a full second, silently, in a CDC stream.

The `java.util.Date` arm is worse — `millis % 1000` keeps the sign, so it emits a **negative** nanos:

| input | seconds | nanos |
|---|---|---|
| `new Date(-1500)` | `-1` | `-500000000` |

The protobuf `Timestamp` contract requires `0 <= nanos <= 999999999`, so that message is invalid; `Timestamps.checkValid` rejects it and a consumer decoding it gets whatever its own library does with an out-of-range field.

`Math.floorDiv` and `Math.floorMod` fix both and are identical to `/` and `%` at or above the epoch, so nothing else moves.

Any replicated table holding a date before 1970-01-01 is affected — dates of birth, historical records, backfilled series.

### Tests

`assertConvertPreEpochTimestampToTimestampMessage` runs `-1500`, `-1`, `-1000`, `-86400000`, `1500` and `0` through both arms and asserts, for each, that the nanos are inside `[0, 1000000000)` and that `seconds * 1000 + nanos / 1000000` comes back as the original millisecond value.

The round trip is deliberate rather than restating the conversion formula — the two existing timestamp tests assert against the same expression the implementation uses, so they pass either way. On `master` the new test fails on the first value:

```
ColumnValueConvertUtilsTest.assertConvertPreEpochTimestampToTimestampMessage:170->assertRoundTrip:180
Timestamp -1500
Expected: is <-1500L>
     but: was <-500L>
```

`mvn test -pl kernel/data-pipeline/scenario/cdc/core` — 121 tests, all passing.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
