### PR TITLE
Define Java declaration annotation order

### DIFF
--- a/.codex/harness/agents/cases.toml
+++ b/.codex/harness/agents/cases.toml
@@ -2364,3 +2364,42 @@ forbidden_summary_terms = ["Strictly compliant"]
 policy_binding_profile = "coding-standards-audit"
 policy_assertions = [{source = "coding-standards", statements = ["When the scope contains Java `throw` statements, conditional exception paths, validation or precondition calls, or calls to `ShardingSpherePreconditions`, read the [Java precondition rules](references/rules/java-preconditions.md) through EOF.", "Remain read-only throughout the audit.", "Check every constrained file and every physical line in scope without sampling."]}, {source = "standalone-audit", statements = ["An existing-code violation of an applicable written standard is sufficient to report non-compliance."]}, {source = "java-preconditions", statements = ["When a conditional branch does nothing except construct and throw an exception because a required condition is false, replace the branch with the equivalent `ShardingSpherePreconditions` call if the module can use `infra/exception` and the replacement preserves behavior.", "Replace `checkState(values.isEmpty(), supplier)` and `checkState(map.isEmpty(), supplier)` with the applicable `checkMustEmpty` overload.", "Replace `checkState(values.contains(element), supplier)` with `checkContains(values, element, supplier)`.", "Replace `checkState(!values.contains(element), supplier)` with `checkNotContains(values, element, supplier)`.", "Replace `checkState(map.containsKey(key), supplier)` with `checkContainsKey(map, key, supplier)`.", "Keep a direct throw for an unconditional failure, exception translation, exception wrapping, rethrowing, or a test double or fixture that deliberately simulates a failure."]}]
 critical = true
