### PR TITLE
Use case-insensitive table name matching in CREATE/ALTER MASK RULE executors

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,7 @@
 1. Metadata: Fix wrong logic table metadata when config same actual table name in different storage unit - [#39157](https://github.com/apache/shardingsphere/pull/39157)
 1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)
 1. DistSQL: Use case-insensitive table name matching in broadcast create and drop executors - [#39200](https://github.com/apache/shardingsphere/pull/39200)
+1. DistSQL: Use case-insensitive table name matching in `CREATE`/`ALTER MASK RULE` executors - [#39359](https://github.com/apache/shardingsphere/issues/39359)
 1. JDBC: Fix stale generated values leaking into prepared statement executeBatch calls without pending batches - [#38160](https://github.com/apache/shardingsphere/pull/38160)
 1. JDBC: Fix MySQL-compatible typed string conversion for `ResultSet#getObject(index, Class<T>)` - [#38444](https://github.com/apache/shardingsphere/pull/38444)
 1. Proxy: Resolve MySQL prepared statement parameter columns for where clause - [#38382](https://github.com/apache/shardingsphere/pull/38382)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,7 +36,7 @@
 1. Metadata: Fix wrong logic table metadata when config same actual table name in different storage unit - [#39157](https://github.com/apache/shardingsphere/pull/39157)
 1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)
 1. DistSQL: Use case-insensitive table name matching in broadcast create and drop executors - [#39200](https://github.com/apache/shardingsphere/pull/39200)
-1. DistSQL: Use case-insensitive table name matching in `CREATE`/`ALTER MASK RULE` executors - [#39359](https://github.com/apache/shardingsphere/issues/39359)
+1. DistSQL: Use case-insensitive table name matching in `CREATE`/`ALTER MASK RULE` executors - [#39660](https://github.com/apache/shardingsphere/pull/39660)
 1. JDBC: Fix stale generated values leaking into prepared statement executeBatch calls without pending batches - [#38160](https://github.com/apache/shardingsphere/pull/38160)
 1. JDBC: Fix MySQL-compatible typed string conversion for `ResultSet#getObject(index, Class<T>)` - [#38444](https://github.com/apache/shardingsphere/pull/38444)
 1. Proxy: Resolve MySQL prepared statement parameter columns for where clause - [#38382](https://github.com/apache/shardingsphere/pull/38382)

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mask.distsql.handler.update;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Setter;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.type.DatabaseRuleAlterExecutor;
 import org.apache.shardingsphere.distsql.handler.required.DistSQLExecutorCurrentRuleRequired;
@@ -55,7 +56,8 @@ public final class AlterMaskRuleExecutor implements DatabaseRuleAlterExecutor<Al
     }
     
     private void checkToBeAlteredRules(final AlterMaskRuleStatement sqlStatement) {
-        Collection<String> currentMaskTableNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toList());
+        Collection<String> currentMaskTableNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName)
+                .collect(Collectors.toCollection(CaseInsensitiveSet::new));
         Collection<String> notExistedMaskTableNames = getToBeAlteredMaskTableNames(sqlStatement).stream().filter(each -> !currentMaskTableNames.contains(each)).collect(Collectors.toList());
         ShardingSpherePreconditions.checkMustEmpty(notExistedMaskTableNames, () -> new MissingRequiredRuleException("Mask", database.getName(), notExistedMaskTableNames));
     }
@@ -71,7 +73,8 @@ public final class AlterMaskRuleExecutor implements DatabaseRuleAlterExecutor<Al
     
     @Override
     public MaskRuleConfiguration buildToBeDroppedRuleConfiguration(final MaskRuleConfiguration toBeAlteredRuleConfig) {
-        Collection<String> toBeAlteredTableNames = toBeAlteredRuleConfig.getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toList());
+        Collection<String> toBeAlteredTableNames = toBeAlteredRuleConfig.getTables().stream().map(MaskTableRuleConfiguration::getName)
+                .collect(Collectors.toCollection(CaseInsensitiveSet::new));
         Collection<MaskColumnRuleConfiguration> columns = rule.getConfiguration().getTables().stream().filter(each -> !toBeAlteredTableNames.contains(each.getName()))
                 .flatMap(each -> each.getColumns().stream()).collect(Collectors.toList());
         columns.addAll(toBeAlteredRuleConfig.getTables().stream().flatMap(each -> each.getColumns().stream()).collect(Collectors.toList()));

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mask.distsql.handler.update;
 
+import com.cedarsoftware.util.CaseInsensitiveMap;
 import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Setter;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.type.DatabaseRuleAlterExecutor;
@@ -36,6 +37,7 @@ import org.apache.shardingsphere.mask.rule.MaskRule;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -85,7 +87,20 @@ public final class AlterMaskRuleExecutor implements DatabaseRuleAlterExecutor<Al
                 toBeDroppedAlgorithms.put(each, rule.getConfiguration().getMaskAlgorithms().get(each));
             }
         }
-        return new MaskRuleConfiguration(Collections.emptyList(), toBeDroppedAlgorithms);
+        return new MaskRuleConfiguration(findStaleCaseChangedTables(toBeAlteredRuleConfig), toBeDroppedAlgorithms);
+    }
+    
+    private Collection<MaskTableRuleConfiguration> findStaleCaseChangedTables(final MaskRuleConfiguration toBeAlteredRuleConfig) {
+        Map<String, String> alteredTableNames = new CaseInsensitiveMap<>();
+        toBeAlteredRuleConfig.getTables().forEach(each -> alteredTableNames.put(each.getName(), each.getName()));
+        Collection<MaskTableRuleConfiguration> result = new LinkedList<>();
+        for (MaskTableRuleConfiguration each : rule.getConfiguration().getTables()) {
+            String alteredName = alteredTableNames.get(each.getName());
+            if (null != alteredName && !alteredName.equals(each.getName())) {
+                result.add(new MaskTableRuleConfiguration(each.getName(), Collections.emptyList()));
+            }
+        }
+        return result;
     }
     
     @Override

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutor.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mask.distsql.handler.update;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Setter;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.type.DatabaseRuleCreateExecutor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
@@ -59,7 +60,8 @@ public final class CreateMaskRuleExecutor implements DatabaseRuleCreateExecutor<
     
     private void checkDuplicatedRuleNames(final CreateMaskRuleStatement sqlStatement) {
         if (null != rule) {
-            Collection<String> currentRuleNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName).collect(Collectors.toList());
+            Collection<String> currentRuleNames = rule.getConfiguration().getTables().stream().map(MaskTableRuleConfiguration::getName)
+                    .collect(Collectors.toCollection(CaseInsensitiveSet::new));
             Collection<String> duplicatedRuleNames = sqlStatement.getRules().stream().map(MaskRuleSegment::getTableName).filter(currentRuleNames::contains).collect(Collectors.toList());
             ShardingSpherePreconditions.checkMustEmpty(duplicatedRuleNames, () -> new DuplicateRuleException("mask", database.getName(), duplicatedRuleNames));
         }

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
@@ -110,6 +110,22 @@ class AlterMaskRuleExecutorTest {
     }
     
     @Test
+    void assertBuildToBeDroppedRuleConfigurationWithCaseInsensitiveTableName() {
+        Map<String, AlgorithmConfiguration> currentAlgorithms = new LinkedHashMap<>(3, 1F);
+        currentAlgorithms.put("order_mask", new AlgorithmConfiguration("MD5", new Properties()));
+        currentAlgorithms.put("user_mask", new AlgorithmConfiguration("MD5", new Properties()));
+        currentAlgorithms.put("unused_mask", new AlgorithmConfiguration("SM3", new Properties()));
+        executor.setRule(createRule(new MaskRuleConfiguration(Arrays.asList(
+                new MaskTableRuleConfiguration("t_order", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "order_mask"))),
+                new MaskTableRuleConfiguration("t_user", Collections.singleton(new MaskColumnRuleConfiguration("user_id", "user_mask")))), currentAlgorithms)));
+        MaskTableRuleConfiguration toBeAlteredTable = new MaskTableRuleConfiguration("T_ORDER", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "order_mask")));
+        MaskRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(new MaskRuleConfiguration(Collections.singleton(toBeAlteredTable), Collections.emptyMap()));
+        assertTrue(actual.getTables().isEmpty());
+        assertThat(actual.getMaskAlgorithms().size(), is(1));
+        assertTrue(actual.getMaskAlgorithms().containsKey("unused_mask"));
+    }
+
+    @Test
     void assertGetRuleClass() {
         assertThat(executor.getRuleClass(), is(MaskRule.class));
     }
@@ -122,7 +138,9 @@ class AlterMaskRuleExecutorTest {
                         createCurrentRuleConfiguration(Collections.singleton("t_order")), MissingRequiredRuleException.class),
                 Arguments.of("one table exists and one missing",
                         new AlterMaskRuleStatement(Arrays.asList(createRuleSegment("t_order", "order_id", "MD5"), createRuleSegment("t_missing", "user_id", "AES"))),
-                        createCurrentRuleConfiguration(Collections.singleton("t_order")), MissingRequiredRuleException.class));
+                        createCurrentRuleConfiguration(Collections.singleton("t_order")), MissingRequiredRuleException.class),
+                Arguments.of("case-insensitive table match", new AlterMaskRuleStatement(Collections.singleton(createRuleSegment("T_ORDER", "order_id", "MD5"))),
+                        createCurrentRuleConfiguration(Collections.singleton("t_order")), null));
     }
     
     private static MaskRuleSegment createRuleSegment(final String tableName, final String columnName, final String algorithmType) {

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
@@ -110,19 +110,21 @@ class AlterMaskRuleExecutorTest {
     }
     
     @Test
-    void assertBuildToBeDroppedRuleConfigurationWithCaseInsensitiveTableName() {
+    void assertBuildToBeDroppedRuleConfigurationWithCaseChangedTableName() {
         Map<String, AlgorithmConfiguration> currentAlgorithms = new LinkedHashMap<>(3, 1F);
-        currentAlgorithms.put("order_mask", new AlgorithmConfiguration("MD5", new Properties()));
+        currentAlgorithms.put("old_order_mask", new AlgorithmConfiguration("MD5", new Properties()));
         currentAlgorithms.put("user_mask", new AlgorithmConfiguration("MD5", new Properties()));
         currentAlgorithms.put("unused_mask", new AlgorithmConfiguration("SM3", new Properties()));
         executor.setRule(createRule(new MaskRuleConfiguration(Arrays.asList(
-                new MaskTableRuleConfiguration("t_order", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "order_mask"))),
+                new MaskTableRuleConfiguration("t_order", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "old_order_mask"))),
                 new MaskTableRuleConfiguration("t_user", Collections.singleton(new MaskColumnRuleConfiguration("user_id", "user_mask")))), currentAlgorithms)));
