### PR TITLE
Add error handling for unknown or closed BLOB handles and ids in Firebird Proxy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -69,7 +69,7 @@
 1. Proxy: Fix MySQL BLOB result set handling in text and binary protocols - [#39340](https://github.com/apache/shardingsphere/pull/39340)
 1. Proxy: Fix silently dropped backslashes and rejected NULL elements in PostgreSQL text array binary parameters - [#39395](https://github.com/apache/shardingsphere/pull/39395)
 1. Proxy: Fix MySQL COM_QUERY binary string literal corruption - [#39433](https://github.com/apache/shardingsphere/pull/39433)
-1. Proxy: Add error handling for unknown or closed BLOB handles and ids in Firebird - [#39052](https://github.com/apache/shardingsphere/issues/39052)
+1. Proxy: Add error handling for unknown or closed BLOB handles and ids in Firebird - [#39773](https://github.com/apache/shardingsphere/pull/39773)
 1. JDBC & Proxy: Remove default MySQL prepared statement query properties when creating data sources - [#38593](https://github.com/apache/shardingsphere/pull/38593)
 1. Mode: Fix rule metadata not removed from memory after dropping rules in Etcd cluster mode - [#38561](https://github.com/apache/shardingsphere/pull/38561)
 1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -69,6 +69,7 @@
 1. Proxy: Fix MySQL BLOB result set handling in text and binary protocols - [#39340](https://github.com/apache/shardingsphere/pull/39340)
 1. Proxy: Fix silently dropped backslashes and rejected NULL elements in PostgreSQL text array binary parameters - [#39395](https://github.com/apache/shardingsphere/pull/39395)
 1. Proxy: Fix MySQL COM_QUERY binary string literal corruption - [#39433](https://github.com/apache/shardingsphere/pull/39433)
+1. Proxy: Add error handling for unknown or closed BLOB handles and ids in Firebird - [#39052](https://github.com/apache/shardingsphere/issues/39052)
 1. JDBC & Proxy: Remove default MySQL prepared statement query properties when creating data sources - [#38593](https://github.com/apache/shardingsphere/pull/38593)
 1. Mode: Fix rule metadata not removed from memory after dropping rules in Etcd cluster mode - [#38561](https://github.com/apache/shardingsphere/pull/38561)
 1. Agent: Fix wrong target class name in StaticMethodAdviceExecutor error logs - [#39077](https://github.com/apache/shardingsphere/pull/39077)

--- a/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/CannotUpdateOldBlobException.java
+++ b/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/CannotUpdateOldBlobException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.exception.firebird.exception.protocol;
+
+import lombok.Getter;
+import org.apache.shardingsphere.database.exception.core.exception.SQLDialectException;
+
+/**
+ * Cannot update old BLOB exception for Firebird.
+ */
+@Getter
+public final class CannotUpdateOldBlobException extends SQLDialectException {
+    
+    private static final long serialVersionUID = -2405790128937812686L;
+    
+    private final int blobHandle;
+    
+    public CannotUpdateOldBlobException(final int blobHandle) {
+        super(String.format("Cannot update old BLOB with handle: %d", blobHandle));
+        this.blobHandle = blobHandle;
+    }
+}

--- a/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/InvalidSegstrHandleException.java
+++ b/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/InvalidSegstrHandleException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.exception.firebird.exception.protocol;
+
+import lombok.Getter;
+import org.apache.shardingsphere.database.exception.core.exception.SQLDialectException;
+
+/**
+ * Invalid BLOB handle exception for Firebird.
+ */
+@Getter
+public final class InvalidSegstrHandleException extends SQLDialectException {
+    
+    private static final long serialVersionUID = 5537229813170963335L;
+    
+    private final int blobHandle;
+    
+    public InvalidSegstrHandleException(final int blobHandle) {
+        super(String.format("Invalid BLOB handle: %d", blobHandle));
+        this.blobHandle = blobHandle;
+    }
+}

--- a/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/InvalidSegstrIdException.java
+++ b/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/InvalidSegstrIdException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.exception.firebird.exception.protocol;
+
+import lombok.Getter;
+import org.apache.shardingsphere.database.exception.core.exception.SQLDialectException;
+
+/**
+ * Invalid BLOB id exception for Firebird.
+ */
+@Getter
+public final class InvalidSegstrIdException extends SQLDialectException {
+    
+    private static final long serialVersionUID = 4470112458245700489L;
+    
+    private final long blobId;
+    
+    public InvalidSegstrIdException(final long blobId) {
+        super(String.format("Invalid BLOB id: %d", blobId));
+        this.blobId = blobId;
+    }
+}

--- a/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/mapper/FirebirdDialectExceptionMapper.java
+++ b/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/mapper/FirebirdDialectExceptionMapper.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.database.exception.core.mapper.SQLDialectExcept
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.BatchAlreadyOpenedException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.BatchParametersRequiredException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.BatchTooBigException;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.CannotUpdateOldBlobException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.ExcessTransactionsException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchHandleException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchMessageFormatException;
@@ -105,6 +106,9 @@ public final class FirebirdDialectExceptionMapper implements SQLDialectException
         }
         if (sqlDialectException instanceof InvalidSegstrIdException) {
             return toSQLException(FirebirdVendorError.INVALID_SEGSTR_ID);
+        }
+        if (sqlDialectException instanceof CannotUpdateOldBlobException) {
+            return toSQLException(FirebirdVendorError.CANNOT_UPDATE_OLD_BLOB);
         }
         return new UnknownSQLException(sqlDialectException).toSQLException();
     }

--- a/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/mapper/FirebirdDialectExceptionMapper.java
+++ b/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/mapper/FirebirdDialectExceptionMapper.java
@@ -33,6 +33,8 @@ import org.apache.shardingsphere.database.exception.firebird.exception.protocol.
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchHandleException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchMessageFormatException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchParameterVersionException;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrIdException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidStatementHandleException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidTransactionHandleException;
 import org.apache.shardingsphere.database.exception.firebird.vendor.FirebirdVendorError;
@@ -97,6 +99,12 @@ public final class FirebirdDialectExceptionMapper implements SQLDialectException
         }
         if (sqlDialectException instanceof InvalidParameterValueException) {
             return toSQLException(FirebirdVendorError.CHARSET_NOT_FOUND, ((InvalidParameterValueException) sqlDialectException).getParameterValue());
+        }
+        if (sqlDialectException instanceof InvalidSegstrHandleException) {
+            return toSQLException(FirebirdVendorError.INVALID_SEGSTR_HANDLE);
+        }
+        if (sqlDialectException instanceof InvalidSegstrIdException) {
+            return toSQLException(FirebirdVendorError.INVALID_SEGSTR_ID);
         }
         return new UnknownSQLException(sqlDialectException).toSQLException();
     }

--- a/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/vendor/FirebirdVendorError.java
+++ b/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/vendor/FirebirdVendorError.java
@@ -70,7 +70,9 @@ public enum FirebirdVendorError implements VendorError {
     
     INVALID_SEGSTR_HANDLE(XOpenSQLState.SYNTAX_ERROR, ISCConstants.isc_bad_segstr_handle, "invalid BLOB handle"),
     
-    INVALID_SEGSTR_ID(XOpenSQLState.SYNTAX_ERROR, ISCConstants.isc_bad_segstr_id, "invalid BLOB ID");
+    INVALID_SEGSTR_ID(XOpenSQLState.SYNTAX_ERROR, ISCConstants.isc_bad_segstr_id, "invalid BLOB ID"),
+    
+    CANNOT_UPDATE_OLD_BLOB(XOpenSQLState.SYNTAX_ERROR, ISCConstants.isc_cannot_update_old_blob, "cannot update old BLOB");
     
     private final SQLState sqlState;
     

--- a/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/vendor/FirebirdVendorError.java
+++ b/database/exception/dialect/firebird/src/main/java/org/apache/shardingsphere/database/exception/firebird/vendor/FirebirdVendorError.java
@@ -66,7 +66,11 @@ public enum FirebirdVendorError implements VendorError {
     
     BATCH_PARAMETERS_REQUIRED(FirebirdState.BATCH_PARAMETERS_REQUIRED, ISCConstants.isc_batch_param, "Statement used in batch must have parameters"),
     
-    SQLDA_ERROR(FirebirdState.SQLDA_ERROR, ISCConstants.isc_dsql_sqlda_err, "");
+    SQLDA_ERROR(FirebirdState.SQLDA_ERROR, ISCConstants.isc_dsql_sqlda_err, ""),
+    
+    INVALID_SEGSTR_HANDLE(XOpenSQLState.SYNTAX_ERROR, ISCConstants.isc_bad_segstr_handle, "invalid BLOB handle"),
+    
+    INVALID_SEGSTR_ID(XOpenSQLState.SYNTAX_ERROR, ISCConstants.isc_bad_segstr_id, "invalid BLOB ID");
     
     private final SQLState sqlState;
     

--- a/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/CannotUpdateOldBlobExceptionTest.java
+++ b/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/CannotUpdateOldBlobExceptionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.exception.firebird.exception.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class CannotUpdateOldBlobExceptionTest {
+    
+    @Test
+    void assertGetMessage() {
+        CannotUpdateOldBlobException actual = new CannotUpdateOldBlobException(42);
+        assertThat(actual.getMessage(), is("Cannot update old BLOB with handle: 42"));
+        assertThat(actual.getBlobHandle(), is(42));
+    }
+}

--- a/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/InvalidSegstrHandleExceptionTest.java
+++ b/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/InvalidSegstrHandleExceptionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.exception.firebird.exception.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class InvalidSegstrHandleExceptionTest {
+    
+    @Test
+    void assertGetMessage() {
+        InvalidSegstrHandleException actual = new InvalidSegstrHandleException(42);
+        assertThat(actual.getMessage(), is("Invalid BLOB handle: 42"));
+        assertThat(actual.getBlobHandle(), is(42));
+    }
+}

--- a/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/InvalidSegstrIdExceptionTest.java
+++ b/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/exception/protocol/InvalidSegstrIdExceptionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.exception.firebird.exception.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class InvalidSegstrIdExceptionTest {
+    
+    @Test
+    void assertGetMessage() {
+        InvalidSegstrIdException actual = new InvalidSegstrIdException(99L);
+        assertThat(actual.getMessage(), is("Invalid BLOB id: 99"));
+        assertThat(actual.getBlobId(), is(99L));
+    }
+}

--- a/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/mapper/FirebirdDialectExceptionMapperTest.java
+++ b/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/mapper/FirebirdDialectExceptionMapperTest.java
@@ -35,6 +35,8 @@ import org.apache.shardingsphere.database.exception.firebird.exception.protocol.
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchHandleException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchMessageFormatException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchParameterVersionException;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrIdException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidStatementHandleException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidTransactionHandleException;
 import org.apache.shardingsphere.database.exception.firebird.vendor.FirebirdVendorError;
@@ -133,6 +135,16 @@ class FirebirdDialectExceptionMapperTest {
     @Test
     void assertConvertWithInvalidParameterValue() {
         assertSQLException(mapper.convert(new InvalidParameterValueException("names", "foo_charset")), FirebirdVendorError.CHARSET_NOT_FOUND, "foo_charset");
+    }
+    
+    @Test
+    void assertConvertWithInvalidSegstrHandle() {
+        assertSQLException(mapper.convert(new InvalidSegstrHandleException(42)), FirebirdVendorError.INVALID_SEGSTR_HANDLE);
+    }
+    
+    @Test
+    void assertConvertWithInvalidSegstrId() {
+        assertSQLException(mapper.convert(new InvalidSegstrIdException(99L)), FirebirdVendorError.INVALID_SEGSTR_ID);
     }
     
     @Test

--- a/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/mapper/FirebirdDialectExceptionMapperTest.java
+++ b/database/exception/dialect/firebird/src/test/java/org/apache/shardingsphere/database/exception/firebird/mapper/FirebirdDialectExceptionMapperTest.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.database.exception.core.mapper.SQLDialectExcept
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.BatchAlreadyOpenedException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.BatchParametersRequiredException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.BatchTooBigException;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.CannotUpdateOldBlobException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.ExcessTransactionsException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchHandleException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidBatchMessageFormatException;
@@ -145,6 +146,11 @@ class FirebirdDialectExceptionMapperTest {
     @Test
     void assertConvertWithInvalidSegstrId() {
         assertSQLException(mapper.convert(new InvalidSegstrIdException(99L)), FirebirdVendorError.INVALID_SEGSTR_ID);
+    }
+    
+    @Test
+    void assertConvertWithCannotUpdateOldBlob() {
+        assertSQLException(mapper.convert(new CannotUpdateOldBlobException(42)), FirebirdVendorError.CANNOT_UPDATE_OLD_BLOB);
     }
     
     @Test

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBatchBlobSegmentsCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBatchBlobSegmentsCommandExecutor.java
@@ -18,11 +18,9 @@
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdBatchBlobSegmentsCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
-import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobWriteCache;
@@ -30,7 +28,6 @@ import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.gene
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 /**
@@ -48,9 +45,9 @@ public final class FirebirdBatchBlobSegmentsCommandExecutor implements CommandEx
     @Override
     public Collection<DatabasePacket> execute() {
         int blobHandle = FirebirdBlobHandleGenerator.getInstance().resolveBlobHandle(connectionSession.getConnectionId(), packet.getBlobHandle());
+        FirebirdBlobWriteHandleValidator.validate(connectionSession.getConnectionId(), blobHandle);
         for (byte[] each : packet.getSegments()) {
-            OptionalInt appendResult = FirebirdBlobWriteCache.getInstance().appendSegment(connectionSession.getConnectionId(), blobHandle, each);
-            ShardingSpherePreconditions.checkState(appendResult.isPresent(), () -> new InvalidSegstrHandleException(blobHandle));
+            FirebirdBlobWriteCache.getInstance().appendSegment(connectionSession.getConnectionId(), blobHandle, each);
         }
         OptionalLong blobId = FirebirdBlobWriteCache.getInstance().getBlobId(connectionSession.getConnectionId(), blobHandle);
         long responseBlobId = blobId.isPresent() ? blobId.getAsLong() : 0L;

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBatchBlobSegmentsCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBatchBlobSegmentsCommandExecutor.java
@@ -18,9 +18,11 @@
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdBatchBlobSegmentsCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
+import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobWriteCache;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.gene
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 /**
@@ -45,10 +48,11 @@ public final class FirebirdBatchBlobSegmentsCommandExecutor implements CommandEx
     @Override
     public Collection<DatabasePacket> execute() {
         int blobHandle = FirebirdBlobHandleGenerator.getInstance().resolveBlobHandle(connectionSession.getConnectionId(), packet.getBlobHandle());
-        OptionalLong blobId = FirebirdBlobWriteCache.getInstance().getBlobId(connectionSession.getConnectionId(), blobHandle);
         for (byte[] each : packet.getSegments()) {
-            FirebirdBlobWriteCache.getInstance().appendSegment(connectionSession.getConnectionId(), blobHandle, each);
+            OptionalInt appendResult = FirebirdBlobWriteCache.getInstance().appendSegment(connectionSession.getConnectionId(), blobHandle, each);
+            ShardingSpherePreconditions.checkState(appendResult.isPresent(), () -> new InvalidSegstrHandleException(blobHandle));
         }
+        OptionalLong blobId = FirebirdBlobWriteCache.getInstance().getBlobId(connectionSession.getConnectionId(), blobHandle);
         long responseBlobId = blobId.isPresent() ? blobId.getAsLong() : 0L;
         return Collections.singleton(new FirebirdGenericResponsePacket().setWriteZeroStatementId(true).setId(responseBlobId));
     }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBlobWriteHandleValidator.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBlobWriteHandleValidator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.CannotUpdateOldBlobException;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobWriteCache;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.generator.FirebirdBlobHandleGenerator;
+
+/**
+ * Validates a BLOB handle used for a write operation for Firebird.
+ *
+ * <p>A handle that is still allocated but absent from the write cache belongs to a BLOB opened for reading,
+ * which Firebird rejects with a dedicated error instead of reporting the handle as unknown.</p>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class FirebirdBlobWriteHandleValidator {
+    
+    /**
+     * Validate that a BLOB handle is open for writing.
+     *
+     * @param connectionId connection id
+     * @param blobHandle blob handle
+     * @throws CannotUpdateOldBlobException when the handle is a valid handle opened for reading
+     * @throws InvalidSegstrHandleException when the handle is unknown
+     */
+    static void validate(final int connectionId, final int blobHandle) {
+        if (FirebirdBlobWriteCache.getInstance().getBlobId(connectionId, blobHandle).isPresent()) {
+            return;
+        }
+        if (FirebirdBlobHandleGenerator.getInstance().isAllocated(connectionId, blobHandle)) {
+            throw new CannotUpdateOldBlobException(blobHandle);
+        }
+        throw new InvalidSegstrHandleException(blobHandle);
+    }
+}

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdOpenBlobCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdOpenBlobCommandExecutor.java
@@ -18,10 +18,12 @@
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrIdException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdOpenBlobCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.statement.execute.protocol.FirebirdBlobBinaryProtocolValue;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
+import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobReadCache;
@@ -43,8 +45,9 @@ public final class FirebirdOpenBlobCommandExecutor implements CommandExecutor {
     @Override
     public Collection<DatabasePacket> execute() {
         byte[] blobContent = FirebirdBlobBinaryProtocolValue.getBlobContent(connectionSession.getConnectionId(), packet.getBlobId());
+        ShardingSpherePreconditions.checkNotNull(blobContent, () -> new InvalidSegstrIdException(packet.getBlobId()));
         int blobHandle = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(connectionSession.getConnectionId());
-        FirebirdBlobReadCache.getInstance().registerBlob(connectionSession.getConnectionId(), blobHandle, null == blobContent ? new byte[0] : blobContent);
+        FirebirdBlobReadCache.getInstance().registerBlob(connectionSession.getConnectionId(), blobHandle, blobContent);
         return Collections.singleton(new FirebirdGenericResponsePacket().setHandle(blobHandle).setId(packet.getBlobId()));
     }
 }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdOpenBlobCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdOpenBlobCommandExecutor.java
@@ -34,6 +34,9 @@ import java.util.Collections;
 
 /**
  * Open blob command executor for Firebird.
+ *
+ * <p>A zero BLOB id is the NULL BLOB quad, which Firebird opens as an empty BLOB instead of rejecting it,
+ * so it is registered with empty content rather than reported as an invalid BLOB id.</p>
  */
 @RequiredArgsConstructor
 public final class FirebirdOpenBlobCommandExecutor implements CommandExecutor {
@@ -44,10 +47,18 @@ public final class FirebirdOpenBlobCommandExecutor implements CommandExecutor {
     
     @Override
     public Collection<DatabasePacket> execute() {
-        byte[] blobContent = FirebirdBlobBinaryProtocolValue.getBlobContent(connectionSession.getConnectionId(), packet.getBlobId());
-        ShardingSpherePreconditions.checkNotNull(blobContent, () -> new InvalidSegstrIdException(packet.getBlobId()));
+        long blobId = packet.getBlobId();
+        if (0L == blobId) {
+            return registerBlob(blobId, new byte[0]);
+        }
+        byte[] blobContent = FirebirdBlobBinaryProtocolValue.getBlobContent(connectionSession.getConnectionId(), blobId);
+        ShardingSpherePreconditions.checkNotNull(blobContent, () -> new InvalidSegstrIdException(blobId));
+        return registerBlob(blobId, blobContent);
+    }
+    
+    private Collection<DatabasePacket> registerBlob(final long blobId, final byte[] blobContent) {
         int blobHandle = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(connectionSession.getConnectionId());
         FirebirdBlobReadCache.getInstance().registerBlob(connectionSession.getConnectionId(), blobHandle, blobContent);
-        return Collections.singleton(new FirebirdGenericResponsePacket().setHandle(blobHandle).setId(packet.getBlobId()));
+        return Collections.singleton(new FirebirdGenericResponsePacket().setHandle(blobHandle).setId(blobId));
     }
 }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdPutBlobSegmentCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdPutBlobSegmentCommandExecutor.java
@@ -18,9 +18,11 @@
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdPutBlobSegmentCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
+import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobWriteCache;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.gene
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 /**
@@ -43,8 +46,9 @@ public final class FirebirdPutBlobSegmentCommandExecutor implements CommandExecu
     @Override
     public Collection<DatabasePacket> execute() {
         int blobHandle = FirebirdBlobHandleGenerator.getInstance().resolveBlobHandle(connectionSession.getConnectionId(), packet.getBlobHandle());
+        OptionalInt appendResult = FirebirdBlobWriteCache.getInstance().appendSegment(connectionSession.getConnectionId(), blobHandle, packet.getSegment());
+        ShardingSpherePreconditions.checkState(appendResult.isPresent(), () -> new InvalidSegstrHandleException(blobHandle));
         OptionalLong blobId = FirebirdBlobWriteCache.getInstance().getBlobId(connectionSession.getConnectionId(), blobHandle);
-        FirebirdBlobWriteCache.getInstance().appendSegment(connectionSession.getConnectionId(), blobHandle, packet.getSegment());
         long responseBlobId = blobId.isPresent() ? blobId.getAsLong() : 0L;
         return Collections.singleton(new FirebirdGenericResponsePacket().setWriteZeroStatementId(true).setId(responseBlobId));
     }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdPutBlobSegmentCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdPutBlobSegmentCommandExecutor.java
@@ -18,11 +18,9 @@
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdPutBlobSegmentCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
-import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobWriteCache;
@@ -30,7 +28,6 @@ import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.gene
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 /**
@@ -46,8 +43,8 @@ public final class FirebirdPutBlobSegmentCommandExecutor implements CommandExecu
     @Override
     public Collection<DatabasePacket> execute() {
         int blobHandle = FirebirdBlobHandleGenerator.getInstance().resolveBlobHandle(connectionSession.getConnectionId(), packet.getBlobHandle());
-        OptionalInt appendResult = FirebirdBlobWriteCache.getInstance().appendSegment(connectionSession.getConnectionId(), blobHandle, packet.getSegment());
-        ShardingSpherePreconditions.checkState(appendResult.isPresent(), () -> new InvalidSegstrHandleException(blobHandle));
+        FirebirdBlobWriteHandleValidator.validate(connectionSession.getConnectionId(), blobHandle);
+        FirebirdBlobWriteCache.getInstance().appendSegment(connectionSession.getConnectionId(), blobHandle, packet.getSegment());
         OptionalLong blobId = FirebirdBlobWriteCache.getInstance().getBlobId(connectionSession.getConnectionId(), blobHandle);
         long responseBlobId = blobId.isPresent() ? blobId.getAsLong() : 0L;
         return Collections.singleton(new FirebirdGenericResponsePacket().setWriteZeroStatementId(true).setId(responseBlobId));

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGenerator.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGenerator.java
@@ -105,6 +105,23 @@ public final class FirebirdBlobHandleGenerator {
     }
     
     /**
+     * Judge whether BLOB handle is allocated for connection.
+     *
+     * @param connectionId connection ID
+     * @param blobHandle BLOB handle
+     * @return whether BLOB handle is allocated
+     */
+    public boolean isAllocated(final int connectionId, final int blobHandle) {
+        ConnectionBlobHandles connectionBlobHandles = connectionRegistry.get(connectionId);
+        if (null == connectionBlobHandles || blobHandle <= 0 || blobHandle > MAX_OBJECT_HANDLE) {
+            return false;
+        }
+        synchronized (connectionBlobHandles) {
+            return connectionBlobHandles.handles.get(blobHandle - 1);
+        }
+    }
+    
+    /**
      * Release BLOB handle for connection.
      *
      * @param connectionId connection ID

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutor.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.proxy.frontend.firebird.command.query.statemen
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrIdException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidStatementHandleException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidTransactionHandleException;
 import org.apache.shardingsphere.database.protocol.binary.BinaryRow;
@@ -144,10 +145,7 @@ public final class FirebirdExecuteStatementCommandExecutor implements CommandExe
                 params.set(i, FirebirdBlobBinaryProtocolValue.getBlobContent(connectionSession.getConnectionId(), blobId));
                 continue;
             }
-            if (!FirebirdBlobWriteCache.getInstance().isClosed(connectionSession.getConnectionId(), blobId)) {
-                params.set(i, null);
-                continue;
-            }
+            ShardingSpherePreconditions.checkState(FirebirdBlobWriteCache.getInstance().isClosed(connectionSession.getConnectionId(), blobId), () -> new InvalidSegstrIdException(blobId));
             Optional<byte[]> blobData = FirebirdBlobWriteCache.getInstance().getBlobData(connectionSession.getConnectionId(), blobId);
             byte[] bytes = blobData.get();
             params.set(i, bytes);

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBatchBlobSegmentsCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBatchBlobSegmentsCommandExecutorTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.CannotUpdateOldBlobException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdBatchBlobSegmentsCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobReadCache;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobWriteCache;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.generator.FirebirdBlobHandleGenerator;
 import org.junit.jupiter.api.AfterEach;
@@ -56,6 +58,7 @@ class FirebirdBatchBlobSegmentsCommandExecutorTest {
     void setup() {
         FirebirdBlobHandleGenerator.getInstance().registerConnection(CONNECTION_ID);
         FirebirdBlobWriteCache.getInstance().registerConnection(CONNECTION_ID);
+        FirebirdBlobReadCache.getInstance().registerConnection(CONNECTION_ID);
         when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
     }
     
@@ -63,6 +66,7 @@ class FirebirdBatchBlobSegmentsCommandExecutorTest {
     void tearDown() {
         FirebirdBlobHandleGenerator.getInstance().unregisterConnection(CONNECTION_ID);
         FirebirdBlobWriteCache.getInstance().unregisterConnection(CONNECTION_ID);
+        FirebirdBlobReadCache.getInstance().unregisterConnection(CONNECTION_ID);
     }
     
     @Test
@@ -97,7 +101,6 @@ class FirebirdBatchBlobSegmentsCommandExecutorTest {
     @Test
     void assertExecuteWithUnknownBlobHandle() {
         when(packet.getBlobHandle()).thenReturn(4);
-        when(packet.getSegments()).thenReturn(Arrays.asList(new byte[]{1, 2}, new byte[]{3, 4, 5}));
         FirebirdBatchBlobSegmentsCommandExecutor executor = new FirebirdBatchBlobSegmentsCommandExecutor(packet, connectionSession);
         assertThrows(InvalidSegstrHandleException.class, executor::execute);
     }
@@ -109,8 +112,16 @@ class FirebirdBatchBlobSegmentsCommandExecutorTest {
         FirebirdBlobWriteCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, blobId);
         FirebirdBlobWriteCache.getInstance().closeWrite(CONNECTION_ID, blobHandle);
         when(packet.getBlobHandle()).thenReturn(blobHandle);
-        when(packet.getSegments()).thenReturn(Arrays.asList(new byte[]{1, 2}, new byte[]{3, 4, 5}));
         FirebirdBatchBlobSegmentsCommandExecutor executor = new FirebirdBatchBlobSegmentsCommandExecutor(packet, connectionSession);
         assertThrows(InvalidSegstrHandleException.class, executor::execute);
+    }
+    
+    @Test
+    void assertExecuteWithReadHandle() {
+        int blobHandle = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(CONNECTION_ID);
+        FirebirdBlobReadCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, new byte[]{1, 2});
+        when(packet.getBlobHandle()).thenReturn(blobHandle);
+        FirebirdBatchBlobSegmentsCommandExecutor executor = new FirebirdBatchBlobSegmentsCommandExecutor(packet, connectionSession);
+        assertThrows(CannotUpdateOldBlobException.class, executor::execute);
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBatchBlobSegmentsCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdBatchBlobSegmentsCommandExecutorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdBatchBlobSegmentsCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
@@ -37,6 +38,7 @@ import java.util.Collection;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -90,5 +92,25 @@ class FirebirdBatchBlobSegmentsCommandExecutorTest {
         Collection<DatabasePacket> actual = executor.execute();
         assertThat(((FirebirdGenericResponsePacket) actual.iterator().next()).getId(), is(blobId));
         assertThat(FirebirdBlobWriteCache.getInstance().getBlobData(CONNECTION_ID, blobId).orElse(new byte[0]).length, is(3));
+    }
+    
+    @Test
+    void assertExecuteWithUnknownBlobHandle() {
+        when(packet.getBlobHandle()).thenReturn(4);
+        when(packet.getSegments()).thenReturn(Arrays.asList(new byte[]{1, 2}, new byte[]{3, 4, 5}));
+        FirebirdBatchBlobSegmentsCommandExecutor executor = new FirebirdBatchBlobSegmentsCommandExecutor(packet, connectionSession);
+        assertThrows(InvalidSegstrHandleException.class, executor::execute);
+    }
+    
+    @Test
+    void assertExecuteAfterClose() {
+        int blobHandle = 4;
+        long blobId = 12L;
+        FirebirdBlobWriteCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, blobId);
+        FirebirdBlobWriteCache.getInstance().closeWrite(CONNECTION_ID, blobHandle);
+        when(packet.getBlobHandle()).thenReturn(blobHandle);
+        when(packet.getSegments()).thenReturn(Arrays.asList(new byte[]{1, 2}, new byte[]{3, 4, 5}));
+        FirebirdBatchBlobSegmentsCommandExecutor executor = new FirebirdBatchBlobSegmentsCommandExecutor(packet, connectionSession);
+        assertThrows(InvalidSegstrHandleException.class, executor::execute);
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdOpenBlobCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdOpenBlobCommandExecutorTest.java
@@ -93,6 +93,18 @@ class FirebirdOpenBlobCommandExecutorTest {
         assertThrows(InvalidSegstrIdException.class, executor::execute);
     }
     
+    @Test
+    void assertExecuteWithZeroBlobId() {
+        when(packet.getBlobId()).thenReturn(0L);
+        FirebirdOpenBlobCommandExecutor executor = new FirebirdOpenBlobCommandExecutor(packet, connectionSession);
+        Collection<DatabasePacket> actual = executor.execute();
+        assertThat(actual.size(), is(1));
+        DatabasePacket response = actual.iterator().next();
+        assertThat(response, isA(FirebirdGenericResponsePacket.class));
+        assertThat(((FirebirdGenericResponsePacket) response).getHandle(), is(1));
+        assertThat(((FirebirdGenericResponsePacket) response).getId(), is(0L));
+    }
+    
     private long registerBlobContent(final byte[] content) {
         ByteBuf byteBuf = Unpooled.buffer();
         FirebirdPacketPayload payload = new FirebirdPacketPayload(byteBuf, StandardCharsets.UTF_8);

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdOpenBlobCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdOpenBlobCommandExecutorTest.java
@@ -17,8 +17,13 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrIdException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdOpenBlobCommandPacket;
+import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.statement.execute.protocol.FirebirdBlobBinaryProtocolValue;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
+import org.apache.shardingsphere.database.protocol.firebird.payload.FirebirdPacketPayload;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobReadCache;
@@ -32,11 +37,13 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,17 +70,34 @@ class FirebirdOpenBlobCommandExecutorTest {
         FirebirdStatementIdGenerator.getInstance().unregisterConnection(CONNECTION_ID);
         FirebirdBlobHandleGenerator.getInstance().unregisterConnection(CONNECTION_ID);
         FirebirdBlobReadCache.getInstance().unregisterConnection(CONNECTION_ID);
+        FirebirdBlobBinaryProtocolValue.unregisterConnection(CONNECTION_ID);
     }
     
     @Test
     void assertExecute() {
-        when(packet.getBlobId()).thenReturn(99L);
+        long blobId = registerBlobContent(new byte[]{1, 2});
+        when(packet.getBlobId()).thenReturn(blobId);
         FirebirdOpenBlobCommandExecutor executor = new FirebirdOpenBlobCommandExecutor(packet, connectionSession);
         Collection<DatabasePacket> actual = executor.execute();
         assertThat(actual.size(), is(1));
         DatabasePacket response = actual.iterator().next();
         assertThat(response, isA(FirebirdGenericResponsePacket.class));
         assertThat(((FirebirdGenericResponsePacket) response).getHandle(), is(1));
-        assertThat(((FirebirdGenericResponsePacket) response).getId(), is(99L));
+        assertThat(((FirebirdGenericResponsePacket) response).getId(), is(blobId));
+    }
+    
+    @Test
+    void assertExecuteWithUnknownBlobId() {
+        when(packet.getBlobId()).thenReturn(99L);
+        FirebirdOpenBlobCommandExecutor executor = new FirebirdOpenBlobCommandExecutor(packet, connectionSession);
+        assertThrows(InvalidSegstrIdException.class, executor::execute);
+    }
+    
+    private long registerBlobContent(final byte[] content) {
+        ByteBuf byteBuf = Unpooled.buffer();
+        FirebirdPacketPayload payload = new FirebirdPacketPayload(byteBuf, StandardCharsets.UTF_8);
+        payload.setConnectionId(CONNECTION_ID);
+        new FirebirdBlobBinaryProtocolValue().write(payload, content);
+        return byteBuf.getLong(0);
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdPutBlobSegmentCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdPutBlobSegmentCommandExecutorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdPutBlobSegmentCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
@@ -38,6 +39,7 @@ import java.util.Collection;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -99,5 +101,25 @@ class FirebirdPutBlobSegmentCommandExecutorTest {
         assertThat(actual.size(), is(1));
         assertThat(((FirebirdGenericResponsePacket) actual.iterator().next()).getId(), is(blobId));
         assertThat(FirebirdBlobWriteCache.getInstance().getBlobData(CONNECTION_ID, blobId).orElse(new byte[0]).length, is(segment.length));
+    }
+    
+    @Test
+    void assertExecuteWithUnknownBlobHandle() {
+        when(packet.getBlobHandle()).thenReturn(4);
+        when(packet.getSegment()).thenReturn(new byte[]{1, 2});
+        FirebirdPutBlobSegmentCommandExecutor executor = new FirebirdPutBlobSegmentCommandExecutor(packet, connectionSession);
+        assertThrows(InvalidSegstrHandleException.class, executor::execute);
+    }
+    
+    @Test
+    void assertExecuteAfterClose() {
+        int blobHandle = 4;
+        long blobId = 12L;
+        FirebirdBlobWriteCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, blobId);
+        FirebirdBlobWriteCache.getInstance().closeWrite(CONNECTION_ID, blobHandle);
+        when(packet.getBlobHandle()).thenReturn(blobHandle);
+        when(packet.getSegment()).thenReturn(new byte[]{1, 2});
+        FirebirdPutBlobSegmentCommandExecutor executor = new FirebirdPutBlobSegmentCommandExecutor(packet, connectionSession);
+        assertThrows(InvalidSegstrHandleException.class, executor::execute);
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdPutBlobSegmentCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/FirebirdPutBlobSegmentCommandExecutorTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob;
 
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.CannotUpdateOldBlobException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrHandleException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.blob.FirebirdPutBlobSegmentCommandPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobReadCache;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.cache.FirebirdBlobWriteCache;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.generator.FirebirdBlobHandleGenerator;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.generator.FirebirdBlobIdGenerator;
@@ -59,6 +61,7 @@ class FirebirdPutBlobSegmentCommandExecutorTest {
         FirebirdBlobIdGenerator.getInstance().registerConnection(CONNECTION_ID);
         FirebirdBlobHandleGenerator.getInstance().registerConnection(CONNECTION_ID);
         FirebirdBlobWriteCache.getInstance().registerConnection(CONNECTION_ID);
+        FirebirdBlobReadCache.getInstance().registerConnection(CONNECTION_ID);
         when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
     }
     
@@ -68,6 +71,7 @@ class FirebirdPutBlobSegmentCommandExecutorTest {
         FirebirdBlobIdGenerator.getInstance().unregisterConnection(CONNECTION_ID);
         FirebirdBlobHandleGenerator.getInstance().unregisterConnection(CONNECTION_ID);
         FirebirdBlobWriteCache.getInstance().unregisterConnection(CONNECTION_ID);
+        FirebirdBlobReadCache.getInstance().unregisterConnection(CONNECTION_ID);
     }
     
     @Test
@@ -106,7 +110,6 @@ class FirebirdPutBlobSegmentCommandExecutorTest {
     @Test
     void assertExecuteWithUnknownBlobHandle() {
         when(packet.getBlobHandle()).thenReturn(4);
-        when(packet.getSegment()).thenReturn(new byte[]{1, 2});
         FirebirdPutBlobSegmentCommandExecutor executor = new FirebirdPutBlobSegmentCommandExecutor(packet, connectionSession);
         assertThrows(InvalidSegstrHandleException.class, executor::execute);
     }
@@ -118,8 +121,26 @@ class FirebirdPutBlobSegmentCommandExecutorTest {
         FirebirdBlobWriteCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, blobId);
         FirebirdBlobWriteCache.getInstance().closeWrite(CONNECTION_ID, blobHandle);
         when(packet.getBlobHandle()).thenReturn(blobHandle);
-        when(packet.getSegment()).thenReturn(new byte[]{1, 2});
         FirebirdPutBlobSegmentCommandExecutor executor = new FirebirdPutBlobSegmentCommandExecutor(packet, connectionSession);
         assertThrows(InvalidSegstrHandleException.class, executor::execute);
+    }
+    
+    @Test
+    void assertExecuteWithReadHandle() {
+        int blobHandle = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(CONNECTION_ID);
+        FirebirdBlobReadCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, new byte[]{1, 2});
+        when(packet.getBlobHandle()).thenReturn(blobHandle);
+        FirebirdPutBlobSegmentCommandExecutor executor = new FirebirdPutBlobSegmentCommandExecutor(packet, connectionSession);
+        assertThrows(CannotUpdateOldBlobException.class, executor::execute);
+    }
+    
+    @Test
+    void assertExecuteWithFullyReadHandle() {
+        int blobHandle = FirebirdBlobHandleGenerator.getInstance().nextBlobHandle(CONNECTION_ID);
+        FirebirdBlobReadCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, new byte[]{1, 2});
+        FirebirdBlobReadCache.getInstance().readSegment(CONNECTION_ID, blobHandle, 2);
+        when(packet.getBlobHandle()).thenReturn(blobHandle);
+        FirebirdPutBlobSegmentCommandExecutor executor = new FirebirdPutBlobSegmentCommandExecutor(packet, connectionSession);
+        assertThrows(CannotUpdateOldBlobException.class, executor::execute);
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/generator/FirebirdBlobHandleGeneratorTest.java
@@ -30,7 +30,9 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FirebirdBlobHandleGeneratorTest {
     
@@ -116,6 +118,31 @@ class FirebirdBlobHandleGeneratorTest {
     @Test
     void assertResolveBlobHandleWithPlaceholderAndUnknownConnectionExpectsPlaceholder() {
         assertThat(FirebirdBlobHandleGenerator.getInstance().resolveBlobHandle(92, INVALID_OBJECT_HANDLE), is(INVALID_OBJECT_HANDLE));
+    }
+    
+    @Test
+    void assertIsAllocatedWithActiveHandle() {
+        FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();
+        assertTrue(generator.isAllocated(CONNECTION_ID, generator.nextBlobHandle(CONNECTION_ID)));
+    }
+    
+    @Test
+    void assertIsAllocatedAfterRelease() {
+        FirebirdBlobHandleGenerator generator = FirebirdBlobHandleGenerator.getInstance();
+        int blobHandle = generator.nextBlobHandle(CONNECTION_ID);
+        generator.releaseBlobHandle(CONNECTION_ID, blobHandle);
+        assertFalse(generator.isAllocated(CONNECTION_ID, blobHandle));
+    }
+    
+    @Test
+    void assertIsAllocatedWhenConnectionIsNotRegistered() {
+        assertFalse(FirebirdBlobHandleGenerator.getInstance().isAllocated(92, 1));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidBlobHandleProvider")
+    void assertIsAllocatedWhenHandleIsOutsideValidRange(final String name, final int blobHandle) {
+        assertFalse(FirebirdBlobHandleGenerator.getInstance().isAllocated(CONNECTION_ID, blobHandle));
     }
     
     @Test

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.proxy.frontend.firebird.command.query.statemen
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidSegstrIdException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidStatementHandleException;
 import org.apache.shardingsphere.database.exception.firebird.exception.protocol.InvalidTransactionHandleException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.FirebirdBinaryColumnType;
@@ -215,7 +216,7 @@ class FirebirdExecuteStatementCommandExecutorTest {
     }
     
     @Test
-    void assertSkipUnclosedBlobParameter() throws SQLException {
+    void assertRejectUnclosedBlobParameter() {
         int blobHandle = 7;
         long blobId = 11L;
         FirebirdBlobWriteCache.getInstance().registerBlob(CONNECTION_ID, blobHandle, blobId);
@@ -224,13 +225,17 @@ class FirebirdExecuteStatementCommandExecutorTest {
         when(packet.getParameterTypes()).thenReturn(Collections.singletonList(FirebirdBinaryColumnType.BLOB));
         when(packet.getParameterValues()).thenReturn(new ArrayList<>(Collections.singletonList(blobId)));
         executor = new FirebirdExecuteStatementCommandExecutor(packet, connectionSession);
-        when(proxyBackendHandler.execute()).thenReturn(new UpdateResponseHeader(UpdateStatement.builder().databaseType(DATABASE_TYPE).build()));
-        ArgumentCaptor<QueryContext> queryContextCaptor = ArgumentCaptor.forClass(QueryContext.class);
-        when(ProxyBackendHandlerFactory.newInstance(eq(DATABASE_TYPE), queryContextCaptor.capture(), eq(connectionSession), eq(true))).thenReturn(proxyBackendHandler);
-        executor.execute();
-        List<Object> actualParams = queryContextCaptor.getValue().getParameters();
-        assertThat(actualParams.size(), is(1));
-        assertNull(actualParams.get(0));
+        assertThrows(InvalidSegstrIdException.class, () -> executor.execute());
+    }
+    
+    @Test
+    void assertRejectUnknownBlobParameter() {
+        long blobId = 13L;
+        when(packet.getStatementId()).thenReturn(2);
+        when(packet.getParameterTypes()).thenReturn(Collections.singletonList(FirebirdBinaryColumnType.BLOB));
+        when(packet.getParameterValues()).thenReturn(new ArrayList<>(Collections.singletonList(blobId)));
+        executor = new FirebirdExecuteStatementCommandExecutor(packet, connectionSession);
+        assertThrows(InvalidSegstrIdException.class, () -> executor.execute());
     }
     
     @Test


### PR DESCRIPTION
Fixes 4 of the 5 sub-cases in #39052. The 5th (isc_blobtoobig) is split off to #39772, per makssent's suggestion, since it needs a buffered-size-limit design decision rather than just wiring an existing signal to an error.

Changes proposed in this pull request:
 - `FirebirdOpenBlobCommandExecutor`: throw `InvalidSegstrIdException` on an unknown BLOB id instead of registering an empty BLOB.
 - `FirebirdPutBlobSegmentCommandExecutor` / `FirebirdBatchBlobSegmentsCommandExecutor`: check `appendSegment()`'s `OptionalInt` result and throw `InvalidSegstrHandleException` on an unknown or already-closed handle instead of silently reporting success. This covers both the "unknown handle" and "put after close" cases from the issue, since `closeWrite()` removes the cache entry either way, so both hit the same signal.
 - `FirebirdExecuteStatementCommandExecutor.bindBlobParameters()`: throw `InvalidSegstrIdException` for an unknown or unclosed BLOB parameter instead of silently binding `null`.
 - Adds `InvalidSegstrHandleException`/`InvalidSegstrIdException` and their `FirebirdVendorError`/`FirebirdDialectExceptionMapper` wiring, following the error-handling pattern established in #38927. The gdscodes and SQL states (`isc_bad_segstr_handle` / `isc_bad_segstr_id`, both SQLSTATE 42000) were verified against the `jaybird` client jar's `isc_error_sqlstates.properties`/`isc_error_msg.properties`, not guessed.
 - Fixed `FirebirdOpenBlobCommandExecutorTest`'s existing `assertExecute` test, which was unintentionally exercising the bug (an unregistered blob id) and asserting success; it now seeds real content via `FirebirdBlobBinaryProtocolValue`. Added unknown-id/unknown-handle/put-after-close regression tests across all four executors.

This pull request was drafted with assistance from Claude Code (Anthropic). Affected scope: the two new exception classes, the `FirebirdVendorError`/`FirebirdDialectExceptionMapper` wiring, the four executor fixes listed above, and their corresponding unit tests. I reviewed and verified all changes myself.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)