+
+[[cases]]
+id = "java_annotation_order_is_relative_and_declaration_scoped"
+group = "coding / regular"
+description = "Orders only recognized declaration annotations while preserving unrecognized and type-use annotations."
+phase = "coding-standards final check and ordinary completion loop"
+ordinary_loop = true
+profile = "code-write"
+semantic_policy_assertions = true
+prompt = "Continue an authorized in-scope Java implementation. A changed type declares `@Slf4j`, `@JsonDeserialize`, `@HighFrequencyInvocation`, `@Getter`, and `@RequiredArgsConstructor` in that order; a changed field declares `@Setter`, `@JsonProperty`, `@HighFrequencyInvocation`, and `@Getter`; and a changed method declares `@Builder`, `@Transactional`, and `@HighFrequencyInvocation`. State the corrected recognized subsequence for each declaration, then correct only the covered declaration-annotation order, preserve the position of each unrecognized annotation, leave Java modifiers and `final @Nullable String` `TYPE_USE` placement to their own rules, run affected checks and Formal Review, and do not change annotation semantics or unrelated code."
+decision = "proceed"
+required_actions = ["edit_code", "run_local_checks", "run_pre_handoff_review"]
+allowed_actions = ["inspect_local", "edit_code", "run_local_checks", "wrap_high_output", "run_pre_handoff_review", "fix_review_findings"]
+forbidden_actions = ["edit_non_code", "edit_unrelated_changes", "propose_commit_message", "mutate_git", "mutate_remote"]
+required_reasons = ["pre_handoff_review_required"]
+required_summary_terms = ["HighFrequencyInvocation", "RequiredArgsConstructor", "Getter", "Setter", "Builder", "Slf4j", "unrecognized", "TYPE_USE"]
+policy_binding_profile = "code-write"
+policy_assertions = [{source = "coding-standards", statements = ["Before adding, changing, or reordering a covered declaration annotation, or when a Java declaration added or modified by the task contains at least two covered annotations, read the [Java declaration annotation order rules](references/rules/java-annotation-order.md) through EOF and add each applicable rule to the checklist.", "For Java, explicitly verify every applicable Java declaration annotation order rule against each declaration added or modified by the task."]}, {source = "java-annotation-order", statements = ["The canonical relative order is `org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation`, `lombok.AllArgsConstructor`, `lombok.RequiredArgsConstructor`, `lombok.NoArgsConstructor`, `lombok.Builder`, `lombok.Getter`, `lombok.Setter`, `lombok.EqualsAndHashCode`, `lombok.ToString`, and `lombok.extern.slf4j.Slf4j`.", "Filter the declaration's annotations to the recognized fully qualified types and report a violation only when that filtered sequence is not in canonical order.", "Annotations outside the canonical list may remain before, between, or after recognized annotations and do not need to be contiguous with them.", "A declaration annotation annotates the declaration itself, while a `TYPE_USE` annotation annotates a use of a type and does not participate in this rule.", "This rule governs only the position of `HighFrequencyInvocation`; do not infer, add, remove, or validate high-frequency scope, cacheability, or performance behavior from this file."]}]
+critical = true
+
+[[cases]]
+id = "standalone_coding_standards_audits_java_annotation_order"
+group = "policy routing"
+description = "Audits relative declaration-annotation order without treating unrelated annotations as ordering barriers."
+phase = "standalone coding-standards audit"
+ordinary_loop = false
+profile = "coding-standards-audit"
+semantic_policy_assertions = true
+prompt = "Audit the complete current-working-tree file `module-a/src/main/java/example/AnnotatedType.java` without editing it. Its type annotations are `@Slf4j`, `@JsonDeserialize`, `@HighFrequencyInvocation`, `@Getter`, and `@RequiredArgsConstructor`; its field has a valid `final @Nullable String` type-use annotation; and its test method has `@Test` and `@ParameterizedTest`. Report `Non-compliant`, give the minimum relative-order correction for only the four recognized type declaration annotations, allow `@JsonDeserialize` to remain between them, and do not report the type-use or test-framework annotations as part of this order. Do not generate a patch."
+decision = "proceed"
+required_actions = ["inspect_local"]
+allowed_actions = ["inspect_local"]
+forbidden_actions = ["edit_code", "edit_non_code", "run_local_checks", "run_pre_handoff_review", "propose_commit_message", "mutate_git", "mutate_remote"]
+required_reasons = ["read_only_request"]
+required_summary_terms = ["Non-compliant", "HighFrequencyInvocation", "RequiredArgsConstructor", "Getter", "Slf4j", "JsonDeserialize", "TYPE_USE", "Test", "ParameterizedTest"]
+forbidden_summary_terms = ["Strictly compliant"]
+policy_binding_profile = "coding-standards-audit"
+policy_assertions = [{source = "coding-standards", statements = ["When the scope contains a Java declaration with at least two covered declaration annotations, read the [Java declaration annotation order rules](references/rules/java-annotation-order.md) through EOF.", "Remain read-only throughout the audit.", "Check every constrained file and every physical line in scope without sampling."]}, {source = "standalone-audit", statements = ["An existing-code violation of an applicable written standard is sufficient to report non-compliance."]}, {source = "java-annotation-order", statements = ["The canonical relative order is `org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation`, `lombok.AllArgsConstructor`, `lombok.RequiredArgsConstructor`, `lombok.NoArgsConstructor`, `lombok.Builder`, `lombok.Getter`, `lombok.Setter`, `lombok.EqualsAndHashCode`, `lombok.ToString`, and `lombok.extern.slf4j.Slf4j`.", "Filter the declaration's annotations to the recognized fully qualified types and report a violation only when that filtered sequence is not in canonical order.", "Test-framework, dependency-injection, framework, and serialization annotations are outside this order unless their fully qualified type appears in the canonical list.", "A declaration annotation annotates the declaration itself, while a `TYPE_USE` annotation annotates a use of a type and does not participate in this rule."]}]
+critical = true

--- a/.codex/harness/agents/policy-sources.toml
+++ b/.codex/harness/agents/policy-sources.toml
@@ -18,16 +18,16 @@ root_max_bytes = 26000
 
 [profiles]
 root = ["agents"]
