### PR TITLE
Use storage-aware schema keys for configured single tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
@@ -69,10 +69,10 @@ public final class DataNode {
      * @param dataNode data node use {@code .} to split schema name and table name
      */
     public DataNode(final String databaseName, final DatabaseType databaseType, final String dataNode) {
-        this(new DatabaseTypeRegistry(databaseType), databaseName, dataNode);
+        this(databaseName, new DatabaseTypeRegistry(databaseType), dataNode);
     }
     
-    private DataNode(final DatabaseTypeRegistry registry, final String databaseName, final String dataNode) {
+    private DataNode(final String databaseName, final DatabaseTypeRegistry registry, final String dataNode) {
         this(registry.getDefaultSchemaName(databaseName), registry.getDialectDatabaseMetaData().getSchemaOption(), dataNode);
     }
     
@@ -89,12 +89,12 @@ public final class DataNode {
     /**
      * Create a data node with resolved default schema name.
      *
-     * @param databaseType database type
      * @param defaultSchemaName resolved default schema name
+     * @param databaseType database type
      * @param dataNode data node use {@code .} to split schema name and table name
      * @return created data node
      */
-    public static DataNode createWithDefaultSchemaName(final DatabaseType databaseType, final String defaultSchemaName, final String dataNode) {
+    public static DataNode createWithDefaultSchemaName(final String defaultSchemaName, final DatabaseType databaseType, final String dataNode) {
         return new DataNode(defaultSchemaName, new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getSchemaOption(), dataNode);
     }
     

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
@@ -69,16 +69,33 @@ public final class DataNode {
      * @param dataNode data node use {@code .} to split schema name and table name
      */
     public DataNode(final String databaseName, final DatabaseType databaseType, final String dataNode) {
+        this(new DatabaseTypeRegistry(databaseType), databaseName, dataNode);
+    }
+    
+    private DataNode(final DatabaseTypeRegistry registry, final String databaseName, final String dataNode) {
+        this(registry.getDefaultSchemaName(databaseName), registry.getDialectDatabaseMetaData().getSchemaOption(), dataNode);
+    }
+    
+    private DataNode(final String defaultSchemaName, final DialectSchemaOption schemaOption, final String dataNode) {
         ShardingSpherePreconditions.checkState(dataNode.contains(DELIMITER), () -> new InvalidDataNodeFormatException(dataNode));
-        DatabaseTypeRegistry registry = new DatabaseTypeRegistry(databaseType);
-        DialectSchemaOption schemaOption = registry.getDialectDatabaseMetaData().getSchemaOption();
         boolean canContainSchema = schemaOption.isSchemaAvailable() && !hasInvalidDelimiterStructure(dataNode);
         List<String> segments = canContainSchema ? Splitter.on(DELIMITER).splitToList(dataNode) : Splitter.on(DELIMITER).limit(2).splitToList(dataNode);
         boolean containsSchema = canContainSchema && 3 == segments.size() && areSegmentsValid(segments);
-        String defaultSchemaName = registry.getDefaultSchemaName(databaseName);
         dataSourceName = segments.get(0);
         schemaName = getSchemaName(schemaOption, containsSchema, segments, defaultSchemaName);
         tableName = getTableName(dataNode, containsSchema, segments);
+    }
+    
+    /**
+     * Create a data node with resolved default schema name.
+     *
+     * @param databaseType database type
+     * @param defaultSchemaName resolved default schema name
+     * @param dataNode data node use {@code .} to split schema name and table name
+     * @return created data node
+     */
+    public static DataNode createWithDefaultSchemaName(final DatabaseType databaseType, final String defaultSchemaName, final String dataNode) {
+        return new DataNode(defaultSchemaName, new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getSchemaOption(), dataNode);
     }
     
     private String getSchemaName(final DialectSchemaOption schemaOption, final boolean containsSchema, final List<String> segments, final String defaultSchemaName) {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
@@ -82,6 +82,22 @@ class DataNodeTest {
     }
     
     @ParameterizedTest(name = "{0}")
+    @MethodSource("resolvedDefaultSchemaDataNodeArguments")
+    void assertCreateWithDefaultSchemaName(final String name, final String defaultSchemaName, final DatabaseType databaseType, final String dataNodeText,
+                                           final String expectedSchemaName, final String expectedTableName) {
+        DataNode actual = DataNode.createWithDefaultSchemaName(databaseType, defaultSchemaName, dataNodeText);
+        assertThat(actual.getDataSourceName(), is("ds"));
+        assertThat(actual.getSchemaName(), is(expectedSchemaName));
+        assertThat(actual.getTableName(), is(expectedTableName));
+    }
+    
+    @Test
+    void assertCreateWithDefaultSchemaNameWithInvalidFormat() {
+        assertThrows(InvalidDataNodeFormatException.class,
+                () -> DataNode.createWithDefaultSchemaName(POSTGRESQL_DATABASE_TYPE, "public", "invalid_format_without_delimiter"));
+    }
+    
+    @ParameterizedTest(name = "{0}")
     @MethodSource("formatArguments")
     void assertFormat(final String name, final DataNode dataNode, final String expectedText) {
         assertThat(dataNode.format(), is(expectedText));
@@ -153,6 +169,14 @@ class DataNodeTest {
                 Arguments.of("mysql_three_segments_kept_as_table_suffix", "test_db", MYSQL_DATABASE_TYPE, "ds.schema.tbl", "ds", "test_db", "schema.tbl"),
                 Arguments.of("postgresql_preserves_table_case", "test_db", POSTGRESQL_DATABASE_TYPE, "ds.schema.TABLE", "ds", "schema", "TABLE"),
                 Arguments.of("oracle_normalizes_database_schema", "logic_db", ORACLE_DATABASE_TYPE, "ds.tbl", "ds", "LOGIC_DB", "tbl"));
+    }
+    
+    private static Stream<Arguments> resolvedDefaultSchemaDataNodeArguments() {
+        return Stream.of(
+                Arguments.of("oracle_preserves_resolved_schema", "storage_schema", ORACLE_DATABASE_TYPE, "ds.tbl", "storage_schema", "tbl"),
+                Arguments.of("postgresql_explicit_schema", "ignored", POSTGRESQL_DATABASE_TYPE, "ds.schema.tbl", "schema", "tbl"),
+                Arguments.of("postgresql_all_schemas", "ignored", POSTGRESQL_DATABASE_TYPE, "ds.tbl", "*", "tbl"),
+                Arguments.of("mysql_dotted_table_suffix", "storage_schema", MYSQL_DATABASE_TYPE, "ds.schema.tbl", "storage_schema", "schema.tbl"));
     }
     
     private static Stream<Arguments> formatArguments() {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
@@ -85,7 +85,7 @@ class DataNodeTest {
     @MethodSource("resolvedDefaultSchemaDataNodeArguments")
     void assertCreateWithDefaultSchemaName(final String name, final String defaultSchemaName, final DatabaseType databaseType, final String dataNodeText,
                                            final String expectedSchemaName, final String expectedTableName) {
-        DataNode actual = DataNode.createWithDefaultSchemaName(databaseType, defaultSchemaName, dataNodeText);
+        DataNode actual = DataNode.createWithDefaultSchemaName(defaultSchemaName, databaseType, dataNodeText);
         assertThat(actual.getDataSourceName(), is("ds"));
         assertThat(actual.getSchemaName(), is(expectedSchemaName));
         assertThat(actual.getTableName(), is(expectedTableName));
@@ -94,7 +94,7 @@ class DataNodeTest {
     @Test
     void assertCreateWithDefaultSchemaNameWithInvalidFormat() {
         assertThrows(InvalidDataNodeFormatException.class,
-                () -> DataNode.createWithDefaultSchemaName(POSTGRESQL_DATABASE_TYPE, "public", "invalid_format_without_delimiter"));
+                () -> DataNode.createWithDefaultSchemaName("public", POSTGRESQL_DATABASE_TYPE, "invalid_format_without_delimiter"));
     }
     
     @ParameterizedTest(name = "{0}")

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -22,6 +22,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.database.connector.core.metadata.data.loader.type.SchemaMetaDataLoader;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.DefaultSchemaNameResolver;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.DatabaseTypeEngine;
 import org.apache.shardingsphere.infra.datanode.DataNode;
@@ -81,7 +82,7 @@ public final class SingleTableDataNodeLoader {
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
         Map<String, DatabaseType> validStorageTypes = validDataSources.entrySet().stream().collect(Collectors.toMap(Entry::getKey, each -> DatabaseTypeEngine.getStorageType(each.getValue())));
         Map<String, Collection<DataNode>> actualDataNodes = load(databaseName, validDataSources, includedTables, excludedTables, validStorageTypes);
-        Map<String, Map<String, Collection<String>>> configuredTableMap = getConfiguredTableMap(databaseName, protocolType, splitTables, validStorageTypes);
+        Map<String, Map<String, Collection<String>>> configuredTableMap = getConfiguredTableMap(databaseName, protocolType, splitTables, validDataSources, validStorageTypes);
         Map<String, Collection<DataNode>> result = loadSpecifiedDataNodes(actualDataNodes, featureRequiredSingleTables, configuredTableMap);
         warnIfSingleTableLoadedFromMultipleDataSources(databaseName, result);
         return result;
@@ -216,15 +217,14 @@ public final class SingleTableDataNodeLoader {
     }
     
     private static Map<String, Map<String, Collection<String>>> getConfiguredTableMap(final String databaseName, final DatabaseType protocolType, final Collection<String> configuredTables,
-                                                                                      final Map<String, DatabaseType> validStorageTypes) {
+                                                                                      final Map<String, DataSource> validDataSources, final Map<String, DatabaseType> validStorageTypes) {
         if (configuredTables.isEmpty()) {
             return Collections.emptyMap();
         }
         Map<String, Map<String, Collection<String>>> result = new LinkedHashMap<>(configuredTables.size(), 1F);
+        Map<String, String> defaultSchemaNames = getDefaultSchemaNames(databaseName, validDataSources, validStorageTypes);
         for (String each : configuredTables) {
-            DataNode parsedDataNode = new DataNode(each);
-            DatabaseType databaseType = validStorageTypes.getOrDefault(parsedDataNode.getDataSourceName(), protocolType);
-            DataNode dataNode = new DataNode(databaseName, databaseType, each);
+            DataNode dataNode = getConfiguredDataNode(databaseName, protocolType, validStorageTypes, defaultSchemaNames, each);
             Map<String, Collection<String>> schemaTables = result.getOrDefault(dataNode.getDataSourceName(), new LinkedHashMap<>());
             Collection<String> tables = schemaTables.computeIfAbsent(dataNode.getSchemaName(),
                     ignored -> SingleTableConstants.ASTERISK.equals(dataNode.getSchemaName()) ? new CaseInsensitiveSet<>() : new LinkedHashSet<>());
@@ -232,6 +232,23 @@ public final class SingleTableDataNodeLoader {
             result.putIfAbsent(dataNode.getDataSourceName(), schemaTables);
         }
         return result;
+    }
+    
+    private static Map<String, String> getDefaultSchemaNames(final String databaseName, final Map<String, DataSource> dataSources, final Map<String, DatabaseType> storageTypes) {
+        Map<String, String> result = new LinkedHashMap<>(dataSources.size(), 1F);
+        for (Entry<String, DataSource> entry : dataSources.entrySet()) {
+            DatabaseType storageType = storageTypes.get(entry.getKey());
+            result.put(entry.getKey(), DefaultSchemaNameResolver.resolveStorage(storageType, entry.getValue(), databaseName));
+        }
+        return result;
+    }
+    
+    private static DataNode getConfiguredDataNode(final String databaseName, final DatabaseType protocolType, final Map<String, DatabaseType> storageTypes,
+                                                  final Map<String, String> defaultSchemaNames, final String dataNode) {
+        String dataSourceName = new DataNode(dataNode).getDataSourceName();
+        return defaultSchemaNames.containsKey(dataSourceName)
+                ? DataNode.createWithDefaultSchemaName(storageTypes.get(dataSourceName), defaultSchemaNames.get(dataSourceName), dataNode)
+                : new DataNode(databaseName, protocolType, dataNode);
     }
     
     /**

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -247,7 +247,7 @@ public final class SingleTableDataNodeLoader {
                                                   final Map<String, String> defaultSchemaNames, final String dataNode) {
         String dataSourceName = new DataNode(dataNode).getDataSourceName();
         return defaultSchemaNames.containsKey(dataSourceName)
-                ? DataNode.createWithDefaultSchemaName(storageTypes.get(dataSourceName), defaultSchemaNames.get(dataSourceName), dataNode)
+                ? DataNode.createWithDefaultSchemaName(defaultSchemaNames.get(dataSourceName), storageTypes.get(dataSourceName), dataNode)
                 : new DataNode(databaseName, protocolType, dataNode);
     }
     

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.single.datanode;
 import ch.qos.logback.classic.Level;
 import org.apache.shardingsphere.database.connector.core.metadata.data.loader.type.SchemaMetaDataLoader;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.DefaultSchemaNameResolver;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.database.DatabaseTypeEngine;
@@ -292,6 +293,20 @@ class SingleTableDataNodeLoaderTest {
             Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load(
                     "foo_db", protocolDatabaseType, localDataSourceMap, Collections.emptyList(), Collections.singleton("foo_ds.foo_tbl1"));
             assertTrue(actual.containsKey("foo_tbl1"));
+            assertThat(actual.get("foo_tbl1"), is(Collections.singletonList(new DataNode("foo_ds", "foo_db", "foo_tbl1"))));
+        }
+    }
+    
+    @Test
+    void assertLoadWithStorageSchemaCasePolicy() throws SQLException {
+        Map<String, DataSource> localDataSourceMap = Collections.singletonMap("foo_ds", mockDataSource("foo_ds", Collections.singletonList("foo_tbl1")));
+        try (
+                MockedStatic<DatabaseTypeEngine> databaseTypeEngine = mockStatic(DatabaseTypeEngine.class);
+                MockedStatic<DefaultSchemaNameResolver> defaultSchemaNameResolver = mockStatic(DefaultSchemaNameResolver.class)) {
+            databaseTypeEngine.when(() -> DatabaseTypeEngine.getStorageType(localDataSourceMap.get("foo_ds"))).thenReturn(storageDatabaseType);
+            defaultSchemaNameResolver.when(() -> DefaultSchemaNameResolver.resolveStorage(storageDatabaseType, localDataSourceMap.get("foo_ds"), "Foo_DB")).thenReturn("foo_db");
+            Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load(
+                    "Foo_DB", protocolDatabaseType, localDataSourceMap, Collections.emptyList(), Collections.singleton("foo_ds.foo_tbl1"));
             assertThat(actual.get("foo_tbl1"), is(Collections.singletonList(new DataNode("foo_ds", "foo_db", "foo_tbl1"))));
         }
     }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [ ] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
