### PR TITLE
Reuse loaded schema keys during generic schema translation

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilder.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilder.java
@@ -71,9 +71,10 @@ public final class GenericSchemaBuilder {
      * @throws SQLException SQL exception
      */
     public static Map<String, ShardingSphereSchema> build(final Collection<String> tableNames, final DatabaseType protocolType, final GenericSchemaBuilderMaterial material) throws SQLException {
-        Map<String, SchemaMetaData> result = loadSchemas(tableNames, protocolType, material);
+        Collection<MetaDataLoaderMaterial> loaderMaterials = SchemaMetaDataUtils.getMetaDataLoaderMaterials(tableNames, protocolType, material);
+        Map<String, SchemaMetaData> result = loadSchemas(loaderMaterials);
         if (!isSchemaCompatible(protocolType, material.getStorageUnits())) {
-            result = translate(result, protocolType, material);
+            result = translate(result, protocolType, material, loaderMaterials);
         }
         return revise(result, material, protocolType);
     }
@@ -86,9 +87,7 @@ public final class GenericSchemaBuilder {
         return result;
     }
     
-    private static Map<String, SchemaMetaData> loadSchemas(final Collection<String> tableNames, final DatabaseType protocolType,
-                                                           final GenericSchemaBuilderMaterial material) throws SQLException {
-        Collection<MetaDataLoaderMaterial> materials = SchemaMetaDataUtils.getMetaDataLoaderMaterials(tableNames, protocolType, material);
+    private static Map<String, SchemaMetaData> loadSchemas(final Collection<MetaDataLoaderMaterial> materials) throws SQLException {
         return materials.isEmpty() ? Collections.emptyMap() : MetaDataLoader.load(materials);
     }
     
@@ -106,12 +105,11 @@ public final class GenericSchemaBuilder {
                 .map(each -> each.getSchemaOption().isSchemaAvailable()).orElse(false);
     }
     
-    private static Map<String, SchemaMetaData> translate(final Map<String, SchemaMetaData> schemaMetaDataMap, final DatabaseType protocolType, final GenericSchemaBuilderMaterial material) {
+    private static Map<String, SchemaMetaData> translate(final Map<String, SchemaMetaData> schemaMetaDataMap, final DatabaseType protocolType, final GenericSchemaBuilderMaterial material,
+                                                         final Collection<MetaDataLoaderMaterial> loaderMaterials) {
         Collection<TableMetaData> tableMetaDataList = new LinkedList<>();
-        for (StorageUnit each : material.getStorageUnits().values()) {
-            DatabaseTypeRegistry databaseTypeRegistry = new DatabaseTypeRegistry(each.getStorageType());
-            String defaultSchemaName = databaseTypeRegistry.getDefaultSchemaName(material.getDefaultSchemaName());
-            tableMetaDataList.addAll(Optional.ofNullable(schemaMetaDataMap.get(defaultSchemaName)).map(SchemaMetaData::getTables).orElseGet(Collections::emptyList));
+        for (String each : loaderMaterials.stream().map(MetaDataLoaderMaterial::getDefaultSchemaName).distinct().collect(Collectors.toList())) {
+            tableMetaDataList.addAll(Optional.ofNullable(schemaMetaDataMap.get(each)).map(SchemaMetaData::getTables).orElseGet(Collections::emptyList));
         }
         String frontendSchemaName = new DatabaseTypeRegistry(protocolType).getDefaultSchemaName(material.getDefaultSchemaName());
         return Collections.singletonMap(frontendSchemaName, new SchemaMetaData(frontendSchemaName, tableMetaDataList));

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.metadata.database.schema.builder;
 
 import org.apache.shardingsphere.database.connector.core.metadata.data.loader.MetaDataLoader;
+import org.apache.shardingsphere.database.connector.core.metadata.data.loader.MetaDataLoaderMaterial;
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.SchemaMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.TableMetaData;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -41,6 +42,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -63,6 +68,8 @@ import static org.mockito.Mockito.when;
 @MockitoSettings(strictness = Strictness.LENIENT)
 @StaticMockSettings(MetaDataLoader.class)
 class GenericSchemaBuilderTest {
+    
+    private static final DatabaseType H2_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "H2");
     
     private static final DatabaseType MYSQL_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "MySQL");
     
@@ -152,9 +159,27 @@ class GenericSchemaBuilderTest {
     
     @Test
     void assertBuildTranslatesSchemaWhenStorageSchemaUnavailable() throws SQLException {
-        when(MetaDataLoader.load(any())).thenReturn(Collections.singletonMap("PUBLIC", createSchemaMetaData("PUBLIC", "foo_tbl")));
+        mockLoadedSchemaWithMaterialDefault("foo_tbl");
         Map<String, ShardingSphereSchema> actual =
                 GenericSchemaBuilder.build(Collections.singleton("foo_tbl"), POSTGRESQL_DATABASE_TYPE, createMaterial(ORACLE_DATABASE_TYPE, "public"));
+        assertThat(actual.size(), is(1));
+        assertSchemaTable(actual, "public", "foo_tbl");
+    }
+    
+    @Test
+    void assertBuildTranslatesSchemaWithStorageDataSourcePolicy() throws SQLException {
+        mockLoadedSchemaWithMaterialDefault("foo_tbl");
+        Map<String, ShardingSphereSchema> actual = GenericSchemaBuilder.build(Collections.singleton("foo_tbl"), POSTGRESQL_DATABASE_TYPE,
+                createMaterial(MYSQL_DATABASE_TYPE, "Foo_DB", mockMySQLDataSource(1)));
+        assertThat(actual.size(), is(1));
+        assertSchemaTable(actual, "public", "foo_tbl");
+    }
+    
+    @Test
+    void assertBuildTranslatesSchemaWithHiddenStorageSchema() throws SQLException {
+        mockLoadedSchemaWithMaterialDefault("foo_tbl");
+        Map<String, ShardingSphereSchema> actual = GenericSchemaBuilder.build(
+                Collections.singleton("foo_tbl"), POSTGRESQL_DATABASE_TYPE, createMaterial(H2_DATABASE_TYPE, "Foo_DB"));
         assertThat(actual.size(), is(1));
         assertSchemaTable(actual, "public", "foo_tbl");
     }
@@ -166,13 +191,38 @@ class GenericSchemaBuilderTest {
     }
     
     private GenericSchemaBuilderMaterial createMaterial(final DatabaseType storageType, final String defaultSchemaName) {
+        return createMaterial(storageType, defaultSchemaName, new MockedDataSource());
+    }
+    
+    private GenericSchemaBuilderMaterial createMaterial(final DatabaseType storageType, final String defaultSchemaName, final DataSource dataSource) {
         ShardingSphereRule rule = mock(ShardingSphereRule.class);
         when(rule.getAttributes()).thenReturn(new RuleAttributes(mock(TableMapperRuleAttribute.class)));
         StorageUnit storageUnit = mock(StorageUnit.class);
         when(storageUnit.getStorageType()).thenReturn(storageType);
-        when(storageUnit.getDataSource()).thenReturn(new MockedDataSource());
+        when(storageUnit.getDataSource()).thenReturn(dataSource);
         return new GenericSchemaBuilderMaterial(Collections.singletonMap("foo_schema", storageUnit), Collections.singleton(rule), new ConfigurationProperties(new Properties()),
                 defaultSchemaName, DatabaseIdentifierContextFactory.createDefault());
+    }
+    
+    private static DataSource mockMySQLDataSource(final int lowerCaseTableNames) throws SQLException {
+        DataSource result = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(result.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement("SELECT @@lower_case_table_names")).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getInt(1)).thenReturn(lowerCaseTableNames);
+        return result;
+    }
+    
+    private void mockLoadedSchemaWithMaterialDefault(final String tableName) throws SQLException {
+        when(MetaDataLoader.load(any())).thenAnswer(invocation -> {
+            Collection<MetaDataLoaderMaterial> loaderMaterials = invocation.getArgument(0);
+            String defaultSchemaName = loaderMaterials.iterator().next().getDefaultSchemaName();
+            return Collections.singletonMap(defaultSchemaName, createSchemaMetaData(defaultSchemaName, tableName));
+        });
     }
     
     private SchemaMetaData createSchemaMetaData(final String schemaName, final String tableName) {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [ ] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
