### PR TITLE
Change the minimum JDK version for compiling the project from JDK 17 to JDK 21

### DIFF
--- a/docs/document/content/quick-start/shardingsphere-jdbc-quick-start.cn.md
+++ b/docs/document/content/quick-start/shardingsphere-jdbc-quick-start.cn.md
@@ -14,7 +14,7 @@ Apache ShardingSphere-JDBC 可以通过 `Java` 和 `YAML` 这 2 种方式进行�
 
 ## 前提条件
 
-开发环境需要具备 Java JRE 8 或更高版本。
+编译 ShardingSphere 需要 JDK 21 或更高版本。运行依赖 ShardingSphere 的应用需要 Java JRE 8 或更高版本。
 
 ## 操作步骤
 

--- a/docs/document/content/quick-start/shardingsphere-jdbc-quick-start.en.md
+++ b/docs/document/content/quick-start/shardingsphere-jdbc-quick-start.en.md
@@ -15,7 +15,7 @@ Currently only Java language is supported.
 
 ## Requirements
 
-The development environment requires Java JRE 8 or later.
+Compiling ShardingSphere requires JDK 21 or later. Running applications that depend on ShardingSphere requires Java JRE 8 or later.
 
 ## Procedure
 

--- a/docs/document/content/test-manual/performance-test/benchmarksql-proxy-sharding-test.cn.md
+++ b/docs/document/content/test-manual/performance-test/benchmarksql-proxy-sharding-test.cn.md
@@ -34,11 +34,11 @@ AFTER_LOAD="indexCreates buildFinish"
 
 **注意：本节中提到的任何参数都不是绝对值，都需要根据实际测试结果进行调整或取舍。**
 
-### 建议使用 Java 17 运行 ShardingSphere
+### 建议使用 Java 21 运行 ShardingSphere
 
-编译 ShardingSphere 可以使用 Java 8。
+编译 ShardingSphere 可以使用 Java 21。
 
-使用 Java 17 可以在默认情况下尽量提升 ShardingSphere 的性能。
+使用 Java 21 可以在默认情况下尽量提升 ShardingSphere 的性能。
 
 ### ShardingSphere 数据分片建议
 

--- a/docs/document/content/test-manual/performance-test/benchmarksql-proxy-sharding-test.en.md
+++ b/docs/document/content/test-manual/performance-test/benchmarksql-proxy-sharding-test.en.md
@@ -34,11 +34,11 @@ AFTER_LOAD="indexCreates buildFinish"
 
 **Note: None of the parameters mentioned in this section are absolute values and need to be adjusted based on actual test results.**
 
-### It is recommended to run ShardingSphere using Java 17
+### It is recommended to run ShardingSphere using Java 21
 
-ShardingSphere can be compiled using Java 8.
+ShardingSphere can be compiled using Java 21.
 
-When using Java 17, maximize the ShardingSphere performance by default.
+When using Java 21, maximize the ShardingSphere performance by default.
 
 ### ShardingSphere data sharding recommendations
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,8 @@
     <properties>
         <!-- Environments -->
         <java.version>8</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <compile.java.version>21</compile.java.version>
+        <maven.compiler.source>${compile.java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.version.range>[3.0.4,)</maven.version.range>
@@ -792,7 +793,7 @@
                                         <version>${maven.version.range}</version>
                                     </requireMavenVersion>
                                     <requireJavaVersion>
-                                        <version>${java.version}</version>
+                                        <version>[${compile.java.version},)</version>
                                     </requireJavaVersion>
                                 </rules>
                                 <fail>${maven.enforcer.fail}</fail>


### PR DESCRIPTION
Fixes #37884 .

Changes proposed in this pull request:
  - Change the minimum JDK version for compiling the project from JDK 17 to JDK 21. This makes it possible to test the HiveServer2 JDBC Driver 4.2.0 on the ShardingSphere master branch. Refer to https://hive.apache.org/general/downloads/#23-november-2025--release-420-available . Also for https://github.com/apache/shardingsphere/issues/26041 .
  - It appears there are actually no CI configuration changes needed.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
- [x] I have disclosed the tool and affected files or scope for any material AI assistance, as required by the [AI-assisted contribution policy].

[AI-assisted contribution policy]: https://github.com/apache/shardingsphere/blob/master/AI_POLICY.md
