### PR TITLE
Decode MySQL TIME2 binlog values outside the LocalTime range

### DIFF
--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValue.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValue.java
@@ -26,6 +26,7 @@ import java.time.LocalTime;
 
 /**
  * TIME2 type value of MySQL binlog protocol.
+ * The 3-byte value is the packed time offset by 0x800000, so it is signed: MySQL TIME ranges from -838:59:59 to 838:59:59.
  * Stored as 3-byte value The number of decimals for the fractional part is stored in the table metadata as a one byte value.
  * The number of bytes that follow the 3 byte time value can be calculated with the following formula: (decimals + 1) / 2
  *
@@ -37,16 +38,37 @@ import java.time.LocalTime;
  */
 public final class MySQLTime2BinlogProtocolValue implements MySQLBinlogProtocolValue {
     
+    private static final int INT_OFFSET = 0x800000;
+    
     @Override
     public Serializable read(final MySQLBinlogColumnDef columnDef, final MySQLPacketPayload payload) {
-        int time = payload.getByteBuf().readUnsignedMedium();
+        int packedTime = payload.getByteBuf().readUnsignedMedium() - INT_OFFSET;
         MySQLFractionalSeconds fractionalSeconds = new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload);
-        if (0x800000 == time) {
+        if (0 == packedTime) {
             return MySQLTimeValueUtils.ZERO_OF_TIME;
         }
-        int hour = (time >> 12) % (1 << 10);
-        int minute = (time >> 6) % (1 << 6);
-        int second = time % (1 << 6);
-        return LocalTime.of(hour, minute, second).withNano(fractionalSeconds.getNanos());
+        int magnitude = Math.abs(packedTime);
+        int hour = (magnitude >> 12) % (1 << 10);
+        int minute = (magnitude >> 6) % (1 << 6);
+        int second = magnitude % (1 << 6);
+        return packedTime > 0 && hour < 24
+                ? LocalTime.of(hour, minute, second).withNano(fractionalSeconds.getNanos())
+                : formatOutOfLocalTimeRange(packedTime < 0, hour, minute, second, fractionalSeconds.getNanos());
+    }
+    
+    /**
+     * Formats a value that {@link LocalTime} cannot hold, which is any negative time and any time from 24:00:00 up to the MySQL maximum of 838:59:59.
+     * The text form matches what {@link MySQLTimeBinlogProtocolValue} returns for every value and what {@link MySQLTimeValueUtils#ZERO_OF_TIME} returns from this same method.
+     *
+     * @param negative whether the time is negative
+     * @param hour hour
+     * @param minute minute
+     * @param second second
+     * @param nanos nanoseconds, always a whole number of microseconds
+     * @return time in MySQL text form
+     */
+    private String formatOutOfLocalTimeRange(final boolean negative, final int hour, final int minute, final int second, final int nanos) {
+        String result = String.format("%s%02d:%02d:%02d", negative ? "-" : "", hour, minute, second);
+        return 0 == nanos ? result : result + String.format(".%06d", nanos / 1000);
     }
 }

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValueTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValueTest.java
@@ -92,6 +92,35 @@ class MySQLTime2BinlogProtocolValueTest {
     }
     
     @Test
