### PR TITLE
Finish SQL execution hook before sane result fallback

### DIFF
--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
@@ -93,13 +93,13 @@ public abstract class JDBCExecutorCallback<T> implements ExecutorCallback<JDBCEx
             processEngine.completeSQLUnitExecution(jdbcExecutionUnit, processId);
             return result;
         } catch (final SQLException ex) {
+            sqlExecutionHook.finishFailure(ex);
             if (!storageType.equals(protocolType)) {
                 Optional<T> saneResult = getSaneResult(sqlStatement, ex);
                 if (saneResult.isPresent()) {
                     return isTrunkThread ? saneResult.get() : null;
                 }
             }
-            sqlExecutionHook.finishFailure(ex);
             SQLExecutorExceptionHandler.handleException(ex);
             return null;
         }

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallbackTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallbackTest.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.context.SQLUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutorExceptionHandler;
+import org.apache.shardingsphere.infra.executor.sql.hook.SPISQLExecutionHook;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
@@ -29,7 +30,11 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.Se
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.PreparedStatement;
@@ -45,7 +50,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,27 +71,35 @@ class JDBCExecutorCallbackTest {
         SQLExecutorExceptionHandler.setExceptionThrown(true);
     }
     
-    @Test
-    void assertExecuteFailedAndProtocolTypeDifferentWithDatabaseType() throws SQLException {
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {true, false})
+    void assertExecuteWithSaneResult(final boolean isTrunkThread) throws SQLException {
         Object saneResult = new Object();
+        SQLException expectedException = new SQLException("foo_failure");
         ResourceMetaData resourceMetaData = mock(ResourceMetaData.class, RETURNS_DEEP_STUBS);
+        when(resourceMetaData.getStorageUnits().containsKey("ds")).thenReturn(true);
         when(resourceMetaData.getStorageUnits().get("ds").getStorageType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
-        JDBCExecutorCallback<Object> callback =
-                new JDBCExecutorCallback<Object>(TypedSPILoader.getService(DatabaseType.class, "MySQL"), resourceMetaData, mock(SelectStatement.class), true) {
-                    
-                    @Override
-                    protected Object executeSQL(final String sql, final Statement statement, final ConnectionMode connectionMode, final DatabaseType storageType) throws SQLException {
-                        throw new SQLException("");
-                    }
-                    
-                    @Override
-                    protected Optional<Object> getSaneResult(final SQLStatement sqlStatement, final SQLException ex) {
-                        return Optional.of(saneResult);
-                    }
-                };
-        String processId = new UUID(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong()).toString().replace("-", "");
-        assertThat(callback.execute(units, true, processId), is(Collections.singletonList(saneResult)));
-        assertThat(callback.execute(units, false, processId), is(Collections.emptyList()));
+        JDBCExecutorCallback<Object> callback = new JDBCExecutorCallback<Object>(mock(DatabaseType.class), resourceMetaData, mock(SelectStatement.class), true) {
+            
+            @Override
+            protected Object executeSQL(final String sql, final Statement statement, final ConnectionMode connectionMode, final DatabaseType storageType) throws SQLException {
+                throw expectedException;
+            }
+            
+            @Override
+            protected Optional<Object> getSaneResult(final SQLStatement sqlStatement, final SQLException ex) {
+                return Optional.of(saneResult);
+            }
+        };
+        try (MockedConstruction<SPISQLExecutionHook> mocked = mockConstruction(SPISQLExecutionHook.class)) {
+            assertThat(callback.execute(units, isTrunkThread, "foo_process"), is(isTrunkThread ? Collections.singletonList(saneResult) : Collections.emptyList()));
+            assertThat(mocked.constructed().size(), is(1));
+            SPISQLExecutionHook sqlExecutionHook = mocked.constructed().get(0);
+            InOrder inOrder = inOrder(sqlExecutionHook);
+            inOrder.verify(sqlExecutionHook).start("ds", "SELECT now()", Collections.emptyList(), resourceMetaData.getStorageUnits().get("ds").getConnectionProperties(), isTrunkThread);
+            inOrder.verify(sqlExecutionHook).finishFailure(expectedException);
+            verifyNoMoreInteractions(sqlExecutionHook);
+        }
     }
     
     @Test


### PR DESCRIPTION
Fixes #39763.

When JDBC execution throws an SQLException that is converted into a sane compatibility result, SQLExecutionHook currently receives start without either terminal callback. Notify finishFailure before attempting the sane-result fallback, preserving the existing trunk/worker return values and ordinary exception propagation.

The regression test covers both trunk and worker paths, verifies the original exception and exactly one terminal callback, and fails on the unchanged base revision. The full executor unit suite passes (196 tests).

Upstream [CI](https://github.com/apache/shardingsphere/actions/runs/34171532124) also completed `./mvnw clean install -T1C -B -ntp -fae` successfully for this head merged with the PR base. Its logs show all 3 focused callback tests, all 196 executor tests, and all 8 Proxy callback tests passing with no failures, errors, or skips in those suites. The [required checks](https://github.com/apache/shardingsphere/actions/runs/34171532135) for Spotless, Checkstyle, and license headers passed.

The test scopes `mockConstruction` with try-with-resources because it needs the constructed hook instance and construction count to verify callback ordering and exactly one terminal notification. `AutoMockExtension` keeps its construction handles private and does not expose the constructed instances.

Material AI assistance: OpenAI Codex assisted with investigation, the JDBCExecutorCallback.java change, and the JDBCExecutorCallbackTest.java regression test in infra/executor. The contributor is responsible for reviewing and explaining the change.

The regression is unit-level coverage of the executor lifecycle. A dedicated live heterogeneous Proxy/database reproduction has not been run. This PR is ready for maintainer review.
