### PR TITLE
Remove unsupported Doris named-window grammar and tests

### DIFF
--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
@@ -1163,11 +1163,11 @@ all
 // DORIS ADDED END
 
 overClause
-    : OVER (windowSpecification | identifier)
+    : OVER windowSpecification
     ;
 
 windowSpecification
-    : LP_ identifier? (PARTITION BY expr (COMMA_ expr)*)? orderByClause? frameClause? RP_
+    : LP_ (PARTITION BY expr (COMMA_ expr)*)? orderByClause? frameClause? RP_
     ;
 
 frameClause
@@ -1243,7 +1243,7 @@ windowFunction
     ;
 
 windowingClause
-    : OVER (windowName=identifier | windowSpecification)
+    : OVER windowSpecification
     ;
 
 leadLagInfo

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DMLStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DMLStatement.g4
@@ -154,7 +154,7 @@ queryPrimary
     ;
 
 querySpecification
-    : SELECT selectSpecification* projections selectIntoExpression? fromClause? whereClause? groupByClause? havingClause? windowClause?
+    : SELECT selectSpecification* projections selectIntoExpression? fromClause? whereClause? groupByClause? havingClause?
     ;
 
 call
@@ -532,14 +532,6 @@ limitRowCount
 
 limitOffset
     : numberLiterals | parameterMarker
-    ;
-
-windowClause
-    : WINDOW windowItem (COMMA_ windowItem)*
-    ;
-
-windowItem
-    : identifier AS windowSpecification
     ;
 
 subquery

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/DorisStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/DorisStatementVisitor.java
@@ -232,7 +232,6 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.Owner
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.ParameterMarkerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.ParenthesesSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WithSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.match.MatchAgainstExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.DeleteMultiTableSegment;
@@ -953,9 +952,6 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
         if (null != ctx.havingClause()) {
             selectStatementBuilder.having((HavingSegment) visit(ctx.havingClause()));
         }
