### PR TITLE
Upgrade Spotless Maven Plugin to 3.10.1

### DIFF
--- a/.github/workflows/required-check.yml
+++ b/.github/workflows/required-check.yml
@@ -57,6 +57,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6.0.1
+      - uses: actions/setup-java@v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
       - name: Run Spotless
         run: ./mvnw spotless:check -Pcheck -T1C
 

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
         
         <!-- Check plugin versions -->
         <apache-rat-plugin.version>0.15</apache-rat-plugin.version>
-        <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
+        <spotless-maven-plugin.version>3.10.1</spotless-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <checkstyle.version>14.0.0</checkstyle.version>
         <maven-pmd-plugin.version>3.20.0</maven-pmd-plugin.version>
@@ -1323,6 +1323,7 @@
                             <configuration>
                                 <java>
                                     <eclipse>
+                                        <version>4.35</version>
                                         <!--suppress MavenModelInspection -->
                                         <file>${maven.multiModuleProjectDirectory}/src/resources/spotless/java.xml</file>
                                     </eclipse>


### PR DESCRIPTION
- Run required Spotless checks with JDK 21
- Pin Eclipse JDT 4.35 to preserve formatting output