+    void assertReadHourBeyondLocalTimeRange() {
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readUnsignedMedium()).thenReturn(0x800000 | (100 << 12) | (8 << 6) | 4);
+        assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is("100:08:04"));
+    }
+    
+    @Test
+    void assertReadMaxHour() {
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readUnsignedMedium()).thenReturn(0x800000 | (838 << 12) | (59 << 6) | 59);
+        assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is("838:59:59"));
+    }
+    
+    @Test
+    void assertReadNegativeTime() {
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readUnsignedMedium()).thenReturn(0x1000000 - (0x800000 | (16 << 12) | (8 << 6) | 4));
+        assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is("-16:08:04"));
+    }
+    
+    @Test
+    void assertReadNegativeTimeWithFraction() {
+        columnDef.setColumnMeta(6);
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readUnsignedMedium()).thenReturn(0x1000000 - (0x800000 | (16 << 12) | (8 << 6) | 4), 10123);
+        assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is("-16:08:04.010123"));
+    }
+    
+    @Test
     void assertReadNullTimeWithFraction() {
         columnDef.setColumnMeta(4);
         when(payload.getByteBuf()).thenReturn(byteBuf);


### PR DESCRIPTION
Changes proposed in this pull request:

  - Subtract the `0x800000` offset before unpacking a TIME2 value, so the sign survives, and return MySQL text form for the range `LocalTime` cannot hold.

`MySQLTime2BinlogProtocolValue` unpacks the 3-byte payload and hands the hour straight to `LocalTime.of`:

```java
int time = payload.getByteBuf().readUnsignedMedium();
...
int hour = (time >> 12) % (1 << 10);
return LocalTime.of(hour, minute, second).withNano(fractionalSeconds.getNanos());
```

MySQL `TIME` is a signed duration, not a time of day: its range is `-838:59:59` to `838:59:59`. The payload is the packed value offset by `0x800000` — the same sign bit `MySQLDatetime2BinlogProtocolValue` masks off with `datetime & (0x8000000000L - 1L)`, except that for `TIME` it carries information. Two consequences, both on values MySQL accepts in an ordinary column:

| column value | payload | current result |
|---|---|---|
| `16:08:04` | `0x810204` | `LocalTime` 16:08:04 |
| `24:00:00` | `0x818000` | `DateTimeException: Invalid value for HourOfDay (valid values 0 - 23): 24` |
| `100:08:04` | `0x864204` | `DateTimeException: ... 100` |
| `838:59:59` | `0xB46EFB` | `DateTimeException: ... 838` |
| `-16:08:04` | `0x7EFDFC` | `DateTimeException: ... 1007` |

The exception propagates out of `MySQLBinlogRowsEventPacket`, so a single such row stops the binlog stream for the whole migration or CDC job rather than affecting one column.

Those payloads are what a live server writes, not a derivation. Against `mysql:8.0.46` started with `--log-bin --binlog-format=ROW`, a `TIME` column accepts `100:08:04` and `-16:08:04`, and the resulting `binlog.000001` carries them as `86 42 04` and `7e fd fc` — the offset encoding above, negative value included.

The negative row also shows the second half of the problem: without the offset the sign bit is folded away by `% (1 << 10)`, which is why the hour comes out as 1007 rather than 16. Even if `LocalTime` accepted it, the value would be wrong.

Subtracting the offset first gives the signed packed value, from which the sign and the magnitude both fall out. `LocalTime` is kept for everything it can represent, so nothing that works today changes; the rest is returned as `[-]HH:mm:ss[.ffffff]`, which is what this same method already returns for zero (`MySQLTimeValueUtils.ZERO_OF_TIME`) and what `MySQLTimeBinlogProtocolValue` returns for every value of the pre-5.6.4 `TIME` type. On the CDC path a `String` reaches `ColumnValueConvertUtils` and comes out a `StringValue`, exactly as the zero value does today.

### Tests

Four cases added to `MySQLTime2BinlogProtocolValueTest`, using the payload encoding the existing tests already assert (`0x800000 | hour << 12 | minute << 6 | second`):

- `assertReadHourBeyondLocalTimeRange` — `100:08:04`
- `assertReadMaxHour` — `838:59:59`, the MySQL maximum
- `assertReadNegativeTime` — `-16:08:04`
- `assertReadNegativeTimeWithFraction` — `-16:08:04.010123`, so the fraction is not dropped on the new path

On `master` all four fail, each with the `DateTimeException` above; the six existing tests pass unchanged there and here, which is what pins that in-range decoding is untouched.

`mvn test -pl database/protocol/dialect/mysql` — 446 tests, and `-pl kernel/data-pipeline/dialect/mysql` — 97 tests, all passing. `checkstyle:check -Pcheck` clean.

The pre-5.6.4 `MySQLTimeBinlogProtocolValue` reads its payload unsigned as well, so negative values of that type decode wrong too. It produces a wrong string rather than an exception, and I did not want to assert the old format's on-disk sign convention without the same level of evidence, so it is left alone here.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)