-        if (null != ctx.windowClause()) {
-            selectStatementBuilder.window((WindowSegment) visit(ctx.windowClause()));
-        }
         if (null != ctx.selectIntoExpression()) {
             ASTNode intoSegment = visit(ctx.selectIntoExpression());
             if (intoSegment instanceof OutfileSegment) {
@@ -1129,21 +1125,13 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
         if (null != ctx.frameClause()) {
             result.setFrameClause(new CommonExpressionSegment(ctx.frameClause().start.getStartIndex(), ctx.frameClause().stop.getStopIndex(), getOriginalText(ctx.frameClause())));
         }
-        if (null != ctx.identifier()) {
-            result.setWindowName(new IdentifierValue(ctx.identifier().getText()));
-        }
         return result;
     }
     
     @Override
     public ASTNode visitOverClause(final OverClauseContext ctx) {
         WindowItemSegment result = new WindowItemSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
-        if (null != ctx.identifier()) {
-            result.setWindowName(new IdentifierValue(ctx.identifier().getText()));
-            return result;
-        }
         WindowItemSegment windowItemSegment = (WindowItemSegment) visit(ctx.windowSpecification());
-        result.setWindowName(windowItemSegment.getWindowName());
         result.setPartitionListSegments(windowItemSegment.getPartitionListSegments());
         result.setOrderBySegment(windowItemSegment.getOrderBySegment());
         result.setFrameClause(windowItemSegment.getFrameClause());

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDMLStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDMLStatementVisitor.java
@@ -55,9 +55,7 @@ import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.BrokerL
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ColumnNameContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.LoadStatementContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.LoadXmlStatementContext;
-import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.WindowClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.WindowFunctionContext;
-import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.WindowItemContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.WindowingClauseContext;
 import org.apache.shardingsphere.sql.parser.engine.doris.visitor.statement.DorisStatementVisitor;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.load.BrokerLoadDataDescSegment;
@@ -81,7 +79,6 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.DatabaseSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.IndexHintSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.CallStatement;
@@ -557,26 +554,6 @@ public final class DorisDMLStatementVisitor extends DorisStatementVisitor implem
     }
     
     @Override
-    public ASTNode visitWindowClause(final WindowClauseContext ctx) {
-        WindowSegment result = new WindowSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
-        for (WindowItemContext each : ctx.windowItem()) {
-            result.getItemSegments().add((WindowItemSegment) visit(each));
-        }
-        return result;
-    }
-    
-    @Override
-    public ASTNode visitWindowItem(final WindowItemContext ctx) {
-        WindowItemSegment result = new WindowItemSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
-        result.setWindowName(new IdentifierValue(ctx.identifier().getText()));
-        WindowItemSegment windowItemSegment = (WindowItemSegment) visit(ctx.windowSpecification());
-        result.setPartitionListSegments(windowItemSegment.getPartitionListSegments());
-        result.setOrderBySegment(windowItemSegment.getOrderBySegment());
-        result.setFrameClause(windowItemSegment.getFrameClause());
-        return result;
-    }
-    
-    @Override
     public ASTNode visitWindowFunction(final WindowFunctionContext ctx) {
         FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.funcName.getText(), getOriginalText(ctx));
         if (null != ctx.NTILE()) {
@@ -616,15 +593,10 @@ public final class DorisDMLStatementVisitor extends DorisStatementVisitor implem
     @Override
     public ASTNode visitWindowingClause(final WindowingClauseContext ctx) {
         WindowItemSegment result = new WindowItemSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
-        if (null != ctx.windowName) {
-            result.setWindowName((IdentifierValue) visit(ctx.windowName));
-        }
-        if (null != ctx.windowSpecification()) {
-            WindowItemSegment windowItemSegment = (WindowItemSegment) visit(ctx.windowSpecification());
-            result.setPartitionListSegments(windowItemSegment.getPartitionListSegments());
-            result.setOrderBySegment(windowItemSegment.getOrderBySegment());
-            result.setFrameClause(windowItemSegment.getFrameClause());
-        }
+        WindowItemSegment windowItemSegment = (WindowItemSegment) visit(ctx.windowSpecification());
+        result.setPartitionListSegments(windowItemSegment.getPartitionListSegments());
+        result.setOrderBySegment(windowItemSegment.getOrderBySegment());
+        result.setFrameClause(windowItemSegment.getFrameClause());
         return result;
     }
 }

--- a/test/it/parser/src/main/resources/case/dml/select-window.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-window.xml
@@ -474,31 +474,4 @@
         </from>
     </select>
 
-    <select sql-case-id="select_window_named_base_partition_doris">
-        <projections start-index="7" stop-index="60">
-            <aggregation-projection type="SUM" expression="SUM(sales) OVER (w PARTITION BY region)" alias="total_sales" start-index="7" stop-index="45">
-                <window-item start-index="18" stop-index="45">
-                    <window-name>w</window-name>
-                    <partition-by>
-                        <column name="region" start-index="39" stop-index="44" />
-                    </partition-by>
-                </window-item>
-                <parameter>
-                    <column name="sales" start-index="11" stop-index="15" />
-                </parameter>
-            </aggregation-projection>
-        </projections>
-        <from>
-            <simple-table name="orders" start-index="67" stop-index="72" />
-        </from>
-        <window start-index="74" stop-index="104">
-            <window-item start-index="81" stop-index="104">
-                <window-name>w</window-name>
-                <order-by start-index="87" stop-index="103">
-                    <column-item name="order_id" order-direction="ASC" start-index="96" stop-index="103" />
-                </order-by>
-            </window-item>
-        </window>
-    </select>
-
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -7307,34 +7307,6 @@
         </order-by>
     </select>
 
-    <select sql-case-id="select_window_named_partition_doris">
-        <projections start-index="7" stop-index="38" literal-start-index="7" literal-stop-index="38">
-            <aggregation-projection type="SUM" expression="SUM(sales) OVER w" alias="total_sales" start-index="7" stop-index="23" literal-start-index="7" literal-stop-index="23">
-                <window-item start-index="18" stop-index="23">
-                    <window-name>w</window-name>
-                </window-item>
-            </aggregation-projection>
-        </projections>
-        <from>
-            <simple-table name="orders" start-index="45" stop-index="50" literal-start-index="45" literal-stop-index="50" />
-        </from>
-        <window start-index="52" stop-index="102">
-            <window-item start-index="59" stop-index="102">
-                <window-name>w</window-name>
-                <partition-by>
-                    <expression-projection text="region" start-index="78" stop-index="83" literal-start-index="78" literal-stop-index="83">
-                        <expr>
-                            <column name="region" start-index="78" stop-index="83" literal-start-index="78" literal-stop-index="83" />
-                        </expr>
-                    </expression-projection>
-                </partition-by>
-                <order-by>
-                    <column-item name="order_id" order-direction="ASC" start-index="94" stop-index="101" literal-start-index="94" literal-stop-index="101" />
-                </order-by>
-            </window-item>
-        </window>
-    </select>
-
     <select sql-case-id="select_window_frame_lag_doris">
         <projections start-index="7" stop-index="124" literal-start-index="7" literal-stop-index="124">
             <expression-projection text="LAG(amount, 1, 0) OVER (PARTITION BY customer_id ORDER BY tx_time ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)" alias="lag_amt" start-index="7" stop-index="124" literal-start-index="7" literal-stop-index="124">

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-window.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-window.xml
@@ -18,7 +18,7 @@
 
 <sql-cases>
     <sql-case id="select_catalog_window_aggregation" value="select pg_catalog.max(ref_0.c36) over (partition by ref_0.c39 order by ref_0.vkey desc) as c_5 from t24 as ref_0" db-types="PostgreSQL,openGauss" />
-    <sql-case id="select_window" value="SELECT user_id, ROW_NUMBER() OVER w AS 'row_number', RANK() OVER w AS 'rank', DENSE_RANK() OVER w AS 'dense_rank' FROM t_order WHERE order_id = ? WINDOW w AS (ORDER BY user_id)" db-types="MySQL,Doris,Hive" />
+    <sql-case id="select_window" value="SELECT user_id, ROW_NUMBER() OVER w AS 'row_number', RANK() OVER w AS 'rank', DENSE_RANK() OVER w AS 'dense_rank' FROM t_order WHERE order_id = ? WINDOW w AS (ORDER BY user_id)" db-types="MySQL,Hive" />
     <sql-case id="select_window_partition_order_doris" value="SELECT ROW_NUMBER() OVER (PARTITION BY k ORDER BY v) FROM t_order" db-types="Doris,Hive" />
     <sql-case id="select_window_rank_doris" value="SELECT RANK() OVER (PARTITION BY k ORDER BY v) FROM t_order" db-types="Doris" />
     <sql-case id="select_window_lead_lag_doris" value="SELECT LEAD(v) OVER (PARTITION BY k ORDER BY v) FROM t_order" db-types="Doris" />
@@ -38,5 +38,4 @@
     <sql-case id="select_window_min_partition_mysql" value="SELECT MIN(order_id) OVER (PARTITION BY user_id) AS min_order_id FROM t_order" db-types="MySQL" />
     <sql-case id="select_window_max_partition_mysql" value="SELECT MAX(order_id) OVER (PARTITION BY user_id) AS max_order_id FROM t_order" db-types="MySQL" />
     <sql-case id="select_window_funnel_over_doris" value="SELECT WINDOW_FUNNEL(3600, 'default', v, k = 1) OVER (PARTITION BY k ORDER BY v) FROM t_order" db-types="Doris" />
-    <sql-case id="select_window_named_base_partition_doris" value="SELECT SUM(sales) OVER (w PARTITION BY region) AS total_sales FROM orders WINDOW w AS (ORDER BY order_id)" db-types="Doris" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -258,7 +258,6 @@
     <sql-case id="select_with_lead_and_lag_function" value="SELECT hire_date, LAG(hire_date, 1) OVER (ORDER BY hire_date) AS LAG1, LEAD(hire_date, 1) OVER (ORDER BY hire_date) AS LEAD1 FROM employees WHERE department_id = 30 ORDER BY hire_date;" db-types="Oracle,MySQL" />
     <sql-case id="select_with_connect_by_root" value="SELECT CONNECT_BY_ROOT last_name 'Manager' FROM employees CONNECT BY PRIOR employee_id = manager_id" db-types="Oracle" />
     <sql-case id="select_with_ntile_function" value="SELECT NTILE(4) OVER (ORDER BY salary DESC) AS quartile FROM employees WHERE department_id = 100 ORDER BY last_name" db-types="Oracle,MySQL,Doris" />
-    <sql-case id="select_window_named_partition_doris" value="SELECT SUM(sales) OVER w AS total_sales FROM orders WINDOW w AS (PARTITION BY region ORDER BY order_id)" db-types="Doris" />
     <sql-case id="select_window_frame_lag_doris" value="SELECT LAG(amount, 1, 0) OVER (PARTITION BY customer_id ORDER BY tx_time ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS lag_amt FROM payments" db-types="Doris" />
     <sql-case id="select_first_value_doris" value="SELECT FIRST_VALUE(price) OVER (ORDER BY created_at) AS first_price FROM product_prices" db-types="Doris" />
     <sql-case id="select_nth_value_doris" value="SELECT NTH_VALUE(score, 2) OVER (ORDER BY score) AS second_score FROM rankings" db-types="Doris" />

--- a/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
+++ b/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
@@ -31,6 +31,8 @@
     <sql-case id="unsupported_alter_database_set_transaction_quota_with_unit_for_doris" value="ALTER DATABASE example_db SET TRANSACTION QUOTA 1G" db-types="Doris" />
     <sql-case id="unsupported_create_table_with_char_varying_without_length_for_doris" value="CREATE TABLE t_varying (c CHAR VARYING)" db-types="Doris" />
     <sql-case id="unsupported_create_table_with_character_varying_without_length_for_doris" value="CREATE TABLE t_varying (c CHARACTER VARYING)" db-types="Doris" />
+    <sql-case id="unsupported_select_window_clause_for_doris" value="SELECT SUM(sales) OVER w FROM orders WINDOW w AS (PARTITION BY region ORDER BY order_id)" db-types="Doris" />
+    <sql-case id="unsupported_select_window_named_reference_for_doris" value="SELECT SUM(sales) OVER (w PARTITION BY region) FROM orders WINDOW w AS (ORDER BY order_id)" db-types="Doris" />
     <sql-case id="select_like" value="select conname, obj_description(oid, 'pg_constraint') as desc from pg_constraint where conname like 'at_partitioned%' order by conname" db-types="PostgreSQL" />
     <sql-case id="select_keyword" value="select relname,c.oid = oldoid as orig_oid,case relfilenode when 0 then 'none' when c.oid then 'own' when oldfilenode then 'orig' else 'OTHER' end as storage, obj_description(c.oid, 'pg_class') as desc from pg_class c left join old_oids using (relname) where relname like 'at_partitioned%' order by relname" db-types="PostgreSQL" />
     <sql-case id="unsupported_date_literal_for_clickhouse" value="SELECT DATE '2024-01-01'" db-types="ClickHouse" />


### PR DESCRIPTION
## Summary

Doris has no WINDOW clause and no named-window OVER reference, only inline `OVER (...)`. This was inherited unchanged from the MySQL-derived Doris dialect baseline and flagged as a follow-up in review on #39519.

- Removed the `identifier`/named-window alternatives from `overClause` and `windowingClause`, and removed `windowClause`/`windowItem` (`WINDOW w AS (...)`) from the Doris grammar.
- Removed the corresponding dead visitor code (`visitWindowClause`,`visitWindowItem`, window-name handling in `visitOverClause` /`visitWindowSpecification` / `visitWindowingClause`).
- Removed the two named-window test cases and their assertions, and dropped `Doris` from a shared MySQL/Doris/Hive case that relied on the same unsupported syntax.
- Added rejection coverage for named-window SQL under Doris.

## Test plan

- [x] `InternalDorisParserIT`: 1388/1388
- [x] `InternalUnsupportedDorisParserIT`: 16/16
- [x] Full `test/it/parser` module: 0 failures, 0 errors
- [x] `checkstyle:check` / `spotless:check` clean on touched modules