### PR TITLE
Refine stale Javadoc in shadow SPI

### DIFF
--- a/features/shadow/api/src/main/java/org/apache/shardingsphere/shadow/spi/ShadowOperationType.java
+++ b/features/shadow/api/src/main/java/org/apache/shardingsphere/shadow/spi/ShadowOperationType.java
@@ -35,7 +35,7 @@ public enum ShadowOperationType {
     DELETE,
     
     /**
-     * The shadow operation is update.
+     * Update shadow operation.
      */
     UPDATE,
     

--- a/features/shadow/api/src/main/java/org/apache/shardingsphere/shadow/spi/hint/HintShadowAlgorithm.java
+++ b/features/shadow/api/src/main/java/org/apache/shardingsphere/shadow/spi/hint/HintShadowAlgorithm.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.shadow.spi.ShadowAlgorithm;
 import java.util.Collection;
 
 /**
- * Precise hint of shadow in SQL comment.
+ * Hint shadow algorithm.
  *
  * @param <T> class type of hint value
  */


### PR DESCRIPTION

No issue: Javadoc-only fix.

Changes proposed in this pull request:
  - `HintShadowAlgorithm` describes itself as "Precise hint of shadow in SQL comment.", which is the Javadoc of the value object `PreciseHintShadowValue` in the same package, not of the algorithm interface.
  - The bulk rename in #13520 copied that sentence onto the interface, replacing the correct algorithm description while renaming `NoteShadowAlgorithm` to `HintShadowAlgorithm`.
  - This renames the class description to "Hint shadow algorithm.", matching `ShadowAlgorithm` ("Shadow algorithm."), `ColumnShadowAlgorithm` ("Column shadow algorithm.") and the implementation `SQLHintShadowAlgorithm` ("SQL hint shadow algorithm.").
  - `ShadowOperationType.UPDATE` still carries the old sentence form "The shadow operation is update.", while `INSERT`, `DELETE`, `SELECT` and `HINT_MATCH` use the noun form.
  - The normalization in #31205 updated those four constants and skipped `UPDATE`; this changes it to "Update shadow operation." so all five read consistently.
  - Javadoc text only: no signature, abstract method, enum constant or runtime behavior is touched.

AI assistance: Claude Code was used to draft this Javadoc correction in `features/shadow/api`. I reviewed, verified, and take responsibility for every line submitted.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`. I ran the module-scoped equivalent instead: `./mvnw spotless:apply`, `checkstyle:check`, `apache-rat:check` and `install -pl features/shadow/api -am -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`, all passing, with `ShadowOperationTypeTest` green.
- [ ] I have made corresponding changes to the documentation. This change is itself Javadoc; no user documentation refers to these sentences.
- [ ] I have added corresponding unit tests for my changes. Javadoc-only change, no behavior change, no test added.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/) Skipped: typo/docs-only change with no behavior or API impact.
- [x] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
