### PR TITLE
Apply default shadow algorithm when swapping YAML shadow rule

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -87,6 +87,7 @@
 1. SQL Federation: Fix SQL Federation pagination binding for long LIMIT parameters - [#39237](https://github.com/apache/shardingsphere/pull/39237)
 1. Broadcast: Fix case-sensitive table name lookup in broadcast data node rule attribute - [#39153](https://github.com/apache/shardingsphere/pull/39153)
 1. Encrypt: Fix stale encryptors leaking when altering an encrypt rule - [#39209](https://github.com/apache/shardingsphere/pull/39209)
+1. Shadow: Apply default shadow algorithm to shadow tables when swapping YAML rule configuration - [#39749](https://github.com/apache/shardingsphere/pull/39749)
 
 ### Enhancements
 

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/yaml/swapper/YamlShadowRuleConfigurationSwapper.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/yaml/swapper/YamlShadowRuleConfigurationSwapper.java
@@ -81,9 +81,9 @@ public final class YamlShadowRuleConfigurationSwapper implements YamlRuleConfigu
         result.setDataSources(swapToDataSources(yamlConfig.getDataSources()));
         result.setTables(swapToShadowTables(yamlConfig.getTables()));
         result.setShadowAlgorithms(swapToShadowAlgorithms(yamlConfig.getShadowAlgorithms()));
+        result.setDefaultShadowAlgorithmName(yamlConfig.getDefaultShadowAlgorithmName());
         setTableDefaultShadowDataSource(result.getTables(), result.getDataSources());
         setTableDefaultShadowAlgorithm(result.getTables(), result.getDefaultShadowAlgorithmName());
-        result.setDefaultShadowAlgorithmName(yamlConfig.getDefaultShadowAlgorithmName());
         return result;
     }
     

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/yaml/swapper/YamlShadowRuleConfigurationSwapperTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/yaml/swapper/YamlShadowRuleConfigurationSwapperTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.shadow.yaml.swapper;
+
+import org.apache.shardingsphere.shadow.config.ShadowRuleConfiguration;
+import org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration;
+import org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class YamlShadowRuleConfigurationSwapperTest {
+    
+    private final YamlShadowRuleConfigurationSwapper swapper = new YamlShadowRuleConfigurationSwapper();
+    
+    @Test
+    void assertSwapToObjectWithDefaultShadowAlgorithmName() {
+        YamlShadowRuleConfiguration yamlConfig = createYamlRuleConfiguration(Collections.emptyList());
+        yamlConfig.setDefaultShadowAlgorithmName("foo_algo");
+        ShadowRuleConfiguration actual = swapper.swapToObject(yamlConfig);
+        assertThat(actual.getDefaultShadowAlgorithmName(), is("foo_algo"));
+        assertThat(actual.getTables().get("foo_tbl").getShadowAlgorithmNames(), is(Collections.singletonList("foo_algo")));
+    }
+    
+    @Test
+    void assertSwapToObjectWithoutDefaultShadowAlgorithmName() {
+        ShadowRuleConfiguration actual = swapper.swapToObject(createYamlRuleConfiguration(Collections.emptyList()));
+        assertThat(actual.getTables().get("foo_tbl").getShadowAlgorithmNames(), is(Collections.emptyList()));
+    }
+    
+    @Test
+    void assertSwapToObjectWithTableShadowAlgorithmNames() {
+        YamlShadowRuleConfiguration yamlConfig = createYamlRuleConfiguration(Collections.singletonList("bar_algo"));
+        yamlConfig.setDefaultShadowAlgorithmName("foo_algo");
+        ShadowRuleConfiguration actual = swapper.swapToObject(yamlConfig);
+        assertThat(actual.getTables().get("foo_tbl").getShadowAlgorithmNames(), is(Collections.singletonList("bar_algo")));
+    }
+    
+    private YamlShadowRuleConfiguration createYamlRuleConfiguration(final Collection<String> shadowAlgorithmNames) {
+        YamlShadowTableConfiguration yamlTableConfig = new YamlShadowTableConfiguration();
+        yamlTableConfig.setShadowAlgorithmNames(new LinkedList<>(shadowAlgorithmNames));
+        YamlShadowRuleConfiguration result = new YamlShadowRuleConfiguration();
+        result.getTables().put("foo_tbl", yamlTableConfig);
+        return result;
+    }
+}


### PR DESCRIPTION
Fixes #39748.

Changes proposed in this pull request:
  - Assign `defaultShadowAlgorithmName` before the two `setTableDefault*` calls in `YamlShadowRuleConfigurationSwapper.swapToObject()`, so a shadow table that omits `shadowAlgorithmNames` inherits the default algorithm.
  - The method contradicted itself: `setTableDefaultShadowDataSource(...)` worked because `result.setDataSources(...)` ran first, while the very next line passed `result.getDefaultShadowAlgorithmName()`, assigned only afterwards and therefore always `null`. The helper's `null != defaultShadowAlgorithmName` guard turned that call into a no-op.
  - Such a table kept an empty algorithm list, so startup failed with `MissingRequiredAlgorithmException` from `ShadowRuleConfigurationChecker`.
  - `swapToYamlConfiguration()` in the same class already assigns the default name before calling both helpers.
  - The statement order changed in #33511; this restores it.
  - Added `YamlShadowRuleConfigurationSwapperTest` covering the inherited default, no default, and a table declaring its own algorithm names. The existing `ShadowRuleConfigurationYamlIT` fixture declares algorithms on every table, so it never exercised this path.

AI assistance: Claude Code was used to draft the change and its unit tests in `features/shadow/core`. I reviewed, verified, and take responsibility for every line submitted.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`. Ran instead, on this branch rebased onto master: repository-wide `./mvnw spotless:check -Pcheck -T1C`, `./mvnw checkstyle:check -Pcheck -T1C` and `./mvnw apache-rat:check -Pcheck -T1C`, plus `./mvnw install -pl features/shadow/core -am -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e` (107 tests, 0 failures). The full-repository `clean install` was not run locally.
- [ ] I have made corresponding changes to the documentation. No documentation change is needed: this restores the documented `defaultShadowAlgorithmName` behaviour without changing the YAML schema.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [x] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
