### PR TITLE
Enforce Checkstyle and Spotless gates in PR reviews

### DIFF
--- a/.codex/harness/agents/cases.toml
+++ b/.codex/harness/agents/cases.toml
@@ -1853,6 +1853,127 @@ policy_assertions = [{source = "agents", statements = ["Use `Review Incomplete` 
 critical = true
 
 [[cases]]
+id = "public_pr_missing_style_verification_cannot_merge"
+group = "review-pr style verification"
+description = "Prevents a public PR with applicable Java changes from receiving Mergeable before current-candidate Checkstyle and Spotless verification."
+phase = "review-pr mandatory style verification"
+ordinary_loop = true
+profile = "review-pr"
+semantic_policy_assertions = true
+prompt = "A public PR Formal Review changes `module-a/src/main/java/example/Foo.java` and `module-a/src/test/java/example/FooTest.java`. The latest head and authoritative file list are available, and code, test, risk, and convergence review found no issue, but neither Checkstyle nor Spotless has run on this candidate. Complete the Code Correctness Review now without querying CI, editing files, or changing Git or remote state."
+decision = "proceed"
+required_actions = ["inspect_local", "run_local_checks"]
+allowed_actions = ["inspect_local", "run_local_checks", "wrap_high_output"]
+forbidden_actions = ["edit_code", "edit_non_code", "run_pre_handoff_review", "propose_commit_message", "mutate_git", "mutate_remote"]
+required_reasons = []
+required_summary_terms = ["Checkstyle", "Spotless"]
+forbidden_summary_terms = ["Review Result: Mergeable"]
+policy_binding_profile = "review-pr"
+policy_assertions = [{source = "review-pr", statements = ["Apply this gate to every Formal Review of a public PR and every PR-backed local candidate.", "This gate is local candidate verification rather than a GitHub CI query, so every Review Focus must complete it even when Code Correctness Review does not read GitHub Actions, checks, workflow runs, or Actions logs.", "Treat production and test Java files as applicable to both Checkstyle and Spotless unless repository configuration proves that a check does not govern a file.", "Only successful current-candidate evidence for both checks, or an explicit not-applicable determination for either check, permits the remaining Formal Decision Contract to select `Mergeable`."]}, {source = "review-pr-evidence", statements = ["Read `Local Style Verification Evidence` for every Formal Review of a public PR or PR-backed local candidate, even when no CI or Actions evidence is requested.", "Keep review read-only by using `spotless:check`; never run `spotless:apply` or another file-modifying formatter."]}]
+critical = true
+
+[[cases]]
+id = "public_pr_spotless_failure_not_mergeable"
+group = "review-pr style verification"
+description = "Maps a Spotless failure on a PR-added Java file to Not Mergeable and Change Request."
+phase = "review-pr mandatory style verification"
+ordinary_loop = true
+profile = "review-pr"
+semantic_policy_assertions = true
+prompt = "A public PR Formal Review is complete on latest head `spot123`. Checkstyle passes, but `spotless:check` exits 1 on the PR-added Java file `module-a/src/main/java/example/Foo.java` because of indentation. All other review work found no issue. Return the Code Correctness Review result without editing, rerunning checks, querying CI, or changing Git or remote state."
+decision = "proceed"
+required_actions = []
+allowed_actions = ["inspect_local", "run_bounded_adversarial_review"]
+forbidden_actions = ["edit_code", "edit_non_code", "run_local_checks", "run_pre_handoff_review", "propose_commit_message", "mutate_git", "mutate_remote"]
+required_reasons = []
+required_summary_terms = ["### Result", "Review Result: Not Mergeable", "Feedback Mode", "Change Request", "Blocking Issues", "Spotless", "### Coverage", "spot123", "exit"]
+forbidden_summary_terms = ["Review Result: Mergeable", "Review Result: Review Incomplete"]
+policy_binding_profile = "review-pr"
+policy_assertions = [{source = "review-pr", statements = ["If Checkstyle or Spotless fails on an applicable PR-impact file, return `Not Mergeable` with `Feedback Mode: Change Request`.", "A style-check failure result must include `Feedback Mode: Change Request` and the blocking-issue count in `### Result`, then identify each failed check and affected PR-impact file in `### Blocking Issues`.", "A style-check failure result must also include `### Coverage` with the effective candidate SHA, authoritative files accounted for, failed command, exit code, and affected PR-impact file.", "If Checkstyle or Spotless fails on an applicable PR-impact file, use `Not Mergeable` with `Feedback Mode: Change Request`."]}, {source = "review-pr-evidence", statements = ["Attribute a Checkstyle or Spotless failure to the PR when the failing path is a PR-impact file governed by that check."]}]
+critical = true
+
+[[cases]]
+id = "public_pr_checkstyle_failure_not_mergeable"
+group = "review-pr style verification"
+description = "Maps a Checkstyle failure on a PR-modified Java file to Not Mergeable and Change Request."
+phase = "review-pr mandatory style verification"
+ordinary_loop = true
+profile = "review-pr"
+semantic_policy_assertions = true
+prompt = "A public PR Formal Review is complete on latest head `check123`. Spotless passes and all tests pass, but `checkstyle:check` exits 1 on the PR-modified Java file `module-a/src/test/java/example/FooTest.java`. All other review work found no issue. Return the Code Correctness Review result without editing, rerunning checks, querying CI, or changing Git or remote state."
+decision = "proceed"
+required_actions = []
+allowed_actions = ["inspect_local", "run_bounded_adversarial_review"]
+forbidden_actions = ["edit_code", "edit_non_code", "run_local_checks", "run_pre_handoff_review", "propose_commit_message", "mutate_git", "mutate_remote"]
+required_reasons = []
+required_summary_terms = ["### Result", "Review Result: Not Mergeable", "Feedback Mode", "Change Request", "Blocking Issues", "Checkstyle", "### Coverage", "check123", "exit"]
+forbidden_summary_terms = ["Review Result: Mergeable", "Review Result: Review Incomplete"]
+policy_binding_profile = "review-pr"
+policy_assertions = [{source = "review-pr", statements = ["If Checkstyle or Spotless fails on an applicable PR-impact file, return `Not Mergeable` with `Feedback Mode: Change Request`.", "A style-check failure result must include `Feedback Mode: Change Request` and the blocking-issue count in `### Result`, then identify each failed check and affected PR-impact file in `### Blocking Issues`.", "A style-check failure result must also include `### Coverage` with the effective candidate SHA, authoritative files accounted for, failed command, exit code, and affected PR-impact file.", "If Checkstyle or Spotless fails on an applicable PR-impact file, use `Not Mergeable` with `Feedback Mode: Change Request`."]}, {source = "review-pr-evidence", statements = ["Attribute a Checkstyle or Spotless failure to the PR when the failing path is a PR-impact file governed by that check."]}]
+critical = true
+
+[[cases]]
+id = "public_pr_complete_module_style_checks_satisfy_gate"
+group = "review-pr style verification"
+description = "Accepts complete affected-module Checkstyle and Spotless evidence without requiring duplicate whole-repository checks."
+phase = "review-pr mandatory style verification"
+ordinary_loop = true
+profile = "review-pr"
+semantic_policy_assertions = true
+prompt = "A public PR at head `abc123` changes only `module-a/src/main/java/example/Foo.java` and `module-a/src/test/java/example/FooTest.java`. The authoritative inventory proves both files belong only to Maven module `module-a`; module-scoped `checkstyle:check` and `spotless:check` selected both files and each exited 0. All other Formal Review gates are complete with no finding or gap. Return the Code Correctness Review result and Coverage without querying CI, rerunning whole-repository checks, editing, or changing Git or remote state."
+decision = "proceed"
+required_actions = []
+allowed_actions = ["inspect_local", "run_bounded_adversarial_review"]
+forbidden_actions = ["edit_code", "edit_non_code", "run_local_checks", "run_pre_handoff_review", "propose_commit_message", "mutate_git", "mutate_remote"]
+required_reasons = []
+required_summary_terms = ["### Result", "Review Result: Mergeable", "### Evidence", "### Coverage", "abc123", "module-a", "checkstyle:check", "spotless:check", "exit", "Foo.java", "FooTest.java"]
+forbidden_summary_terms = ["Review Result: Not Mergeable", "Review Result: Review Incomplete"]
+policy_binding_profile = "review-pr"
+policy_assertions = [{source = "review-pr", statements = ["Use a whole-repository check, complete affected-module checks, or an exact-file check only when the command output and file inventory prove that the selected scope covers every applicable PR-impact file.", "Only successful current-candidate evidence for both checks, or an explicit not-applicable determination for either check, permits the remaining Formal Decision Contract to select `Mergeable`."]}, {source = "review-pr-evidence", statements = ["Run `checkstyle:check` and `spotless:check` over the whole repository, every complete affected module, or a reliable exact-file scope that covers the inventory.", "Treat a zero exit code without selection proof as inconclusive, including when a filter matches no intended file."]}]
+critical = true
+
+[[cases]]
+id = "public_pr_new_head_invalidates_style_evidence"
+group = "review-pr style verification"
+description = "Requires Checkstyle and Spotless to rerun after a new public PR head invalidates old evidence."
+phase = "review-pr mandatory style verification"
+ordinary_loop = true
+profile = "review-pr"
+semantic_policy_assertions = true
+prompt = "Checkstyle and Spotless passed for public PR head `aaa111`. The PR then added a commit, and the latest authoritative head is now `bbb222`; the accurate new candidate is available and the remaining review found no issue. Complete the Code Correctness Review without querying CI, editing, or changing Git or remote state."
+decision = "proceed"
+required_actions = ["inspect_local", "run_local_checks"]
+allowed_actions = ["inspect_local", "run_local_checks", "wrap_high_output"]
+forbidden_actions = ["edit_code", "edit_non_code", "run_pre_handoff_review", "propose_commit_message", "mutate_git", "mutate_remote"]
+required_reasons = []
+required_summary_terms = ["bbb222", "Checkstyle", "Spotless"]
+forbidden_summary_terms = ["Review Result: Mergeable"]
+policy_binding_profile = "review-pr"
+policy_assertions = [{source = "review-pr", statements = ["Invalidate all prior Checkstyle and Spotless evidence immediately when the public PR head or authorized local delta changes."]}, {source = "review-pr-evidence", statements = ["Record the effective candidate SHA before each command and invalidate both Checkstyle and Spotless results when the public head or authorized local delta changes.", "Passing GitHub Actions, required checks, commit statuses, PR comments, or results from an older candidate neither satisfy nor waive this local evidence requirement."]}]
+critical = true
+
+[[cases]]
+id = "public_pr_unchanged_style_failure_is_not_pr_blocker"
+group = "review-pr style verification"
+description = "Keeps an unchanged-file historical failure from blocking a PR after all applicable PR-impact files pass reliable exact checks."
+phase = "review-pr mandatory style verification"
+ordinary_loop = true
+profile = "review-pr"
+semantic_policy_assertions = true
+prompt = "A module check for a public PR fails only on unchanged `module-a/src/main/java/example/Legacy.java`. The exact base and effective candidate fail on that same unchanged file. Reliable exact-file `checkstyle:check` and `spotless:check` selected the PR-modified `module-a/src/main/java/example/Foo.java` and every other applicable PR-impact file, and both commands exited 0. All other Formal Review gates are complete with no finding or gap. Return the Code Correctness Review result without querying CI, rerunning checks, editing, or changing Git or remote state."
+decision = "proceed"
+required_actions = []
+allowed_actions = ["inspect_local", "run_bounded_adversarial_review"]
+forbidden_actions = ["edit_code", "edit_non_code", "run_local_checks", "run_pre_handoff_review", "propose_commit_message", "mutate_git", "mutate_remote"]
+required_reasons = []
+required_summary_terms = ["### Result", "Review Result: Mergeable", "### Evidence", "### Coverage", "Legacy.java", "Checkstyle", "Spotless", "Foo.java"]
+required_summary_term_groups = [["pre-existing", "historical", "baseline"]]
+forbidden_summary_terms = ["Review Result: Not Mergeable", "Review Result: Review Incomplete"]
+policy_binding_profile = "review-pr"
+policy_assertions = [{source = "review-pr", statements = ["If a module-scoped command fails only on unchanged files, narrow the check reliably or compare the base and effective candidate before attribution; do not classify the PR from that module failure alone."]}, {source = "review-pr-evidence", statements = ["When a module check fails only on unchanged files, use a reliable narrower scope or compare the same scope on the exact base and effective candidate before classifying the PR.", "If the exact base and effective candidate fail on the same unchanged file, record a pre-existing issue but still obtain separate passing evidence for every applicable PR-impact file."]}]
+critical = true
+
+[[cases]]
 id = "layered_response_when_details_needed"
 group = "operations"
 description = "Separates a concise answer from necessary requested detail."

--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -114,11 +114,10 @@ context, relevant earlier review, and affected production or test paths. Fetch
 the complete file list when scope is disputed or the reply changes an overall
 readiness conclusion.
 
-Before the first GitHub request, read and complete `GitHub Access Preflight` in
-[evidence-access.md](references/evidence-access.md). Do not invoke a browser,
-search, connector, `gh`, or anonymous HTTP route before the preflight selects
-the read route. Read the remaining reference whenever CI, Actions, or
-third-party behavior evidence is required.
+Before the first GitHub request, read and complete `GitHub Access Preflight` in [evidence-access.md](references/evidence-access.md).
+Do not invoke a browser, search, connector, `gh`, or anonymous HTTP route before the preflight selects the read route.
+Read `Local Style Verification Evidence` in that reference for every public-PR or PR-backed local-candidate Formal Review, regardless of Review Focus.
+Read the remaining reference whenever CI, Actions, or third-party behavior evidence is required.
 
 AI-assistance disclosure is a mergeability concern, not a code-correctness
 signal. In Mergeability Review or an explicit policy-compliance review, apply
@@ -127,6 +126,31 @@ assistance. Verify that the PR description names the tool and affected files or
 scope. Never infer AI use from code, prose style, metadata, or an automated
 classifier; without explicit public evidence, missing disclosure is neither a
 finding nor an evidence gap.
+
+## Mandatory Style Verification Gate
+
+Apply this gate to every Formal Review of a public PR and every PR-backed local candidate.
+This gate is local candidate verification rather than a GitHub CI query, so every Review Focus must complete it even when Code Correctness Review does not read GitHub Actions, checks, workflow runs, or Actions logs.
+
+1. Derive the applicable PR-impact files and their owning Maven modules from the authoritative changed-file list for the effective candidate.
+2. Treat production and test Java files as applicable to both Checkstyle and Spotless unless repository configuration proves that a check does not govern a file.
+3. Run both checks against the latest public PR head or an accurate PR-backed local candidate that contains the latest public head and only its authorized local delta.
+4. Invalidate all prior Checkstyle and Spotless evidence immediately when the public PR head or authorized local delta changes.
+5. Use a whole-repository check, complete affected-module checks, or an exact-file check only when the command output and file inventory prove that the selected scope covers every applicable PR-impact file.
+6. Expand verification to the complete rule impact, normally the whole repository, when the PR changes global Checkstyle or Spotless configuration, a parent POM, or another cross-module style rule.
+7. Treat an exit code of zero as passing evidence only when the output also proves that every applicable PR-impact file was selected; a successful command that matched no intended file is not evidence.
+8. Do not use passing CI, required checks, commit statuses, a PR comment summary, or evidence from an older candidate to satisfy or waive this gate.
+9. Do not run `spotless:apply` or another file-modifying formatter during review.
+
+Map the gate result before applying the remaining Formal Decision Contract.
+
+- If Checkstyle or Spotless fails on an applicable PR-impact file, return `Not Mergeable` with `Feedback Mode: Change Request`.
+- A style-check failure result must include `Feedback Mode: Change Request` and the blocking-issue count in `### Result`, then identify each failed check and affected PR-impact file in `### Blocking Issues`.
+- A style-check failure result must also include `### Coverage` with the effective candidate SHA, authoritative files accounted for, failed command, exit code, and affected PR-impact file.
+- If environment, dependency, candidate-materialization, tool, or coverage-proof failure leaves any applicable PR-impact file unverified, return `Review Incomplete`.
+- If a module-scoped command fails only on unchanged files, narrow the check reliably or compare the base and effective candidate before attribution; do not classify the PR from that module failure alone.
+- If a check has no applicable PR-impact file, record `Not Applicable` and the repository-configuration basis in `### Coverage`.
+- Only successful current-candidate evidence for both checks, or an explicit not-applicable determination for either check, permits the remaining Formal Decision Contract to select `Mergeable`.
 
 ## Finding Proof Gate
 
@@ -206,9 +230,10 @@ a previous result to influence the assessment:
      documentation, rollout, and rollback.
 5. Apply the Finding Proof Gate to every candidate. Keep discovery notes
    private and classify every candidate before publication.
-6. Consolidate confirmed findings by independent fix boundary and identify any
+6. Complete the Mandatory Style Verification Gate for a public PR or PR-backed local candidate.
+7. Consolidate confirmed findings by independent fix boundary and identify any
    evidence or coverage gap that could still change the blocker set.
-7. Review the latest delta and run a full-scope convergence pass after the most
+8. Review the latest delta and run a full-scope convergence pass after the most
    recent candidate change. If it finds a new independent candidate, return to
    step 5 and repeat. Freeze the canonical assessment only after the Completion
    Gate evaluation, then map it to the selected mode's status.
@@ -225,6 +250,7 @@ readiness conclusion.
 - Complete the behavior-cluster mapping and risk triage for every authoritative
   file; classify churn-only files explicitly.
 - Finish all three discovery lenses and classify every candidate.
+- Complete the Mandatory Style Verification Gate against the latest effective candidate for every public PR or PR-backed local candidate.
 - Leave no unresolved evidence or coverage gap that could change the blocker
   set.
 - Require a full-scope convergence pass after the latest candidate change with
@@ -250,12 +276,14 @@ Map the canonical assessment to Formal Review only after the Completion Gate
 evaluation:
 
 1. If the gate fails because a gap satisfies the Review Incomplete Proof Gate, use `Review Incomplete`, even when some blockers are already confirmed.
-2. If admissible evidence disproves the problem model, expected behavior, ownership,
+2. If the Mandatory Style Verification Gate is incomplete for any applicable PR-impact file, use `Review Incomplete`, even when some blockers are already confirmed.
+3. If Checkstyle or Spotless fails on an applicable PR-impact file, use `Not Mergeable` with `Feedback Mode: Change Request`.
+4. If admissible evidence disproves the problem model, expected behavior, ownership,
    protocol or SQL semantics, compatibility assumption, or solution direction,
    use `Not Mergeable` with `Feedback Mode: Needs Discussion`.
-3. If at least one candidate passes the Finding Proof Gate, use `Not Mergeable`
+5. If at least one candidate passes the Finding Proof Gate, use `Not Mergeable`
    with `Feedback Mode: Change Request`.
-4. Otherwise use `Mergeable` for the selected focus.
+6. Otherwise use `Mergeable` for the selected focus.
 
 `Mergeable` in Code Correctness Review means code-scope readiness only. Required
 pending CI prevents Mergeable in Mergeability Review. A relevant CI failure is
@@ -318,7 +346,12 @@ For each blocking issue include:
 - `Required Change` for Change Request, or `Discussion Needed` for Needs
   Discussion.
 
-Do not add patch-level changes after selecting Needs Discussion. Do not include placeholder headings. In `### Coverage`, report the candidate type, reviewed baseline or head, authoritative requirements and files accounted for, behavior clusters, completed discovery lenses, unresolved gaps, and CI scope. For a standalone local candidate, identify the task baseline and attributed local delta; for a PR-backed candidate, identify authorized local commits, index changes, or working-tree changes separately from the public PR state. In Code Correctness Review, state that the result is code-scope only and CI was not reviewed.
+Do not add patch-level changes after selecting Needs Discussion.
+Do not include placeholder headings.
+In `### Coverage`, report the candidate type, reviewed baseline or head, authoritative requirements and files accounted for, behavior clusters, completed discovery lenses, unresolved gaps, and CI scope.
+For every public PR or PR-backed local candidate, also report the effective candidate SHA, each style-verification scope and command, each exit code, every covered applicable PR-impact file, and every `Not Applicable` check with its basis.
+For a standalone local candidate, identify the task baseline and attributed local delta; for a PR-backed candidate, identify authorized local commits, index changes, or working-tree changes separately from the public PR state.
+In Code Correctness Review, state that the result is code-scope only and CI was not reviewed while distinguishing the completed local style verification from CI.
 
 ### PR Discussion Reply
 

--- a/.codex/skills/review-pr/references/evidence-access.md
+++ b/.codex/skills/review-pr/references/evidence-access.md
@@ -17,9 +17,8 @@
 
 # Evidence Access
 
-Read this reference when a Formal Review of a public PR or local candidate,
-or a PR Discussion Reply requires current GitHub facts, or when
-the selected review focus requires CI or Actions evidence.
+Read this reference when a Formal Review of a public PR or local candidate, or a PR Discussion Reply requires current GitHub facts, or when the selected review focus requires CI or Actions evidence.
+Read `Local Style Verification Evidence` for every Formal Review of a public PR or PR-backed local candidate, even when no CI or Actions evidence is requested.
 
 ## Public and Authorized Evidence Boundary
 
@@ -84,6 +83,43 @@ For discussion replies, record the latest public head and fetch the complete
 thread, relevant prior review, and affected paths. Fetch the authoritative
 changed-file list when scope is disputed or the reply changes a formal
 readiness conclusion.
+
+## Local Style Verification Evidence
+
+Use this section to satisfy the Mandatory Style Verification Gate independently of GitHub CI state.
+
+### Candidate Identity and Freshness
+
+- Prefer a local commit that exactly equals the latest public PR head, an accurate PR-backed local candidate, or a temporary read-only snapshot materialized from the exact public head.
+- For a PR-backed local candidate, verify that it contains the latest public head and only the authorized local delta used by the Formal Review.
+- Do not produce passing evidence from a stale checkout, a base-only workspace, or a workspace containing unattributed changes that can affect the checks.
+- Record the effective candidate SHA before each command and invalidate both Checkstyle and Spotless results when the public head or authorized local delta changes.
+- If the latest public head is unavailable locally, do not fetch, checkout, switch, merge, reset, or perform another Git write without exact user authorization.
+- Use an allowed read-only temporary snapshot route when it can materialize the exact head; return `Review Incomplete` when every allowed route fails to produce an accurate candidate.
+
+### Applicable Files and Verification Scope
+
+1. Start from the authoritative changed-file list and classify every PR-impact file as governed by Checkstyle, Spotless, both, or neither under the repository configuration.
+2. Resolve the owning Maven module for every applicable file and retain an explicit file-to-module inventory.
+3. Run `checkstyle:check` and `spotless:check` over the whole repository, every complete affected module, or a reliable exact-file scope that covers the inventory.
+4. Use an exact-file filter only when the Maven plugin supports it reliably and the command output plus the inventory prove that every intended file was selected.
+5. Expand to the complete affected rule scope, normally the whole repository, when a changed global style configuration, parent POM, or cross-module rule can govern files outside the directly changed modules.
+6. Treat a zero exit code without selection proof as inconclusive, including when a filter matches no intended file.
+7. Keep review read-only by using `spotless:check`; never run `spotless:apply` or another file-modifying formatter.
+
+### Failure Attribution
+
+- Attribute a Checkstyle or Spotless failure to the PR when the failing path is a PR-impact file governed by that check.
+- When a module check fails only on unchanged files, use a reliable narrower scope or compare the same scope on the exact base and effective candidate before classifying the PR.
+- If the exact base passes and the effective candidate fails, attribute the newly observed failure to the PR and identify the affected file.
+- If the exact base and effective candidate fail on the same unchanged file, record a pre-existing issue but still obtain separate passing evidence for every applicable PR-impact file.
+- If no allowed method can distinguish an unchanged-file failure from the PR-impact files, return `Review Incomplete` instead of a false blocker or a false pass.
+
+### Sanitized Verification Summary
+
+Record the effective candidate SHA, authoritative applicable-file inventory, verification scope, Maven module set, exact commands, exit codes, covered PR-impact files, decisive failure paths, and every not-applicable determination with its repository-configuration basis.
+Keep raw high-volume output in the local log required by the repository command-execution rules and expose only a sanitized summary.
+Passing GitHub Actions, required checks, commit statuses, PR comments, or results from an older candidate neither satisfy nor waive this local evidence requirement.
 
 ## CI and Actions
 


### PR DESCRIPTION
## Purpose

Prevent the `review-pr` skill from returning a `Mergeable` recommendation for a public PR or PR-backed local candidate before all applicable changed files have passed current-candidate Checkstyle and Spotless verification.

## Changes

- Add a mandatory local style-verification gate to every public-PR and PR-backed local-candidate Formal Review, regardless of Review Focus.
- Require both Checkstyle and Spotless evidence for the latest effective candidate before a review can return `Mergeable`.
- Derive applicable files and owning Maven modules from the authoritative changed-file inventory.
- Accept whole-repository, complete affected-module, or reliable exact-file verification only when the evidence proves that every applicable PR-impact file was selected.
- Invalidate previous style-verification evidence whenever the public PR head or authorized local delta changes.
- Expand verification to the complete rule scope when global style configuration, a parent POM, or another cross-module rule changes.
- Map Checkstyle or Spotless failures on PR-impact files to `Review Result: Not Mergeable` with `Feedback Mode: Change Request`.
- Map missing, stale, or inconclusive style evidence to `Review Result: Review Incomplete`.
- Distinguish failures on unchanged files from failures introduced by the PR through narrower checks or exact base/candidate comparison.
- Prohibit file-modifying formatters such as `spotless:apply` during review.
- Require the Formal Review coverage report to include the candidate SHA, verification scope, commands, exit codes, and covered files.
- Add six critical synthetic policy cases covering:
  - missing style verification;
  - Spotless failures;
  - Checkstyle failures;
  - complete affected-module verification;
  - stale evidence after a new PR head;
  - pre-existing failures on unchanged files.

## Verification

- Deterministic policy manifest and binding validation passed with no source or binding regressions.
- All six newly added style-verification policy cases passed.
- The recorded isolated V0-to-candidate comparison for this PR completed with no critical regressions:
  - baseline: 128 of 140 cases passed;
  - candidate: 140 of 146 cases passed;
  - critical regressions: none.
- The policy harness test suite passed: 65 tests.
- Apache RAT passed with no unapproved or unknown licenses.
- `git diff --check` passed.
- Checkstyle and Spotless are not directly applicable to the changed Markdown and TOML policy files under the current repository configuration.
- The current GitHub `Check - License`, `Check - Spotless`, and `Check - CheckStyle` jobs succeeded.
- The isolated evaluation received only canonical policy text and synthetic policy cases; no project source, private logs, credentials, or conversation content was transmitted.

## AI Assistance

OpenAI Codex materially assisted with drafting, reviewing, and validating the changes to:

- `.codex/skills/review-pr/SKILL.md`
- `.codex/skills/review-pr/references/evidence-access.md`
- `.codex/harness/agents/c Lashcases.toml`

The contributor reviewed and validated the final changes and remains responsible for their correctness, scope, and compliance with project policy.

## Files Changed

- `.codex/skills/review-pr/SKILL.md`
- `.codex/skills/review-pr/references/evidence-access.md`
- `.codex/harness/одаряagents/cases.toml`