### PR TITLE
Fix Spotless check failures introduced by #39675

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/yaml/data/swapper/YamlRowStatisticsSwapperTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/yaml/data/swapper/YamlRowStatisticsSwapperTest.java
@@ -30,10 +30,10 @@ import java.sql.Types;
 import java.util.Collections;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class YamlRowStatisticsSwapperTest {
     

--- a/infra/rewrite/dialect/mysql/src/test/java/org/apache/shardingsphere/infra/rewrite/mysql/MySQLToBeRemovedSegmentsProviderTest.java
+++ b/infra/rewrite/dialect/mysql/src/test/java/org/apache/shardingsphere/infra/rewrite/mysql/MySQLToBeRemovedSegmentsProviderTest.java
@@ -32,9 +32,9 @@ import org.apache.shardingsphere.sql.parser.statement.mysql.dal.show.table.MySQL
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.show.table.MySQLShowTablesStatement;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class MySQLToBeRemovedSegmentsProviderTest {

--- a/infra/spi/src/test/java/org/apache/shardingsphere/infra/spi/type/ordered/OrderedSPILoaderTest.java
+++ b/infra/spi/src/test/java/org/apache/shardingsphere/infra/spi/type/ordered/OrderedSPILoaderTest.java
@@ -35,13 +35,13 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("rawtypes")
 class OrderedSPILoaderTest {

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/execute/PipelineExecuteEngineTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/execute/PipelineExecuteEngineTest.java
@@ -41,9 +41,9 @@ import static org.mockito.Mockito.verify;
 class PipelineExecuteEngineTest {
     
     private static final long FUTURE_TIMEOUT_SECONDS = 30L;
-
+    
     private static final Duration ASSERTION_TIMEOUT = Duration.ofSeconds(FUTURE_TIMEOUT_SECONDS + 1L);
-
+    
     @Test
     void assertSubmitWithoutExecuteCallback() {
         PipelineLifecycleRunnable pipelineLifecycleRunnable = mock(PipelineLifecycleRunnable.class);

--- a/kernel/sql-federation/executor/src/test/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/memory/MemoryTableStatisticsBuilderTest.java
+++ b/kernel/sql-federation/executor/src/test/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/enumerator/memory/MemoryTableStatisticsBuilderTest.java
@@ -39,10 +39,10 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/model/MCPMetadataSnapshotTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/model/MCPMetadataSnapshotTest.java
@@ -23,9 +23,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MCPMetadataSnapshotTest {
     

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/AlterSchemaPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/AlterSchemaPushDownMetaDataRefresherTest.java
@@ -32,9 +32,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class AlterSchemaPushDownMetaDataRefresherTest {
     

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/CreateSchemaPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/CreateSchemaPushDownMetaDataRefresherTest.java
@@ -31,9 +31,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class CreateSchemaPushDownMetaDataRefresherTest {
     

--- a/mode/node/src/test/java/org/apache/shardingsphere/mode/node/rule/tuple/YamlRuleConfigurationReflectionEngineTest.java
+++ b/mode/node/src/test/java/org/apache/shardingsphere/mode/node/rule/tuple/YamlRuleConfigurationReflectionEngineTest.java
@@ -35,10 +35,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/MySQLServerPreparedStatementTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/MySQLServerPreparedStatementTest.java
@@ -36,12 +36,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryBinaryParameterExtractorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryBinaryParameterExtractorTest.java
@@ -25,9 +25,9 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.SQLException;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MySQLComQueryBinaryParameterExtractorTest {
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/TestShardingService.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/TestShardingService.java
@@ -35,10 +35,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Getter


### PR DESCRIPTION
Changes proposed in this pull request:

  - Reorder the static imports in the twelve test files that Spotless rejects after #39675, so `spotless:check` passes on master again.

`master` is currently red on **Check - Spotless**, which runs `./mvnw spotless:check -Pcheck -T1C`. On a clean checkout of `48730d8` with no other changes:

```
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:3.10.1:check
        on project shardingsphere-infra-spi: The following files had format violations:
[ERROR]     src/test/java/org/apache/shardingsphere/infra/spi/type/ordered/OrderedSPILoaderTest.java
[ERROR]         -import·static·org.junit.jupiter.api.Assertions.assertTrue;
[ERROR]          import·static·org.hamcrest.MatcherAssert.assertThat;
```

All twelve files were touched by #39675, and the Spotless sort order and the new Checkstyle rule want the same thing — this just finishes the reordering in the files where the two static-import blocks ended up out of order.

Twelve, not one: `spotless:check` stops at the first failing module, and `-fae` does not help either, because the modules that depend on a failed one are skipped rather than checked. The count only settles by re-running until the reactor comes back clean, which took seven rounds:

| round | modules still failing |
|---|---|
| 1 | infra-spi |
| 2 | infra-common |
| 3 | mcp-support, mode-node |
| 4 | infra-rewrite-dialect-mysql, mode-core |
| 5 | sql-federation-executor |
| 6 | data-pipeline-core |
| 7 | proxy-frontend-dialect-mysql, test-native → then clean |

The diff is `spotless:apply` output and nothing else. Every changed line is an `import static` line, apart from two blank lines inside a class body in `PipelineExecuteEngineTest` that pick up the four-space indentation used throughout the codebase.

### Verification

- `./mvnw spotless:check -Pcheck -T1C -fae` — clean across the whole reactor.
- `./mvnw checkstyle:check -Pcheck -T1C -fae` — clean across the whole reactor, so the new rule from #39675 and Spotless agree on this ordering rather than pulling against each other.
- `mvn test -pl :shardingsphere-infra-spi` — 29 tests, passing.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
