### PR TITLE
Fix excldue typo in apache-rat exclude patterns

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -198,7 +198,7 @@
                         <exclude>**/.github/**</exclude>
                         <!-- document files -->
                         <exclude>**/*.md</exclude>
-                        <excldue>**/*.MD</excldue>
+                        <exclude>**/*.MD</exclude>
                         <exclude>**/*.txt</exclude>
                         <exclude>**/docs/**</exclude>
                     </excludes>


### PR DESCRIPTION
## What
Fixed `<excldue>` → `<exclude>` in the apache-rat plugin config.

Maven silently ignores unknown tags, so `**/*.MD` (and any other patterns under the misspelled tag) were never excluded from license checks.

## Why
Same class of bug as apache/shenyu#7028 / related rat typo reports. Small, safe pom-only fix.

## Test
Diff-only change to POM exclude tags; no runtime behavior change.