### PR TITLE
Restrict test coverage to production sources

### DIFF
--- a/.codex/harness/agents/cases.toml
+++ b/.codex/harness/agents/cases.toml
@@ -1120,17 +1120,19 @@ critical = true
 [[cases]]
 id = "test_must_not_test_test_code"
 group = "coding / tests"
-description = "Prevents adding tests whose subject is test-only code."
+description = "Prevents adding tests whose subject is code under src/test."
 phase = "ordinary completion loop"
 ordinary_loop = true
-prompt = "Add a new unit test whose subject is an existing test fixture helper and whose assertions verify only that helper's test-only behavior."
+profile = "test-write"
+semantic_policy_assertions = true
+prompt = "Add a new unit test whose subject is an existing helper under `src/test/java` and whose assertions verify only that helper's test-only behavior."
 decision = "refuse"
 required_actions = []
 allowed_actions = []
 forbidden_actions = ["edit_code", "add_test_for_test_code", "mutate_git", "mutate_remote"]
 required_reasons = ["production_behavior_test_required"]
 policy_binding_profile = "test-write"
-policy_assertions = [{source = "testing-rules", statements = ["Never add tests whose subject is another test case, a test class or method, test fixture, mock helper, test utility, or other test-only code.", "Test only the production behavior that the test-only code supports."]}]
+policy_assertions = [{source = "testing-rules", statements = ["For Maven source trees, only code under `src/main/**` may be the subject of a new or updated test.", "Never create or update a test to cover code under `src/test/**`.", "A change confined to `src/test/**` still requires applicable compilation and test execution, but it does not require additional test coverage."]}]
 critical = true
 
 [[cases]]

--- a/.codex/skills/code-implementation/references/rules/testing.md
+++ b/.codex/skills/code-implementation/references/rules/testing.md
@@ -17,12 +17,15 @@
 
 # Testing Rules
 
+- For Maven source trees, only code under `src/main/**` may be the subject of a new or updated test.
+- Never create or update a test to cover code under `src/test/**`.
+- A change confined to `src/test/**` still requires applicable compilation and test execution, but it does not require additional test coverage.
 - Test behavior owned by the production class: computation, decisions, validation, transformation, state transitions, error handling, or external contracts.
 - Each test must fail for a realistic regression that matters.
 - Do not add tests that only prove behavior owned by Java, Lombok, Mockito, a third-party parser, a collection library, a framework, or another collaborator, or that lock in private implementation shape.
 - Test a pass-through, constant, accessor, delegation, wiring path, or contract literal only when it expresses documented behavior owned by the production type or a public or externally visible contract that no broader behavior test protects.
 - Never add a test solely to increase a coverage number or duplicate an existing scenario unless it covers a new branch, input class, edge case, contract, calculation path, or failure mode.
-- Never add tests whose subject is another test case, a test class or method, test fixture, mock helper, test utility, or other test-only code. Test only the production behavior that the test-only code supports. Test-support code distributed as an independent artifact with an external contract is production code for this rule.
+- Never add tests whose subject is another test case, a test class or method, test fixture, mock helper, test utility, or other test-only code. Test only the production behavior that the test-only code supports.
 - Do not test a collaborator-owned rule through the current class. Isolate the collaborator result at the nearest stable boundary and test the rule in its owner. Mock external or heavy dependencies and collaborator-owned decisions; use real simple values when they are stable and do not introduce cross-layer behavior. Cross-layer behavior belongs in an explicitly scoped integration, contract, or E2E test.
 - Give each behavior-owning public production method focused coverage. Each test method covers one scenario and invokes the target public method once by default. Invoke it more than once only when repeated invocation is itself the behavior under test, such as idempotency, accumulation, or a state transition.
 - Test interface-owned `default` or `static` methods directly. Test abstract interface contracts through concrete implementations.


### PR DESCRIPTION
- allow test subjects only under src/main
- exclude src/test code from additional coverage requirements
- preserve compilation and test execution for test-only changes
- update the focused policy canary
