### PR TITLE
Fix INSERT SELECT being routed to shadow data source

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -87,6 +87,7 @@
 1. SQL Federation: Fix SQL Federation pagination binding for long LIMIT parameters - [#39237](https://github.com/apache/shardingsphere/pull/39237)
 1. Broadcast: Fix case-sensitive table name lookup in broadcast data node rule attribute - [#39153](https://github.com/apache/shardingsphere/pull/39153)
 1. Encrypt: Fix stale encryptors leaking when altering an encrypt rule - [#39209](https://github.com/apache/shardingsphere/pull/39209)
+1. Shadow: Fix INSERT SELECT statement being routed to shadow data source - [#39751](https://github.com/apache/shardingsphere/pull/39751)
 
 ### Enhancements
 

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/retriever/dml/table/column/impl/ShadowInsertStatementDataSourceMappingsRetriever.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/retriever/dml/table/column/impl/ShadowInsertStatementDataSourceMappingsRetriever.java
@@ -54,6 +54,9 @@ public final class ShadowInsertStatementDataSourceMappingsRetriever extends Shad
             }
             Collection<Comparable<?>> columnValues = getColumnValues(sqlStatementContext.getInsertValueContexts(), columnIndex);
             columnIndex++;
+            if (columnValues.isEmpty()) {
+                continue;
+            }
             String tableName = sqlStatementContext.getTablesContext().getTableNames().iterator().next();
             result.add(new ShadowColumnCondition(tableName, each, columnValues));
         }

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/retriever/dml/ShadowDMLStatementDataSourceMappingsRetrieverTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/retriever/dml/ShadowDMLStatementDataSourceMappingsRetrieverTest.java
@@ -34,11 +34,13 @@ import org.apache.shardingsphere.shadow.route.retriever.dml.table.column.impl.Sh
 import org.apache.shardingsphere.shadow.route.retriever.dml.table.hint.ShadowTableHintDataSourceMappingsRetriever;
 import org.apache.shardingsphere.shadow.rule.ShadowRule;
 import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
+import org.apache.shardingsphere.shadow.spi.column.ColumnShadowAlgorithm;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.DeleteStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.InsertStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.UpdateStatement;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -93,6 +95,30 @@ class ShadowDMLStatementDataSourceMappingsRetrieverTest {
         }
         Map<String, String> actual = retriever.retrieve(rule);
         assertThat(name, actual, is(expected));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    void assertRetrieveWithInsertSelectStatement() {
+        ShadowDMLStatementDataSourceMappingsRetriever retriever =
+                new ShadowDMLStatementDataSourceMappingsRetriever(createQueryContext(createInsertSelectSqlStatementContext()), ShadowOperationType.INSERT);
+        ShadowRule rule = mock(ShadowRule.class);
+        when(rule.filterShadowTables(Collections.singleton("t_order"))).thenReturn(Collections.singleton("t_order"));
+        when(rule.getShadowColumnNames(ShadowOperationType.INSERT, "t_order")).thenReturn(Collections.singleton("foo_col"));
+        when(rule.getColumnShadowAlgorithms(ShadowOperationType.INSERT, "t_order", "foo_col")).thenReturn(Collections.singleton(mock(ColumnShadowAlgorithm.class)));
+        when(rule.getShadowDataSourceMappings("t_order")).thenReturn(Collections.singletonMap("foo_prod_ds", "foo_shadow_ds"));
+        Map<String, String> actual = retriever.retrieve(rule);
+        assertThat(actual, is(Collections.emptyMap()));
+    }
+    
+    private static SQLStatementContext createInsertSelectSqlStatementContext() {
+        InsertStatementContext result = mock(InsertStatementContext.class, RETURNS_DEEP_STUBS);
+        when(result.getSqlStatement()).thenReturn(mock(InsertStatement.class));
+        when(result.getTablesContext().getDatabaseName()).thenReturn(Optional.empty());
+        when(result.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_order"));
+        when(result.getInsertColumnNames()).thenReturn(Collections.singletonList("foo_col"));
+        when(result.getInsertValueContexts()).thenReturn(Collections.emptyList());
+        return result;
     }
     
     private QueryContext createQueryContext(final SQLStatementContext sqlStatementContext) {

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/retriever/dml/table/column/impl/ShadowInsertStatementDataSourceMappingsRetrieverTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/retriever/dml/table/column/impl/ShadowInsertStatementDataSourceMappingsRetrieverTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import static org.apache.shardingsphere.test.infra.framework.matcher.ShardingSphereAssertionMatchers.deepEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -49,6 +50,17 @@ class ShadowInsertStatementDataSourceMappingsRetrieverTest {
         Collection<ShadowColumnCondition> actual = retriever.getShadowColumnConditions("foo_col");
         Collection<ShadowColumnCondition> expected = Collections.singletonList(new ShadowColumnCondition("foo_tbl", "foo_col", Collections.singletonList("foo")));
         assertThat(actual, deepEqual(expected));
+    }
+    
+    @Test
+    void assertRetrieveWithInsertSelect() {
+        InsertStatementContext sqlStatementContext = mock(InsertStatementContext.class, RETURNS_DEEP_STUBS);
+        when(sqlStatementContext.getInsertColumnNames()).thenReturn(Arrays.asList("foo_col", "bar_col"));
+        when(sqlStatementContext.getInsertValueContexts()).thenReturn(Collections.emptyList());
+        ShadowInsertStatementDataSourceMappingsRetriever retriever = new ShadowInsertStatementDataSourceMappingsRetriever(sqlStatementContext);
+        Collection<ShadowColumnCondition> actual = retriever.getShadowColumnConditions("foo_col");
+        Collection<ShadowColumnCondition> expected = Collections.emptyList();
+        assertThat(actual, is(expected));
     }
     
     @Test


### PR DESCRIPTION
Fixes #39750.

Changes proposed in this pull request:
  - Skip building a `ShadowColumnCondition` when the insert column has no values, so `INSERT INTO table (column,...) SELECT ...` is no longer routed to the shadow data source.
  - Without the guard, `getInsertValueContexts()` is empty for `INSERT ... SELECT`, and `ColumnShadowAlgorithmDeterminer.isShadow()` returns `true` vacuously over the empty value collection, skipping the algorithm entirely.
  - The three sibling retrievers already drop conditions without values, so this aligns INSERT with them at the producer instead of changing the AND semantics of `ColumnShadowAlgorithmDeterminer`.
  - Matches `limitations.en.md`, which marks this SQL `do not support`; the sibling `do not support` rows (`BETWEEN`, `Sub Query`) also stay on production because `ShadowExtractor.extractValues` returns `Optional.empty()`.
  - Hint based shadow routing is unaffected: `ShadowDMLStatementDataSourceMappingsRetriever` runs the hint retriever first, so `INSERT ... SELECT` can still be shadowed by SQL hint.
  - Adds a retriever unit test and a `ShadowDMLStatementDataSourceMappingsRetrieverTest` case asserting that `INSERT ... SELECT` yields empty data source mappings.

AI assistance: Claude Code was used to draft the change and its unit tests in `features/shadow/core`. I reviewed, verified, and take responsibility for every line submitted.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request. Not added; a committer can apply the `feature: shadow` label.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`. Ran instead, on this branch rebased onto master: repository-wide `./mvnw spotless:check -Pcheck -T1C`, `./mvnw checkstyle:check -Pcheck -T1C` and `./mvnw apache-rat:check -Pcheck -T1C`, plus `./mvnw install -pl features/shadow/core -am -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e` (106 tests, 0 failures). The full-repository `clean install` was not run locally.
- [ ] I have made corresponding changes to the documentation. No documentation change needed: `limitations.en.md` and `limitations.cn.md` already list this SQL as unsupported.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [x] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
