### PR TITLE
Decode MySQL binlog dates that have a zero month or a zero day

### DIFF
--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDateBinlogProtocolValue.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDateBinlogProtocolValue.java
@@ -39,6 +39,11 @@ public final class MySQLDateBinlogProtocolValue implements MySQLBinlogProtocolVa
         int year = date / 16 / 32;
         int month = date / 32 % 16;
         int day = date % 32;
-        return 0 == date ? MySQLTimeValueUtils.ZERO_OF_DATE : Date.valueOf(LocalDate.of(year, month, day));
+        if (0 == date) {
+            return MySQLTimeValueUtils.ZERO_OF_DATE;
+        }
+        return MySQLTimeValueUtils.isCompleteDate(month, day)
+                ? Date.valueOf(LocalDate.of(year, month, day))
+                : MySQLTimeValueUtils.formatIncompleteDate(year, month, day);
     }
 }

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetime2BinlogProtocolValue.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetime2BinlogProtocolValue.java
@@ -68,7 +68,9 @@ public final class MySQLDatetime2BinlogProtocolValue implements MySQLBinlogProto
         int minute = (int) ((time >> 6) % (1L << 6L));
         int second = (int) (time % (1L << 6L));
         MySQLFractionalSeconds fractionalSeconds = new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload);
-        return Timestamp.valueOf(LocalDateTime.of(year, month, day, hour, minute, second, fractionalSeconds.getNanos()));
+        return MySQLTimeValueUtils.isCompleteDate(month, day)
+                ? Timestamp.valueOf(LocalDateTime.of(year, month, day, hour, minute, second, fractionalSeconds.getNanos()))
+                : MySQLTimeValueUtils.formatIncompleteDatetime(year, month, day, hour, minute, second, fractionalSeconds.getNanos());
     }
     
     private void skipFractionalSeconds(final MySQLBinlogColumnDef columnDef, final MySQLPacketPayload payload) {

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetimeBinlogProtocolValue.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetimeBinlogProtocolValue.java
@@ -24,7 +24,6 @@ import org.apache.shardingsphere.database.protocol.mysql.payload.MySQLPacketPayl
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.util.Date;
 
 /**
  * MySQL DATETIME binlog protocol value.
@@ -40,7 +39,7 @@ public final class MySQLDatetimeBinlogProtocolValue implements MySQLBinlogProtoc
         return 0L == datetime ? MySQLTimeValueUtils.DATETIME_OF_ZERO : readDateTime(datetime);
     }
     
-    private Date readDateTime(final long datetime) {
+    private Serializable readDateTime(final long datetime) {
         int date = (int) (datetime / 1000000L);
         int year = date / 10000;
         int month = (date % 10000) / 100;
@@ -49,6 +48,8 @@ public final class MySQLDatetimeBinlogProtocolValue implements MySQLBinlogProtoc
         int hour = time / 10000;
         int minute = (time % 10000) / 100;
         int second = time % 100;
-        return Timestamp.valueOf(LocalDateTime.of(year, month, day, hour, minute, second));
+        return MySQLTimeValueUtils.isCompleteDate(month, day)
+                ? Timestamp.valueOf(LocalDateTime.of(year, month, day, hour, minute, second))
+                : MySQLTimeValueUtils.formatIncompleteDatetime(year, month, day, hour, minute, second, 0);
     }
 }

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimeValueUtils.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimeValueUtils.java
@@ -33,4 +33,45 @@ public final class MySQLTimeValueUtils {
     public static final String YEAR_OF_ZERO = "0000";
     
     public static final String DATETIME_OF_ZERO = "0000-00-00 00:00:00";
+    
+    /**
+     * Judge whether a date has both a month and a day, which is what {@link java.time.LocalDate} requires.
+     * MySQL stores a zero month or a zero day whenever NO_ZERO_IN_DATE is not in sql_mode.
+     *
+     * @param month month
+     * @param day day
+     * @return whether the date is complete
+     */
+    public static boolean isCompleteDate(final int month, final int day) {
+        return month > 0 && day > 0;
+    }
+    
+    /**
+     * Format a date that {@link java.time.LocalDate} cannot hold, in the text form MySQL prints it in.
+     *
+     * @param year year
+     * @param month month
+     * @param day day
+     * @return date in MySQL text form
+     */
+    public static String formatIncompleteDate(final int year, final int month, final int day) {
+        return String.format("%04d-%02d-%02d", year, month, day);
+    }
+    
+    /**
+     * Format a datetime whose date part {@link java.time.LocalDate} cannot hold, in the text form MySQL prints it in.
+     *
+     * @param year year
+     * @param month month
+     * @param day day
+     * @param hour hour
+     * @param minute minute
+     * @param second second
+     * @param nanos nanoseconds, always a whole number of microseconds
+     * @return datetime in MySQL text form
+     */
+    public static String formatIncompleteDatetime(final int year, final int month, final int day, final int hour, final int minute, final int second, final int nanos) {
+        String result = String.format("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
+        return 0 == nanos ? result : result + String.format(".%06d", nanos / 1000);
+    }
 }

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDateBinlogProtocolValueTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDateBinlogProtocolValueTest.java
@@ -53,6 +53,20 @@ class MySQLDateBinlogProtocolValueTest {
     }
     
     @Test
+    void assertReadDateWithZeroMonth() {
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readUnsignedMediumLE()).thenReturn(2023 * 16 * 32 + 15);
+        assertThat(new MySQLDateBinlogProtocolValue().read(columnDef, payload), is("2023-00-15"));
+    }
+    
+    @Test
+    void assertReadDateWithZeroDay() {
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readUnsignedMediumLE()).thenReturn(2023 * 16 * 32 + 5 * 32);
+        assertThat(new MySQLDateBinlogProtocolValue().read(columnDef, payload), is("2023-05-00"));
+    }
+    
+    @Test
     void assertReadNullDate() {
         when(payload.getByteBuf()).thenReturn(byteBuf);
         when(byteBuf.readUnsignedMediumLE()).thenReturn(0);

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetime2BinlogProtocolValueTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetime2BinlogProtocolValueTest.java
@@ -85,6 +85,18 @@ class MySQLDatetime2BinlogProtocolValueTest {
     }
     
     @Test
+    void assertReadWithZeroMonth() {
+        when(payload.readInt1()).thenReturn(0x99, 0xae, 0xde, 0xa0, 0x00);
+        assertThat(protocolValue.read(columnDef, payload), is("2023-00-15 10:00:00"));
+    }
+    
+    @Test
+    void assertReadWithZeroDay() {
+        when(payload.readInt1()).thenReturn(0x99, 0xb0, 0x00, 0xa0, 0x00);
+        assertThat(protocolValue.read(columnDef, payload), is("2023-05-00 10:00:00"));
+    }
+    
+    @Test
     void assertReadWithZeroDatetime() {
         assertThat(protocolValue.read(columnDef, payload), is(MySQLTimeValueUtils.DATETIME_OF_ZERO));
     }

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetimeBinlogProtocolValueTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetimeBinlogProtocolValueTest.java
@@ -41,6 +41,18 @@ class MySQLDatetimeBinlogProtocolValueTest {
     private MySQLBinlogColumnDef columnDef;
     
     @Test
+    void assertReadDatetimeWithZeroMonth() {
+        when(payload.readInt8()).thenReturn(20230015100000L);
+        assertThat(new MySQLDatetimeBinlogProtocolValue().read(columnDef, payload), is("2023-00-15 10:00:00"));
+    }
+    
+    @Test
+    void assertReadDatetimeWithZeroDay() {
+        when(payload.readInt8()).thenReturn(20230500100000L);
+        assertThat(new MySQLDatetimeBinlogProtocolValue().read(columnDef, payload), is("2023-05-00 10:00:00"));
+    }
+    
+    @Test
     void assertRead() {
         when(payload.readInt8()).thenReturn(99991231235959L);
         LocalDateTime expected = LocalDateTime.of(9999, 12, 31, 23, 59, 59);


### PR DESCRIPTION
Changes proposed in this pull request:

  - Return MySQL text form from the `DATE`, `DATETIME` and `DATETIME2` binlog decoders when the date has a zero month or a zero day, instead of handing it to `LocalDate`.

MySQL stores a date with a zero month or a zero day whenever `NO_ZERO_IN_DATE` is not in `sql_mode`. Verified against a real server:

```
$ docker run -d mysql:8.0 --log-bin=binlog --binlog-format=ROW --sql-mode=''
$ mysql> INSERT INTO t_date VALUES (1, '2023-00-15', '2023-00-15 10:00:00'),
                                   (2, '2023-05-00', '2023-05-00 10:00:00'),
                                   (3, '2023-05-15', '2023-05-15 10:00:00');
$ mysql> SELECT id, d, dt FROM t_date;
+----+------------+---------------------+
| id | d          | dt                  |
+----+------------+---------------------+
|  1 | 2023-00-15 | 2023-00-15 10:00:00 |
|  2 | 2023-05-00 | 2023-05-00 10:00:00 |
|  3 | 2023-05-15 | 2023-05-15 10:00:00 |
+----+------------+---------------------+
```

Reading the resulting `binlog.000001` back, the row events carry those dates in the ordinary packed encodings — `0f ce 0f` and `a0 ce 0f` for the two `DATE` values, `99 ae de a0 00` and `99 b0 00 a0 00` for the two `DATETIME2` values. Running the decoders' own arithmetic over exactly those bytes:

| column value | payload | current result |
|---|---|---|
| `DATE` `2023-05-15` | `af ce 0f` | `java.sql.Date` 2023-05-15 |
| `DATE` `2023-00-15` | `0f ce 0f` | `DateTimeException: Invalid value for MonthOfYear (valid values 1 - 12): 0` |
| `DATE` `2023-05-00` | `a0 ce 0f` | `DateTimeException: Invalid value for DayOfMonth (valid values 1 - 28/31): 0` |
| `DATETIME2` `2023-00-15 10:00:00` | `99 ae de a0 00` | `DateTimeException: ... MonthOfYear ...: 0` |
| `DATETIME2` `2023-05-00 10:00:00` | `99 b0 00 a0 00` | `DateTimeException: ... DayOfMonth ...: 0` |

The exception propagates out of `MySQLBinlogRowsEventPacket`, so one such row stops the binlog stream for the whole migration or CDC job rather than affecting one column.

Each of these decoders already returns text for the *all*-zero date — `MySQLTimeValueUtils.ZERO_OF_DATE` and `DATETIME_OF_ZERO` — which needs exactly the same relaxed `sql_mode` to exist in a table at all. So the partially zero case is returned the same way, and the `java.sql` types are kept for every date they can hold, leaving anything that works today unchanged. On the CDC path a `String` reaches `ColumnValueConvertUtils` and comes out a `StringValue`, as the zero value already does.

The pre-5.6.4 `MySQLDatetimeBinlogProtocolValue` unpacks a plain decimal `YYYYMMDDHHMMSS`, so its zero-month and zero-day paths reach `LocalDateTime.of` the same way; it is fixed alongside, although a modern server writes `DATETIME2` and I could not produce a live payload for it.

### Tests

Six cases added, two per decoder, using the payloads above:

- `MySQLDateBinlogProtocolValueTest` — `assertReadDateWithZeroMonth`, `assertReadDateWithZeroDay`
- `MySQLDatetimeBinlogProtocolValueTest` — `assertReadDatetimeWithZeroMonth`, `assertReadDatetimeWithZeroDay`
- `MySQLDatetime2BinlogProtocolValueTest` — `assertReadWithZeroMonth`, `assertReadWithZeroDay`

On `master` all six fail with the `DateTimeException` above; the existing cases in those three classes pass unchanged there and here, which pins that complete dates are untouched.

`mvn test -pl database/protocol/dialect/mysql` — 448 tests, and `-pl kernel/data-pipeline/dialect/mysql` — 97 tests, all passing. `checkstyle:check -Pcheck` clean.

Related to #39674, which fixes the same shape of failure in the `TIME2` decoder. The two do not overlap and can be reviewed in either order.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
