### PR TITLE
Add datasource-aware default schema resolver

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DefaultSchemaNameResolver.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DefaultSchemaNameResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.identifier;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierNormalizeEngine;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
+
+import javax.sql.DataSource;
+import java.util.function.Supplier;
+
+/**
+ * Default schema name resolver.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DefaultSchemaNameResolver {
+    
+    /**
+     * Resolve protocol default schema name.
+     *
+     * @param protocolType protocol type
+     * @param databaseName database name
+     * @return default schema name
+     */
+    public static String resolveProtocol(final DatabaseType protocolType, final String databaseName) {
+        return resolve(protocolType, databaseName, () -> IdentifierCasePolicyResolver.resolveProtocol(protocolType).getPolicy(IdentifierScope.SCHEMA));
+    }
+    
+    /**
+     * Resolve storage default schema name.
+     *
+     * @param storageType storage type
+     * @param dataSource data source
+     * @param databaseName database name
+     * @return default schema name
+     */
+    public static String resolveStorage(final DatabaseType storageType, final DataSource dataSource, final String databaseName) {
+        return resolve(storageType, databaseName, () -> IdentifierCasePolicyResolver.resolveStorage(storageType, dataSource).getPolicy(IdentifierScope.SCHEMA));
+    }
+    
+    private static String resolve(final DatabaseType databaseType, final String databaseName, final Supplier<IdentifierCasePolicy> identifierCasePolicySupplier) {
+        return new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getSchemaOption().getDefaultSchema()
+                .orElseGet(() -> IdentifierNormalizeEngine.normalize(identifierCasePolicySupplier.get(), databaseName));
+    }
+}

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DefaultSchemaNameResolverTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DefaultSchemaNameResolverTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.identifier;
+
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultSchemaNameResolverTest {
+    
+    @Test
+    void assertResolveProtocolWithFixedDefaultSchema() {
+        DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "PostgreSQL");
+        assertThat(DefaultSchemaNameResolver.resolveProtocol(databaseType, "foo_db"), is("public"));
+    }
+    
+    @Test
+    void assertResolveProtocolWithNormalizedDatabaseName() {
+        DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Oracle");
+        assertThat(DefaultSchemaNameResolver.resolveProtocol(databaseType, "foo_db"), is("FOO_DB"));
+    }
+    
+    @Test
+    void assertResolveStorageWithDataSourcePolicy() throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement("SELECT @@lower_case_table_names")).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getInt(1)).thenReturn(1);
+        DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
+        assertThat(DefaultSchemaNameResolver.resolveStorage(databaseType, dataSource, "Foo_DB"), is("foo_db"));
+    }
+}


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [ ] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