-        MaskTableRuleConfiguration toBeAlteredTable = new MaskTableRuleConfiguration("T_ORDER", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "order_mask")));
+        MaskTableRuleConfiguration toBeAlteredTable = new MaskTableRuleConfiguration("T_ORDER", Collections.singleton(new MaskColumnRuleConfiguration("order_id", "new_order_mask")));
         MaskRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(new MaskRuleConfiguration(Collections.singleton(toBeAlteredTable), Collections.emptyMap()));
-        assertTrue(actual.getTables().isEmpty());
-        assertThat(actual.getMaskAlgorithms().size(), is(1));
+        assertThat(actual.getTables().size(), is(1));
+        assertThat(actual.getTables().iterator().next().getName(), is("t_order"));
+        assertThat(actual.getMaskAlgorithms().size(), is(2));
         assertTrue(actual.getMaskAlgorithms().containsKey("unused_mask"));
+        assertTrue(actual.getMaskAlgorithms().containsKey("old_order_mask"));
     }
     
     @Test

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/AlterMaskRuleExecutorTest.java
@@ -124,7 +124,7 @@ class AlterMaskRuleExecutorTest {
         assertThat(actual.getMaskAlgorithms().size(), is(1));
         assertTrue(actual.getMaskAlgorithms().containsKey("unused_mask"));
     }
