### PR TITLE
Bump org.postgresql:postgresql from 42.7.8 to 42.7.13

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -146,6 +146,7 @@
 1. Fix CVE-2023-39017 [#38039](https://github.com/apache/shardingsphere/pull/38039)
 1. Fix CVE-2024-22399, CVE-2021-32824, CVE-2025-5222, CVE-2016-1000027 [#38040](https://github.com/apache/shardingsphere/pull/38040)
 1. Fix CVE-2023-2976, CVE-2024-29131, CVE-2025-27821 [#38042](https://github.com/apache/shardingsphere/pull/38042)
+1. Fix CVE-2026-42198, CVE-2026-54291
 
 ### Metadata Storage Changes
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,10 @@
 
 1. MCP: Add standalone ShardingSphere-MCP Server - [#38541](https://github.com/apache/shardingsphere/pull/38541)
 
+### CVE
+
+1. Fix CVE-2026-42198, CVE-2026-54291 [#39724](https://github.com/apache/shardingsphere/pull/39724)
+
 ### Bug Fixes
 
 1. Infra: Avoid retaining transient multi-object lookup keys in `OrderedSPILoader` - [#38980](https://github.com/apache/shardingsphere/pull/38980)
@@ -146,7 +150,6 @@
 1. Fix CVE-2023-39017 [#38039](https://github.com/apache/shardingsphere/pull/38039)
 1. Fix CVE-2024-22399, CVE-2021-32824, CVE-2025-5222, CVE-2016-1000027 [#38040](https://github.com/apache/shardingsphere/pull/38040)
 1. Fix CVE-2023-2976, CVE-2024-29131, CVE-2025-27821 [#38042](https://github.com/apache/shardingsphere/pull/38042)
-1. Fix CVE-2026-42198, CVE-2026-54291
 
 ### Metadata Storage Changes
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <jsr305.version>3.0.2</jsr305.version>
         <immutables.version>2.10.1</immutables.version>
         
-        <postgresql.version>42.7.8</postgresql.version>
+        <postgresql.version>42.7.13</postgresql.version>
         <mysql-connector-java.version>8.4.0</mysql-connector-java.version>
         <mssql.version>12.10.2.jre8</mssql.version>
         <h2.version>2.2.224</h2.version>


### PR DESCRIPTION
Fixes CVE-2026-42198 (GHSA-98qh-xjc8-98pq, Dependabot alert #127) and CVE-2026-54291 (GHSA-j92g-9f8w-j867, Dependabot alert #129).