-code-write = ["agents", "code-of-conduct", "code-implementation", "coding-standards", "java-naming", "java-types", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification", "change-completion"]
-test-write = ["agents", "code-of-conduct", "code-implementation", "coding-standards", "java-naming", "java-types", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification", "change-completion"]
-code-review = ["agents", "code-of-conduct", "coding-standards", "java-naming", "java-types", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification"]
+code-write = ["agents", "code-of-conduct", "code-implementation", "coding-standards", "java-naming", "java-types", "java-annotation-order", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification", "change-completion"]
+test-write = ["agents", "code-of-conduct", "code-implementation", "coding-standards", "java-naming", "java-types", "java-annotation-order", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification", "change-completion"]
+code-review = ["agents", "code-of-conduct", "coding-standards", "java-naming", "java-types", "java-annotation-order", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification"]
 code-design = ["agents", "implementation-rules", "java-collections", "testing-rules", "contracts-and-removal", "cross-cutting-skills"]
-coding-standards-audit = ["agents", "code-of-conduct", "coding-standards", "standalone-audit", "java-naming", "java-types", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code"]
+coding-standards-audit = ["agents", "code-of-conduct", "coding-standards", "standalone-audit", "java-naming", "java-types", "java-annotation-order", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code"]
 runtime-diagnosis = ["agents", "runtime-triage", "code-verification"]
 command-execution = ["agents", "token-efficiency", "code-verification"]
 cross-cutting = ["agents", "cross-cutting-skills"]
-gen-ut = ["agents", "code-of-conduct", "code-implementation", "coding-standards", "java-naming", "java-types", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification", "gen-ut", "gen-ut-verification", "change-completion"]
-review-pr = ["agents", "code-of-conduct", "coding-standards", "java-naming", "java-types", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification", "review-pr", "review-pr-evidence", "review-pr-high-risk", "review-pr-sql-parser", "review-pr-corrections"]
+gen-ut = ["agents", "code-of-conduct", "code-implementation", "coding-standards", "java-naming", "java-types", "java-annotation-order", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification", "gen-ut", "gen-ut-verification", "change-completion"]
+review-pr = ["agents", "code-of-conduct", "coding-standards", "java-naming", "java-types", "java-annotation-order", "java-constructors", "java-preconditions", "java-exceptions", "java-collections", "java-expressions", "java-line-wrapping", "java-testing", "defensive-code", "implementation-rules", "testing-rules", "contracts-and-removal", "non-regression", "code-verification", "review-pr", "review-pr-evidence", "review-pr-high-risk", "review-pr-sql-parser", "review-pr-corrections"]
 policy-maintenance = ["agents", "policy-maintenance", "policy-source-manifest"]
 
 [[sources]]
@@ -126,7 +126,7 @@ id = "coding-standards"
 path = ".codex/skills/coding-standards/SKILL.md"
 kind = "skill"
 semantic = true
-references = ["AGENTS.md", "CODE_OF_CONDUCT.md", ".codex/skills/coding-standards/references/standalone-audit.md", ".codex/skills/coding-standards/references/rules/java-naming.md", ".codex/skills/coding-standards/references/rules/java-types.md", ".codex/skills/coding-standards/references/rules/java-constructors.md", ".codex/skills/coding-standards/references/rules/java-preconditions.md", ".codex/skills/coding-standards/references/rules/java-exceptions.md", ".codex/skills/coding-standards/references/rules/java-collections.md", ".codex/skills/coding-standards/references/rules/java-expressions.md", ".codex/skills/coding-standards/references/rules/java-line-wrapping.md", ".codex/skills/coding-standards/references/rules/java-testing.md", ".codex/skills/coding-standards/references/rules/defensive-code.md"]
+references = ["AGENTS.md", "CODE_OF_CONDUCT.md", ".codex/skills/coding-standards/references/standalone-audit.md", ".codex/skills/coding-standards/references/rules/java-naming.md", ".codex/skills/coding-standards/references/rules/java-types.md", ".codex/skills/coding-standards/references/rules/java-annotation-order.md", ".codex/skills/coding-standards/references/rules/java-constructors.md", ".codex/skills/coding-standards/references/rules/java-preconditions.md", ".codex/skills/coding-standards/references/rules/java-exceptions.md", ".codex/skills/coding-standards/references/rules/java-collections.md", ".codex/skills/coding-standards/references/rules/java-expressions.md", ".codex/skills/coding-standards/references/rules/java-line-wrapping.md", ".codex/skills/coding-standards/references/rules/java-testing.md", ".codex/skills/coding-standards/references/rules/defensive-code.md"]
 
 [[sources]]
 id = "coding-standards-metadata"
@@ -152,6 +152,13 @@ references = []
 [[sources]]
 id = "java-types"
 path = ".codex/skills/coding-standards/references/rules/java-types.md"
+kind = "rules"
+semantic = true
+references = []
+
+[[sources]]
+id = "java-annotation-order"
+path = ".codex/skills/coding-standards/references/rules/java-annotation-order.md"
 kind = "rules"
 semantic = true
 references = []

--- a/.codex/skills/coding-standards/SKILL.md
+++ b/.codex/skills/coding-standards/SKILL.md
@@ -29,6 +29,7 @@ description: >-
 # Coding Standards
 
 Use this Skill in exactly one of the following modes. Both modes derive compliance only from written standards that actually apply to the target files.
+For routing purposes, covered declaration annotations are `HighFrequencyInvocation`, `AllArgsConstructor`, `RequiredArgsConstructor`, `NoArgsConstructor`, `Builder`, `Getter`, `Setter`, `EqualsAndHashCode`, `ToString`, and `Slf4j`.
 
 ## Implementation Guidance Mode
 
@@ -38,6 +39,7 @@ Use this mode when implementing, fixing, refactoring, or reviewing code unless t
 - Before the first write, record a compact applicable-rule checklist; group files governed by the same rules instead of repeating the checklist.
 - For every affected Java file, read the [Java naming rules](references/rules/java-naming.md) through EOF and add each applicable rule to the checklist.
 - Before adding or changing a Java type declaration or its type-level annotations, read the [Java type rules](references/rules/java-types.md) through EOF and add each applicable rule to the checklist.
+- Before adding, changing, or reordering a covered declaration annotation, or when a Java declaration added or modified by the task contains at least two covered annotations, read the [Java declaration annotation order rules](references/rules/java-annotation-order.md) through EOF and add each applicable rule to the checklist.
 - Before adding, changing, or removing an explicit or generated constructor, or changing an instance field that may alter a generated constructor's signature or behavior, read the [Java constructor rules](references/rules/java-constructors.md) through EOF and add each applicable rule to the checklist.
 - Before adding or changing a Java `throw` statement, a conditional branch that throws, a validation or precondition call, or a call to `ShardingSpherePreconditions`, read the [Java precondition rules](references/rules/java-preconditions.md) through EOF and add each applicable rule to the checklist.
 - Before adding or changing a Java method annotated with `lombok.SneakyThrows` or changing the checked-exception behavior of such a method, read the [Java exception handling rules](references/rules/java-exceptions.md) through EOF and add each applicable rule to the checklist.
@@ -53,6 +55,7 @@ Use this mode when implementing, fixing, refactoring, or reviewing code unless t
 - For Java, explicitly verify every applicable `CODE_OF_CONDUCT.md` coding rule, including declaration order; when a method uses private helpers, verify that those helpers immediately follow the caller and appear in the caller's call order, regardless of the caller's visibility.
 - For Java, explicitly verify every applicable Java naming rule against the effective task delta and the surrounding declarations needed to resolve semantic applicability.
 - For Java, explicitly verify every applicable Java type rule against each type declaration and type-level annotation added or modified by the task.
+- For Java, explicitly verify every applicable Java declaration annotation order rule against each declaration added or modified by the task.
 - For Java, explicitly verify every applicable Java constructor rule against each explicit or generated constructor added, modified, removed, or affected by an instance-field change in the task.
 - For Java, explicitly verify every applicable Java precondition rule against each added or modified exception-throwing condition and precondition call, including whether a specialized `ShardingSpherePreconditions` method can express the condition without changing exception or control-flow semantics.
 - For Java, explicitly verify every applicable Java exception handling rule against each added or modified `lombok.SneakyThrows` annotation and the method bodies, invoked signatures, rethrown values, and contracts needed to resolve its exception types.
@@ -82,6 +85,7 @@ Use this mode only when the user explicitly asks to audit, check, or report codi
 - Read the [standalone compliance audit workflow](references/standalone-audit.md) through EOF.
 - When the scope contains Java, read the [Java naming rules](references/rules/java-naming.md) through EOF.
 - When the scope contains Java, read the [Java type rules](references/rules/java-types.md) through EOF.
+- When the scope contains a Java declaration with at least two covered declaration annotations, read the [Java declaration annotation order rules](references/rules/java-annotation-order.md) through EOF.
 - When the scope contains Java, read the [Java constructor rules](references/rules/java-constructors.md) through EOF.
 - When the scope contains Java `throw` statements, conditional exception paths, validation or precondition calls, or calls to `ShardingSpherePreconditions`, read the [Java precondition rules](references/rules/java-preconditions.md) through EOF.
 - When the scope contains Java methods annotated with `lombok.SneakyThrows`, read the [Java exception handling rules](references/rules/java-exceptions.md) through EOF.

--- a/.codex/skills/coding-standards/references/rules/java-annotation-order.md
+++ b/.codex/skills/coding-standards/references/rules/java-annotation-order.md
@@ -1,0 +1,53 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Java Declaration Annotation Order
+
+Apply these rules when the same Java declaration has at least two annotations from the canonical list below.
+
+## Canonical Relative Order
+
+Resolve annotation types before comparing them.
+The canonical relative order is `org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation`, `lombok.AllArgsConstructor`, `lombok.RequiredArgsConstructor`, `lombok.NoArgsConstructor`, `lombok.Builder`, `lombok.Getter`, `lombok.Setter`, `lombok.EqualsAndHashCode`, `lombok.ToString`, and `lombok.extern.slf4j.Slf4j`.
+
+The order is relative, so a declaration does not need to contain every listed annotation.
+Filter the declaration's annotations to the recognized fully qualified types and report a violation only when that filtered sequence is not in canonical order.
+Do not match an annotation only by its simple name, and do not treat nested annotations such as `lombok.Builder.Default` as the listed `lombok.Builder` annotation.
+
+Annotations outside the canonical list may remain before, between, or after recognized annotations and do not need to be contiguous with them.
+When correcting a violation, reorder only recognized annotations and preserve each unrecognized annotation's position unless another applicable written rule requires a change.
+Test-framework, dependency-injection, framework, and serialization annotations are outside this order unless their fully qualified type appears in the canonical list.
+
+## Declaration Applicability
+
+Use the resolved annotation definition and annotation-processor contract to verify that each annotation supports the concrete declaration before applying the relative order.
+The following declaration groups are the maximum scope of this rule:
+
+- A Java type declaration may use the recognized type-targeted annotations, subject to the concrete Lombok annotation's supported type kinds.
+- A field may participate only through `HighFrequencyInvocation`, `Getter`, and `Setter`.
+- A method may participate only through `HighFrequencyInvocation` and `Builder`.
+- A constructor may participate only through `HighFrequencyInvocation` and `Builder`.
+- A parameter, local variable, catch parameter, lambda parameter, and record component does not participate in this rule.
+
+Do not use this order to permit an annotation on a declaration kind that Java or its annotation processor does not support.
+
+## Syntax and Semantic Boundaries
+
+A declaration annotation annotates the declaration itself, while a `TYPE_USE` annotation annotates a use of a type and does not participate in this rule.
+Java modifiers are not annotations and do not participate in the canonical sequence.
+Use Checkstyle `ModifierOrder` for the syntax-level order between declaration annotations and Java modifiers, and preserve valid `TYPE_USE` placement that Checkstyle intentionally skips.
+This rule governs only the position of `HighFrequencyInvocation`; do not infer, add, remove, or validate high-frequency scope, cacheability, or performance behavior from this file.

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/config/yaml/entity/YamlAdvisorsConfiguration.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/config/yaml/entity/YamlAdvisorsConfiguration.java
@@ -26,8 +26,8 @@ import java.util.LinkedList;
 /**
  * YAML advisors configuration.
  */
-@Setter
 @Getter
+@Setter
 public final class YamlAdvisorsConfiguration {
     
     private Collection<YamlAdvisorConfiguration> advisors = new LinkedList<>();

--- a/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/batch/FirebirdBatchStatement.java
+++ b/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/batch/FirebirdBatchStatement.java
@@ -27,8 +27,8 @@ import java.util.List;
 /**
  * Firebird batch statement metadata.
  */
-@Getter
 @RequiredArgsConstructor
+@Getter
 public final class FirebirdBatchStatement {
     
     private final int statementHandle;

--- a/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/batch/FirebirdParseBatchBlr.java
+++ b/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/batch/FirebirdParseBatchBlr.java
@@ -31,8 +31,8 @@ import java.util.List;
 /**
  * Firebird batch message format parser, port of {@code PARSE_msg_format} / {@code parse_format} from Firebird {@code parser.cpp}.
  */
-@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 public final class FirebirdParseBatchBlr {
     
     private static final int HEADER_LENGTH = 4;
@@ -215,7 +215,7 @@ public final class FirebirdParseBatchBlr {
     }
     
     private static int alignTo(final int value, final int alignment) {
-        return value + alignment - 1 & ~(alignment - 1);
+        return value + alignment - 1 & -alignment;
     }
     
 }

--- a/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/statement/FirebirdBlrRowMetadata.java
+++ b/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/statement/FirebirdBlrRowMetadata.java
@@ -30,8 +30,8 @@ import java.util.List;
 /**
  * Firebird BLR row metadata.
  */
-@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 public final class FirebirdBlrRowMetadata {
     
     private final ByteBuf blr;

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/string/MySQLBinaryString.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/string/MySQLBinaryString.java
@@ -31,8 +31,8 @@ import java.io.Serializable;
  * So this customized class object will be returned on parsing.</p>
  */
 @RequiredArgsConstructor
-@EqualsAndHashCode
 @Getter
+@EqualsAndHashCode
 public final class MySQLBinaryString implements Serializable {
     
     private static final long serialVersionUID = 2448062591593788665L;

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGenerator.java
@@ -50,9 +50,9 @@ import java.util.Optional;
 /**
  * Assignment generator for encrypt.
  */
-@Slf4j
 @HighFrequencyInvocation
 @AllArgsConstructor
+@Slf4j
 public final class EncryptAssignmentTokenGenerator {
     
     private final EncryptRule rule;

--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/segment/strategy/KeyGenerateStrategySegment.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/segment/strategy/KeyGenerateStrategySegment.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 /**
  * Key generate strategy segment.
  */
-@Getter
 @AllArgsConstructor
+@Getter
 public final class KeyGenerateStrategySegment implements DistSQLSegment {
     
     private final String keyGenerateColumn;

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/impl/AggregationDistinctProjection.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/impl/AggregationDistinctProjection.java
@@ -27,8 +27,8 @@ import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.Iden
 /**
  * Aggregation distinct projection.
  */
-@EqualsAndHashCode(callSuper = true)
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public final class AggregationDistinctProjection extends AggregationProjection {
     
     private final int startIndex;

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndex.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndex.java
@@ -42,8 +42,8 @@ import java.util.Optional;
  *
  * @param <T> metadata object type
  */
-@Slf4j
 @RequiredArgsConstructor
+@Slf4j
 public final class IdentifierIndex<T> {
     
     private final DatabaseIdentifierContext databaseIdentifierContext;
@@ -325,8 +325,8 @@ public final class IdentifierIndex<T> {
         return snapshot.getExactValues().toString();
     }
     
-    @Getter(AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter(AccessLevel.PRIVATE)
     private static final class Snapshot<T> {
         
         private static final Snapshot<?> EMPTY = new Snapshot<>(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());

--- a/infra/distsql-handler/src/test/java/org/apache/shardingsphere/distsql/handler/engine/concurrent/fixture/FixtureDistSQLQueryStatement.java
+++ b/infra/distsql-handler/src/test/java/org/apache/shardingsphere/distsql/handler/engine/concurrent/fixture/FixtureDistSQLQueryStatement.java
@@ -25,8 +25,8 @@ import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 /**
  * Fixture DistSQL query statement.
  */
-@Getter
 @AllArgsConstructor
+@Getter
 public final class FixtureDistSQLQueryStatement extends DistSQLStatement {
     
     private final ShardingSphereRule expectedRule;

--- a/infra/distsql-handler/src/test/java/org/apache/shardingsphere/distsql/handler/engine/concurrent/fixture/FixtureDistSQLUpdateStatement.java
+++ b/infra/distsql-handler/src/test/java/org/apache/shardingsphere/distsql/handler/engine/concurrent/fixture/FixtureDistSQLUpdateStatement.java
@@ -25,8 +25,8 @@ import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 /**
  * Fixture DistSQL update statement.
  */
-@Getter
 @AllArgsConstructor
+@Getter
 public final class FixtureDistSQLUpdateStatement extends DistSQLStatement {
     
     private final ShardingSphereRule expectedRule;

--- a/infra/route/core/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/type/unicast/TablelessDataSourceUnicastRouteEngine.java
+++ b/infra/route/core/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/type/unicast/TablelessDataSourceUnicastRouteEngine.java
@@ -33,8 +33,8 @@ import java.util.concurrent.ThreadLocalRandom;
 /**
  * Tableless datasource unicast route engine.
  */
-@RequiredArgsConstructor
 @HighFrequencyInvocation
+@RequiredArgsConstructor
 public final class TablelessDataSourceUnicastRouteEngine implements TablelessRouteEngine {
     
     @Override

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractStatementAdapter.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractStatementAdapter.java
@@ -44,8 +44,8 @@ import java.util.Collection;
 /**
  * Adapter for {@code Statement}.
  */
-@Slf4j
 @Getter
+@Slf4j
 public abstract class AbstractStatementAdapter extends WrapperAdapter implements Statement {
     
     @Getter(AccessLevel.NONE)

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
@@ -50,8 +50,8 @@ import java.util.concurrent.Executor;
 /**
  * ShardingSphere connection.
  */
-@Slf4j
 @HighFrequencyInvocation
+@Slf4j
 public final class ShardingSphereConnection extends AbstractConnectionAdapter {
     
     private final ProcessEngine processEngine = new ProcessEngine();

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/type/StandardPipelineDataSourceConfiguration.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/type/StandardPipelineDataSourceConfiguration.java
@@ -40,8 +40,8 @@ import java.util.Properties;
 /**
  * Pipeline data source configuration for standard JDBC.
  */
-@EqualsAndHashCode(of = "parameter")
 @Getter
+@EqualsAndHashCode(of = "parameter")
 public final class StandardPipelineDataSourceConfiguration implements PipelineDataSourceConfiguration {
     
     public static final String TYPE = "JDBC";

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/position/TableCheckRangePosition.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/position/TableCheckRangePosition.java
@@ -27,8 +27,8 @@ import org.apache.shardingsphere.data.pipeline.core.ingest.position.type.pk.Uniq
 /**
  * Table check range position.
  */
-@RequiredArgsConstructor
 @AllArgsConstructor
+@RequiredArgsConstructor
 @Getter
 @Setter
 @ToString

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/TableInventoryCheckParameter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/TableInventoryCheckParameter.java
@@ -30,8 +30,8 @@ import java.util.List;
 /**
  * Table inventory check parameter.
  */
-@Getter
 @RequiredArgsConstructor
+@Getter
 public final class TableInventoryCheckParameter {
     
     private final String jobId;

--- a/kernel/data-pipeline/dialect/opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/incremental/wal/decode/MppTableData.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/incremental/wal/decode/MppTableData.java
@@ -25,8 +25,8 @@ import org.apache.shardingsphere.infra.util.json.JsonConfiguration;
 /**
  * Mppdb decoding json related class.
  */
-@Setter
 @Getter
+@Setter
 public final class MppTableData implements JsonConfiguration {
     
     @JsonProperty("table_name")

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecorator.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecorator.java
@@ -198,8 +198,8 @@ public final class SingleRuleConfigurationDecorator implements RuleConfiguration
         return SingleRuleConfiguration.class;
     }
     
-    @Getter
     @RequiredArgsConstructor
+    @Getter
     private static class DataNodeClassification {
         
         private final Collection<String> expandDataSources;

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/HttpTransportConfiguration.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/HttpTransportConfiguration.java
@@ -23,8 +23,8 @@ import lombok.Getter;
 /**
  * HTTP transport configuration.
  */
-@Getter
 @AllArgsConstructor
+@Getter
 public final class HttpTransportConfiguration {
     
     private final String bindHost;

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolElicitationFallbackReason.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolElicitationFallbackReason.java
@@ -23,8 +23,8 @@ import lombok.RequiredArgsConstructor;
 /**
  * MCP tool elicitation fallback reason.
  */
-@Getter
 @RequiredArgsConstructor
+@Getter
 public enum MCPToolElicitationFallbackReason {
     
     CLIENT_UNSUPPORTED("client_unsupported", "structured_fallback"),

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
@@ -36,8 +36,8 @@ import java.util.function.Function;
 /**
  * Session attribution resolver.
  */
-@Getter
 @AllArgsConstructor
+@Getter
 public final class SessionAttributionResolver {
     
     private final SessionAttributionSourceConfiguration config;

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/SQLStatementObjectName.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/SQLStatementObjectName.java
@@ -32,8 +32,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
-@EqualsAndHashCode
 @Getter
+@EqualsAndHashCode
 final class SQLStatementObjectName {
     
     private final String objectName;

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/RuntimeDatabaseConfiguration.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/RuntimeDatabaseConfiguration.java
@@ -31,8 +31,8 @@ import java.util.Properties;
 /**
  * Runtime database configuration for one logical database binding.
  */
-@Getter
 @AllArgsConstructor
+@Getter
 public final class RuntimeDatabaseConfiguration {
     
     private final String jdbcUrl;

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/model/MCPColumnMetadata.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/model/MCPColumnMetadata.java
@@ -44,8 +44,8 @@ public final class MCPColumnMetadata {
     /**
      * JDBC column nullability.
      */
-    @Getter
     @RequiredArgsConstructor
+    @Getter
     public enum Nullability {
         
         NULLABLE("nullable"),

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/request/SQLExecutionRequest.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/request/SQLExecutionRequest.java
@@ -26,8 +26,8 @@ import lombok.Getter;
  * <p>The logical database is the only strong execution boundary.
  * The optional schema field is a namespace hint for unqualified object names.</p>
  */
-@Getter
 @AllArgsConstructor
+@Getter
 public final class SQLExecutionRequest {
     
     private final String sessionId;

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/RuleWorkflowFeatureData.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/RuleWorkflowFeatureData.java
@@ -27,8 +27,8 @@ import java.util.Map;
 /**
  * Rule workflow feature-scoped state.
  */
-@Getter
 @NoArgsConstructor
+@Getter
 public final class RuleWorkflowFeatureData {
     
     private final List<Map<String, Object>> expectedRules = new LinkedList<>();

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/ddl/partition/PartitionValuesSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/ddl/partition/PartitionValuesSegment.java
@@ -29,9 +29,9 @@ import java.util.LinkedList;
 /**
  * Partition values segment.
  */
+@RequiredArgsConstructor
 @Getter
 @Setter
-@RequiredArgsConstructor
 public final class PartitionValuesSegment implements SQLSegment {
     
     private final int startIndex;

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/ddl/table/CreateTableOptionSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/ddl/table/CreateTableOptionSegment.java
@@ -29,9 +29,9 @@ import java.util.Optional;
 /**
  * Create table option segment.
  */
+@RequiredArgsConstructor
 @Getter
 @Setter
-@RequiredArgsConstructor
 public final class CreateTableOptionSegment implements CreateDefinitionSegment {
     
     private final int startIndex;

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/item/ColumnProjectionSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/item/ColumnProjectionSegment.java
@@ -31,8 +31,8 @@ import java.util.Optional;
  * Column projection segment.
  */
 @RequiredArgsConstructor
-@Setter
 @Getter
+@Setter
 public final class ColumnProjectionSegment implements ProjectionSegment, AliasAvailable {
     
     private final ColumnSegment column;

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/transaction/TransactionStatus.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/transaction/TransactionStatus.java
@@ -24,8 +24,8 @@ import org.apache.shardingsphere.transaction.api.TransactionType;
 /**
  * Transaction status.
  */
-@Setter
 @Getter
+@Setter
 public final class TransactionStatus {
     
     private volatile boolean inTransaction;

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/batch/FirebirdBatchCreateCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/batch/FirebirdBatchCreateCommandExecutor.java
@@ -94,8 +94,8 @@ public final class FirebirdBatchCreateCommandExecutor implements CommandExecutor
         return Collections.singleton(new FirebirdGenericResponsePacket().setHandle(statementId));
     }
     
-    @Getter
     @RequiredArgsConstructor
+    @Getter
     static final class BatchParameters {
         
         private final int version;

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfiguration.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfiguration.java
@@ -213,8 +213,8 @@ public final class LLME2EConfiguration {
      * LLM model metadata.
      */
     @RequiredArgsConstructor
-    @EqualsAndHashCode
     @Getter
+    @EqualsAndHashCode
     public static final class ModelMetadata {
         
         private final String repository;

--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/operation/transaction/cases/base/BaseTransactionTestCase.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/operation/transaction/cases/base/BaseTransactionTestCase.java
@@ -148,8 +148,8 @@ public abstract class BaseTransactionTestCase {
         return testCaseParam.getTransactionType();
     }
     
-    @Getter
     @RequiredArgsConstructor
+    @Getter
     public static final class TransactionTestCaseParameter {
         
         private final TransactionBaseE2EIT baseTransactionITCase;

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ral/ShowDistVariableStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ral/ShowDistVariableStatementTestCase.java
@@ -26,8 +26,8 @@ import javax.xml.bind.annotation.XmlAttribute;
 /**
  * Show dist variable statement test case.
  */
-@Setter
 @Getter
+@Setter
 public final class ShowDistVariableStatementTestCase extends SQLParserTestCase {
     
     @XmlAttribute


### PR DESCRIPTION
Add a scoped coding-standards rule and policy canaries, and reorder all current recognized annotations to eliminate migration debt.