-
+    
     @Test
     void assertGetRuleClass() {
         assertThat(executor.getRuleClass(), is(MaskRule.class));

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutorTest.java
@@ -59,6 +59,14 @@ class CreateMaskRuleExecutorTest {
     }
     
     @Test
+    void assertExecuteUpdateWithCaseInsensitiveDuplicateMaskRule() {
+        MaskRule rule = mock(MaskRule.class);
+        when(rule.getConfiguration()).thenReturn(getCurrentRuleConfiguration());
+        CreateMaskRuleStatement sqlStatement = createDuplicatedSQLStatement(false, "MD5", "T_MASK", "T_ORDER");
+        assertThrows(DuplicateRuleException.class, () -> new DistSQLUpdateExecuteEngine(sqlStatement, "foo_db", mockContextManager(rule), null).executeUpdate());
+    }
+
+    @Test
     void assertExecuteUpdateWithoutIfNotExists() throws SQLException {
         MaskRuleConfiguration currentRuleConfig = getCurrentRuleConfiguration();
         CreateMaskRuleStatement sqlStatement = createSQLStatement(false, "MD5");
@@ -94,10 +102,14 @@ class CreateMaskRuleExecutorTest {
     }
     
     private CreateMaskRuleStatement createDuplicatedSQLStatement(final boolean ifNotExists, final String algorithmType) {
+        return createDuplicatedSQLStatement(ifNotExists, algorithmType, "t_mask", "t_order");
+    }
+
+    private CreateMaskRuleStatement createDuplicatedSQLStatement(final boolean ifNotExists, final String algorithmType, final String maskTableName, final String orderTableName) {
         MaskColumnSegment tMaskColumnSegment = new MaskColumnSegment("user_id", new AlgorithmSegment(algorithmType, new Properties()));
         MaskColumnSegment tOrderColumnSegment = new MaskColumnSegment("order_id", new AlgorithmSegment(algorithmType, new Properties()));
-        MaskRuleSegment tMaskRuleSegment = new MaskRuleSegment("t_mask", Collections.singleton(tMaskColumnSegment));
-        MaskRuleSegment tOrderRuleSegment = new MaskRuleSegment("t_order", Collections.singleton(tOrderColumnSegment));
+        MaskRuleSegment tMaskRuleSegment = new MaskRuleSegment(maskTableName, Collections.singleton(tMaskColumnSegment));
+        MaskRuleSegment tOrderRuleSegment = new MaskRuleSegment(orderTableName, Collections.singleton(tOrderColumnSegment));
         Collection<MaskRuleSegment> rules = new LinkedList<>();
         rules.add(tMaskRuleSegment);
         rules.add(tOrderRuleSegment);

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleExecutorTest.java
@@ -65,7 +65,7 @@ class CreateMaskRuleExecutorTest {
         CreateMaskRuleStatement sqlStatement = createDuplicatedSQLStatement(false, "MD5", "T_MASK", "T_ORDER");
         assertThrows(DuplicateRuleException.class, () -> new DistSQLUpdateExecuteEngine(sqlStatement, "foo_db", mockContextManager(rule), null).executeUpdate());
     }
-
+    
     @Test
     void assertExecuteUpdateWithoutIfNotExists() throws SQLException {
         MaskRuleConfiguration currentRuleConfig = getCurrentRuleConfiguration();
@@ -104,7 +104,7 @@ class CreateMaskRuleExecutorTest {
     private CreateMaskRuleStatement createDuplicatedSQLStatement(final boolean ifNotExists, final String algorithmType) {
         return createDuplicatedSQLStatement(ifNotExists, algorithmType, "t_mask", "t_order");
     }
-
+    
     private CreateMaskRuleStatement createDuplicatedSQLStatement(final boolean ifNotExists, final String algorithmType, final String maskTableName, final String orderTableName) {
         MaskColumnSegment tMaskColumnSegment = new MaskColumnSegment("user_id", new AlgorithmSegment(algorithmType, new Properties()));
         MaskColumnSegment tOrderColumnSegment = new MaskColumnSegment("order_id", new AlgorithmSegment(algorithmType, new Properties()));


### PR DESCRIPTION
Fixes #39359.

Changes proposed in this pull request:
 - `CreateMaskRuleExecutor.checkDuplicatedRuleNames()`: copy current table names into a `CaseInsensitiveSet` instead of `Collectors.toList()`, so `CREATE MASK RULE T_ORDER` over an existing `t_order` now raises `DuplicateRuleException` instead of storing a duplicate.
 - `AlterMaskRuleExecutor.checkToBeAlteredRules()`: same fix, so `ALTER MASK RULE T_ORDER` no longer fails with `MissingRequiredRuleException` when only `t_order` exists.
 - `AlterMaskRuleExecutor.buildToBeDroppedRuleConfiguration()`: same fix for the `toBeAlteredTableNames` comparison, so a case-differing ALTER no longer leaves the old table's algorithm incorrectly counted as still in use.
 - Matches the existing `CaseInsensitiveSet` pattern already used in `DropMaskRuleExecutor` and applied to the sibling broadcast rule type in #39200.
 - Added case-insensitive unit test coverage to both executor test classes.

This pull request was drafted with assistance from Claude Code (Anthropic). Affected scope: the three executor methods above and their corresponding unit tests in `CreateMaskRuleExecutorTest`/`AlterMaskRuleExecutorTest`. I reviewed and verified all changes myself.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)