### PR TITLE
Fix duplicate vendor codes 10003, 10005 and 10010 in metadata kernel block

### DIFF
--- a/docs/document/content/user-manual/error-code/sql-error-code.cn.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.cn.md
@@ -25,6 +25,9 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 | 10008       | HY000     | Unexpected variable value of '%s', required '%s', now is '%s'.                      |
 | 10010       | HY000     | Rule and storage meta data mismatched, reason is: %s.                               |
 | 10012       | HY000     | Load table meta data failed for database '%s' and tables '%s'.                      |
+| 10013       | 42S01     | Duplicate column name '%s'.                                                         |
+| 10014       | 42S01     | Index '%s' already exists.                                                          |
+| 10016       | HY000     | Cluster repository persist error.                                                   |
 | 10023       | HY000     | Identifier '%s' is ambiguous, matched actual identifiers: %s.                       |
 | 10024       | HY000     | Can not resolve prepared statement metadata because %s.                             |
 | 10100       | HY000     | Can not %s storage units '%s'.                                                      |

--- a/docs/document/content/user-manual/error-code/sql-error-code.en.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.en.md
@@ -25,6 +25,9 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 | 10008       | HY000     | Unexpected variable value of '%s', required '%s', now is '%s'.                      |
 | 10010       | HY000     | Rule and storage meta data mismatched, reason is: %s.                               |
 | 10012       | HY000     | Load table meta data failed for database '%s' and tables '%s'.                      |
+| 10013       | 42S01     | Duplicate column name '%s'.                                                         |
+| 10014       | 42S01     | Index '%s' already exists.                                                          |
+| 10016       | HY000     | Cluster repository persist error.                                                   |
 | 10023       | HY000     | Identifier '%s' is ambiguous, matched actual identifiers: %s.                       |
 | 10024       | HY000     | Can not resolve prepared statement metadata because %s.                             |
 | 10100       | HY000     | Can not %s storage units '%s'.                                                      |

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/exception/kernel/metadata/DuplicateColumnException.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/exception/kernel/metadata/DuplicateColumnException.java
@@ -28,6 +28,6 @@ public final class DuplicateColumnException extends MetaDataSQLException {
     private static final long serialVersionUID = -8930912306382133265L;
     
     public DuplicateColumnException(final String columnExpression) {
-        super(XOpenSQLState.DUPLICATE, 3, "Duplicate column name '%s'.", columnExpression);
+        super(XOpenSQLState.DUPLICATE, 13, "Duplicate column name '%s'.", columnExpression);
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/exception/kernel/metadata/DuplicateIndexException.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/exception/kernel/metadata/DuplicateIndexException.java
@@ -28,6 +28,6 @@ public final class DuplicateIndexException extends MetaDataSQLException {
     private static final long serialVersionUID = 1463379993377506978L;
     
     public DuplicateIndexException(final String indexName) {
-        super(XOpenSQLState.DUPLICATE, 5, "Index '%s' already exists.", indexName);
+        super(XOpenSQLState.DUPLICATE, 14, "Index '%s' already exists.", indexName);
     }
 }

--- a/mode/type/cluster/repository/api/src/main/java/org/apache/shardingsphere/mode/repository/cluster/exception/ClusterRepositoryPersistException.java
+++ b/mode/type/cluster/repository/api/src/main/java/org/apache/shardingsphere/mode/repository/cluster/exception/ClusterRepositoryPersistException.java
@@ -28,6 +28,6 @@ public final class ClusterRepositoryPersistException extends MetaDataPersistExce
     private static final long serialVersionUID = -6417179023552012152L;
     
     public ClusterRepositoryPersistException(final Exception cause) {
-        super(XOpenSQLState.GENERAL_ERROR, 10, cause, "Cluster repository persist error.");
+        super(XOpenSQLState.GENERAL_ERROR, 16, cause, "Cluster repository persist error.");
     }
 }


### PR DESCRIPTION
- Change DuplicateColumnException error code from 3 to 13 (vendor code 10013) to stop colliding with ColumnNotFoundException
- Change DuplicateIndexException error code from 5 to 14 (vendor code 10014) to stop colliding with CheckDatabaseEnvironmentFailedException
- Change ClusterRepositoryPersistException error code from 10 to 16 (vendor code 10016) to stop colliding with RuleAndStorageMetaDataMismatchedException
- Register the three messages in sql-error-code.cn.md and sql-error-code.en.md

Intentional behavior change: duplicate column, duplicate index, and cluster repository persist errors previously returned 10003/10005/10010 and now return 10013/10014/10016, restoring one error definition per vendor code.
